### PR TITLE
Remove benchmark workflow for base, since it cannot diff it right now

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,10 +4,6 @@ name: "Benchmark"
 
 on:
   pull_request:
-  push:
-    branches:
-      - "[0-9]+.[0-9]+.x"
-      - "renovate/*"
 
 jobs:
   phpbench:


### PR DESCRIPTION
Right now, the benchmark workflow only work on PR branches. So i deactivated it for now for the base branches. But maybe we should add some more logic here so it can run on these?