### PR TITLE
make repository rollback safe

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -1,24 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
-  <file src="src/Serializer/Hydrator/MetadataAggregateRootHydrator.php">
-    <InaccessibleProperty occurrences="1">
-      <code>$aggregateRoot-&gt;playhead</code>
-    </InaccessibleProperty>
-  </file>
   <file src="src/Store/MultiTableStore.php">
     <UnnecessaryVarAnnotation occurrences="1">
       <code>array{id: string, aggregate_id: string, playhead: string, event: string, payload: string, recorded_on: string}|null</code>
     </UnnecessaryVarAnnotation>
   </file>
   <file src="tests/Benchmark/LoadEventsBench.php">
-    <MissingConstructor occurrences="2">
+    <MissingConstructor occurrences="3">
       <code>$bus</code>
+      <code>$repository</code>
       <code>$store</code>
     </MissingConstructor>
   </file>
   <file src="tests/Benchmark/LoadEventsWithSnapshotsBench.php">
-    <MissingConstructor occurrences="3">
+    <MissingConstructor occurrences="4">
       <code>$bus</code>
+      <code>$repository</code>
       <code>$snapshotStore</code>
       <code>$store</code>
     </MissingConstructor>

--- a/tests/Benchmark/LoadEventsBench.php
+++ b/tests/Benchmark/LoadEventsBench.php
@@ -10,6 +10,7 @@ use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
+use Patchlevel\EventSourcing\Repository\Repository;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaManager;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\SingleTableStore;
@@ -28,6 +29,7 @@ final class LoadEventsBench
 
     private Store $store;
     private EventBus $bus;
+    private Repository $repository;
 
     public function setUp(): void
     {
@@ -49,7 +51,7 @@ final class LoadEventsBench
             'eventstore'
         );
 
-        $repository = new DefaultRepository($this->store, $this->bus, Profile::class);
+        $this->repository = new DefaultRepository($this->store, $this->bus, Profile::class);
 
         // create tables
         (new DoctrineSchemaManager())->create($this->store);
@@ -60,15 +62,13 @@ final class LoadEventsBench
             $profile->changeName('Peter');
         }
 
-        $repository->save($profile);
+        $this->repository->save($profile);
     }
 
     #[Bench\Revs(10)]
     #[Bench\Iterations(2)]
     public function benchLoadEvents(): void
     {
-        $repository = new DefaultRepository($this->store, $this->bus, Profile::class);
-
-        $repository->load('1');
+        $this->repository->load('1');
     }
 }

--- a/tests/Benchmark/LoadEventsWithSnapshotsBench.php
+++ b/tests/Benchmark/LoadEventsWithSnapshotsBench.php
@@ -67,6 +67,7 @@ final class LoadEventsWithSnapshotsBench
         }
 
         $repository->save($profile);
+        $this->snapshotStore->save($profile);
     }
 
     #[Bench\Revs(10)]

--- a/tests/Benchmark/LoadEventsWithSnapshotsBench.php
+++ b/tests/Benchmark/LoadEventsWithSnapshotsBench.php
@@ -10,6 +10,7 @@ use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
+use Patchlevel\EventSourcing\Repository\Repository;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaManager;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Snapshot\Adapter\InMemorySnapshotAdapter;
@@ -32,6 +33,7 @@ final class LoadEventsWithSnapshotsBench
     private Store $store;
     private EventBus $bus;
     private SnapshotStore $snapshotStore;
+    private Repository $repository;
 
     public function setUp(): void
     {
@@ -55,7 +57,7 @@ final class LoadEventsWithSnapshotsBench
 
         $this->snapshotStore = new DefaultSnapshotStore(['default' => new InMemorySnapshotAdapter()]);
 
-        $repository = new DefaultRepository($this->store, $this->bus, Profile::class, $this->snapshotStore);
+        $this->repository = new DefaultRepository($this->store, $this->bus, Profile::class, $this->snapshotStore);
 
         // create tables
         (new DoctrineSchemaManager())->create($this->store);
@@ -66,7 +68,7 @@ final class LoadEventsWithSnapshotsBench
             $profile->changeName('Peter');
         }
 
-        $repository->save($profile);
+        $this->repository->save($profile);
         $this->snapshotStore->save($profile);
     }
 
@@ -74,8 +76,6 @@ final class LoadEventsWithSnapshotsBench
     #[Bench\Iterations(2)]
     public function benchLoadEvents(): void
     {
-        $repository = new DefaultRepository($this->store, $this->bus, Profile::class, $this->snapshotStore);
-
-        $repository->load('1');
+        $this->repository->load('1');
     }
 }


### PR DESCRIPTION
* remove instance cache in repository
* move snapshot save from repository save into repository load method
* move batch condition from snapshot store into repository

As a result, neither the repository nor the snapshot store is stateful and can continue to be used after a rollback.