### PR TITLE
dependencies in Makefiles so composer deps are up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,35 @@
 help:                                                                           ## shows this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_\-\.]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
+vendor: composer.json composer.lock
+	composer install
+	
 .PHONY: php-cs-check
-php-cs-check:                                                                   ## run cs fixer (dry-run)
+php-cs-check: vendor                                                            ## run cs fixer (dry-run)
 	vendor/bin/php-cs-fixer fix --diff --dry-run
 
 .PHONY: php-cs-fix
-php-cs-fix:                                                                     ## run cs fixer
+php-cs-fix: vendor                                                              ## run cs fixer
 	vendor/bin/php-cs-fixer fix
 
 .PHONY: phpstan
-phpstan:                                                                        ## run phpstan static code analyser
+phpstan: vendor                                                                 ## run phpstan static code analyser
 	vendor/bin/phpstan analyse
 
 .PHONY: psalm
-psalm:                                                                          ## run psalm static code analyser
+psalm: vendor                                                                   ## run psalm static code analyser
 	vendor/bin/psalm
 
 .PHONY: phpunit
-phpunit:                                                                        ## run phpunit tests
+phpunit: vendor                                                                 ## run phpunit tests
 	vendor/bin/phpunit --testdox --colors=always -v $(OPTIONS)
 
 .PHONY: static
 static: php-cs-fix phpstan psalm                                                ## run static analyser
 
 .PHONY: test
-test: phpunit                                                                   ## run tests
+test: vendor
+	phpunit                                                                   ## run tests
 
 .PHONY: dev
 dev: static test                                                                ## run dev tools


### PR DESCRIPTION
> untested :stuck_out_tongue: 

This will automatically run `composer install` when executing any task that depends on composer dependencies being up to date. It does that by comparing the timestamps of the vendor folder with those of the files `composer.lock` and `composer.json`.

Have made this change 'blindly' with github web-editor, but I am using that quite succesfully e.g. here https://github.com/tolry/bcr/blob/master/Makefile