### PR TITLE
rename record method to recordThat

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ final class Hotel extends AggregateRoot
             throw new GuestHasAlreadyCheckedIn($guestName);
         }
     
-        $this->record(new GuestIsCheckedIn($guestName));
+        $this->recordThat(new GuestIsCheckedIn($guestName));
     }
     
     public function checkOut(string $guestName): void
@@ -144,7 +144,7 @@ final class Hotel extends AggregateRoot
             throw new IsNotAGuest($guestName);
         }
     
-        $this->record(new GuestIsCheckedOut($guestName));
+        $this->recordThat(new GuestIsCheckedOut($guestName));
     }
     
     #[Apply(HotelCreated::class)]

--- a/docs/aggregate.md
+++ b/docs/aggregate.md
@@ -119,7 +119,7 @@ final class Profile extends AggregateRoot
     public static function create(string $id, string $name): self
     {
         $self = new self();
-        $self->record(new ProfileCreated($id, $name));
+        $self->recordThat(new ProfileCreated($id, $name));
 
         return $self;
     }
@@ -193,7 +193,7 @@ final class Profile extends AggregateRoot
     
     public function changeName(string $name): void 
     {
-        $this->record(new NameChanged($name));
+        $this->recordThat(new NameChanged($name));
     }
     
     #[Apply(ProfileCreated::class)]
@@ -371,7 +371,7 @@ final class Profile extends AggregateRoot
             throw new NameIsToShortException($name);
         }
     
-        $this->record(new NameChanged($name));
+        $this->recordThat(new NameChanged($name));
     }
     
     #[Apply(NameChanged::class)]
@@ -439,7 +439,7 @@ final class Profile extends AggregateRoot
     
     public function changeName(Name $name): void 
     {
-        $this->record(new NameChanged($name));
+        $this->recordThat(new NameChanged($name));
     }
     
     #[Apply(NameChanged::class)]
@@ -496,10 +496,10 @@ final class Hotel extends AggregateRoot
             throw new NoPlaceException($name);
         }
         
-        $this->record(new RoomBocked($name));
+        $this->recordThat(new RoomBocked($name));
         
         if ($this->people === self::SIZE) {
-            $this->record(new FullyBooked());
+            $this->recordThat(new FullyBooked());
         }
     }
     

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,7 +47,7 @@ final class Profile extends AggregateRoot
         $id = Uuid::uuid4();
     
         $self = new self();
-        $self->record(ProfileCreated::raise($id, $name));
+        $self->recordThat(ProfileCreated::raise($id, $name));
 
         return $self;
     }
@@ -121,7 +121,7 @@ final class Profile extends AggregateRoot
         $id = ProfileId::generate();
     
         $self = new self();
-        $self->record(ProfileCreated::raise($id, $name));
+        $self->recordThat(ProfileCreated::raise($id, $name));
 
         return $self;
     }

--- a/src/Aggregate/AggregateRoot.php
+++ b/src/Aggregate/AggregateRoot.php
@@ -43,7 +43,7 @@ abstract class AggregateRoot
         $this->$method($event);
     }
 
