### PR TITLE
Allow infection/infection to report coverage (for badge purposes) on SemVer branches

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -7,7 +7,7 @@
   "logs": {
     "text": "infection.log",
     "badge": {
-      "branch": "master"
+      "branch": "/^\\d+\\.\\d+\\.x$/"
     }
   },
   "mutators": {


### PR DESCRIPTION
As soon as we use the branch naming convention based on SemVer we would need this patch to provide the infection badge info, maybe we also must change the link in the readme.