### PR TITLE
Silence socket warnings for DefaultWatchServerClient

### DIFF
--- a/src/WatchServer/DefaultWatchServerClient.php
+++ b/src/WatchServer/DefaultWatchServerClient.php
@@ -53,7 +53,7 @@ final class DefaultWatchServerClient implements WatchServerClient
         set_error_handler([self::class, 'nullErrorHandler']);
 
         try {
-            if (stream_socket_sendto($socket, $encodedPayload) !== -1) {
+            if (@stream_socket_sendto($socket, $encodedPayload) !== -1) {
                 return;
             }
 
@@ -64,7 +64,7 @@ final class DefaultWatchServerClient implements WatchServerClient
                 throw new SendingFailed('socket connection could not be established');
             }
 
-            if (stream_socket_sendto($socket, $encodedPayload) !== -1) {
+            if (@stream_socket_sendto($socket, $encodedPayload) !== -1) {
                 return;
             }
         } finally {
@@ -86,7 +86,7 @@ final class DefaultWatchServerClient implements WatchServerClient
         set_error_handler([self::class, 'nullErrorHandler']);
 
         try {
-            $socket = stream_socket_client(
+            $socket = @stream_socket_client(
                 $this->host,
                 $errno,
                 $errstr,
@@ -114,7 +114,7 @@ final class DefaultWatchServerClient implements WatchServerClient
             return;
         }
 
-        if (!stream_socket_shutdown($socket, STREAM_SHUT_RDWR)) {
+        if (!@stream_socket_shutdown($socket, STREAM_SHUT_RDWR)) {
             throw new SendingFailed('socket shutdown failed');
         }
 


### PR DESCRIPTION
Event if I deactivate the watch server in the symfony config it executes this watcher and I get some warning, that the socket is not available or broken pipe warnings. What do you think to prevent warnings like this?