-    final protected function record(object $event): void
+    final protected function recordThat(object $event): void
     {
         $this->playhead++;
 

--- a/tests/Benchmark/BasicImplementation/Aggregate/Profile.php
+++ b/tests/Benchmark/BasicImplementation/Aggregate/Profile.php
@@ -23,14 +23,14 @@ final class Profile extends SnapshotableAggregateRoot
     public static function create(ProfileId $id, string $name): self
     {
         $self = new self();
-        $self->record(new ProfileCreated($id, $name));
+        $self->recordThat(new ProfileCreated($id, $name));
 
         return $self;
     }
 
     public function changeName(string $name): void
     {
-        $this->record(new NameChanged($name));
+        $this->recordThat(new NameChanged($name));
     }
 
     #[Apply(ProfileCreated::class)]

--- a/tests/Integration/BasicImplementation/Aggregate/Profile.php
+++ b/tests/Integration/BasicImplementation/Aggregate/Profile.php
@@ -22,7 +22,7 @@ final class Profile extends SnapshotableAggregateRoot
     public static function create(ProfileId $id, string $name): self
     {
         $self = new self();
-        $self->record(new ProfileCreated($id, $name));
+        $self->recordThat(new ProfileCreated($id, $name));
 
         return $self;
     }

--- a/tests/Integration/Pipeline/Aggregate/Profile.php
+++ b/tests/Integration/Pipeline/Aggregate/Profile.php
@@ -26,19 +26,19 @@ final class Profile extends AggregateRoot
     public static function create(ProfileId $id): self
     {
         $self = new self();
-        $self->record(new ProfileCreated($id));
+        $self->recordThat(new ProfileCreated($id));
 
         return $self;
     }
 
     public function visit(): void
     {
-        $this->record(new OldVisited($this->id));
+        $this->recordThat(new OldVisited($this->id));
     }
 
     public function privacy(): void
     {
-        $this->record(new PrivacyAdded($this->id));
+        $this->recordThat(new PrivacyAdded($this->id));
     }
 
     public function isPrivate(): bool

--- a/tests/Unit/Fixture/Profile.php
+++ b/tests/Unit/Fixture/Profile.php
@@ -33,28 +33,28 @@ final class Profile extends AggregateRoot
     public static function createProfile(ProfileId $id, Email $email): self
     {
         $self = new self();
-        $self->record(new ProfileCreated($id, $email));
+        $self->recordThat(new ProfileCreated($id, $email));
 
         return $self;
     }
 
     public function publishMessage(Message $message): void
     {
-        $this->record(new MessagePublished(
+        $this->recordThat(new MessagePublished(
             $message
         ));
     }
 
     public function deleteMessage(MessageId $messageId): void
     {
-        $this->record(new MessageDeleted(
+        $this->recordThat(new MessageDeleted(
             $messageId
         ));
     }
 
     public function visitProfile(ProfileId $profileId): void
     {
-        $this->record(new ProfileVisited($profileId));
+        $this->recordThat(new ProfileVisited($profileId));
     }
 
     #[Apply(ProfileCreated::class)]

--- a/tests/Unit/Fixture/ProfileInvalid.php
+++ b/tests/Unit/Fixture/ProfileInvalid.php
@@ -15,7 +15,7 @@ final class ProfileInvalid extends AggregateRoot
     public static function createProfile(ProfileId $id, Email $email): self
     {
         $self = new self();
-        $self->record(new ProfileCreated($id, $email));
+        $self->recordThat(new ProfileCreated($id, $email));
 
         return $self;
     }

--- a/tests/Unit/Fixture/ProfileWithSnapshot.php
+++ b/tests/Unit/Fixture/ProfileWithSnapshot.php
@@ -35,21 +35,21 @@ final class ProfileWithSnapshot extends SnapshotableAggregateRoot
     public static function createProfile(ProfileId $id, Email $email): self
     {
         $self = new self();
-        $self->record(new ProfileCreated($id, $email));
+        $self->recordThat(new ProfileCreated($id, $email));
 
         return $self;
     }
 
     public function publishMessage(Message $message): void
     {
-        $this->record(new MessagePublished(
+        $this->recordThat(new MessagePublished(
             $message
         ));
     }
 
     public function visitProfile(ProfileId $profileId): void
     {
-        $this->record(new ProfileVisited($profileId));
+        $this->recordThat(new ProfileVisited($profileId));
     }
 
     #[Apply(ProfileCreated::class)]

--- a/tests/Unit/Fixture/ProfileWithSuppressAll.php
+++ b/tests/Unit/Fixture/ProfileWithSuppressAll.php
@@ -13,7 +13,7 @@ final class ProfileWithSuppressAll extends AggregateRoot
     public static function createProfile(ProfileId $id, Email $email): self
     {
         $self = new self();
-        $self->record(new ProfileCreated($id, $email));
+        $self->recordThat(new ProfileCreated($id, $email));
 
         return $self;
     }


### PR DESCRIPTION
Why rename it?

1) It improves the flow of reading
2) record is to general. could be a getter in the business domain.


```php
$this->recordThat(new GuestIsCheckedIn($guestName));
```