### PR TITLE
snapshots version

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -11,6 +11,11 @@
       <code>$playhead</code>
     </MixedOperand>
   </file>
+  <file src="src/Snapshot/DefaultSnapshotStore.php">
+    <MixedArgument occurrences="1">
+      <code>$data['payload']</code>
+    </MixedArgument>
+  </file>
   <file src="src/Store/DoctrineStore.php">
     <MixedReturnTypeCoercion occurrences="2">
       <code>$normalizedCustomHeaders</code>

--- a/docs/pages/snapshots.md
+++ b/docs/pages/snapshots.md
@@ -136,7 +136,7 @@ use Patchlevel\EventSourcing\Attribute\Aggregate;
 use Patchlevel\EventSourcing\Attribute\Snapshot;
 
 #[Aggregate('profile')]
-#[Snapshot('default', version: 2)]
+#[Snapshot('default', version: '2')]
 final class Profile extends AggregateRoot
 {
     // ...

--- a/docs/pages/snapshots.md
+++ b/docs/pages/snapshots.md
@@ -90,7 +90,8 @@ final class Profile extends AggregateRoot
 
 !!! danger
 
-    If anything changes in the properties of the aggregate, then the cache must be cleared!
+    If anything changes in the properties of the aggregate, then the cache must be cleared.
+    Or the snapshot version needs to be changed so that the previous snapshot is invalid.
 
 !!! warning
 
@@ -119,6 +120,36 @@ final class Profile extends AggregateRoot
     // ...
 }
 ```
+
+### Snapshot versioning
+
+Whenever something changes on the aggregate, the previous snapshot must be discarded. 
+You can do this by removing the entire snapshot cache when deploying. 
+But that can be quickly forgotten. It is much easier to specify a snapshot version. 
+This snapshot version is also saved. When loading, the versions are compared and if they do not match, 
+the snapshot is discarded and the aggregate is rebuilt from scratch. 
+The new aggregate is then saved again as a snapshot.
+
+```php
+use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Snapshot;
+
+#[Aggregate('profile')]
+#[Snapshot('default', version: 2)]
+final class Profile extends AggregateRoot
+{
+    // ...
+}
+```
+
+!!! warning
+
+    If the snapshots are discarded, a load peak can occur since the aggregates have to be rebuilt.
+
+!!! tip
+
+    You can also use uuids for the snapshot version.
 
 ## Adapter
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: src/Console/DoctrineHelper.php
 
 		-
+			message: "#^Parameter \\#2 \\$data of method Patchlevel\\\\EventSourcing\\\\Serializer\\\\Hydrator\\\\AggregateRootHydrator\\:\\:hydrate\\(\\) expects array\\<string, mixed\\>, mixed given\\.$#"
+			count: 1
+			path: src/Snapshot/DefaultSnapshotStore.php
+
+		-
 			message: "#^While loop condition is always true\\.$#"
 			count: 1
 			path: src/WatchServer/SocketWatchServer.php

--- a/src/Attribute/Snapshot.php
+++ b/src/Attribute/Snapshot.php
@@ -11,11 +11,13 @@ final class Snapshot
 {
     private string $name;
     private ?int $batch;
+    private string|int|null $version;
 
-    public function __construct(string $name, ?int $batch = null)
+    public function __construct(string $name, ?int $batch = null, string|int|null $version = null)
     {
         $this->name = $name;
         $this->batch = $batch;
+        $this->version = $version;
     }
 
     public function name(): string
@@ -26,5 +28,10 @@ final class Snapshot
     public function batch(): ?int
     {
         return $this->batch;
+    }
+
+    public function version(): string|int|null
+    {
+        return $this->version;
     }
 }

--- a/src/Attribute/Snapshot.php
+++ b/src/Attribute/Snapshot.php
@@ -11,9 +11,9 @@ final class Snapshot
 {
     private string $name;
     private ?int $batch;
-    private string|int|null $version;
+    private ?string $version;
 
-    public function __construct(string $name, ?int $batch = null, string|int|null $version = null)
+    public function __construct(string $name, ?int $batch = null, ?string $version = null)
     {
         $this->name = $name;
         $this->batch = $batch;
@@ -30,7 +30,7 @@ final class Snapshot
         return $this->batch;
     }
 
-    public function version(): string|int|null
+    public function version(): ?string
     {
         return $this->version;
     }

--- a/src/Metadata/AggregateRoot/AggregateRootMetadata.php
+++ b/src/Metadata/AggregateRoot/AggregateRootMetadata.php
@@ -17,7 +17,7 @@ final class AggregateRootMetadata
         public readonly bool $suppressAll,
         public readonly ?string $snapshotStore,
         public readonly ?int $snapshotBatch,
-        public readonly int|string|null $snapshotVersion = null,
+        public readonly ?string $snapshotVersion = null,
     ) {
     }
 }

--- a/src/Metadata/AggregateRoot/AggregateRootMetadata.php
+++ b/src/Metadata/AggregateRoot/AggregateRootMetadata.php
@@ -17,6 +17,7 @@ final class AggregateRootMetadata
         public readonly bool $suppressAll,
         public readonly ?string $snapshotStore,
         public readonly ?int $snapshotBatch,
+        public readonly int|string|null $snapshotVersion = null,
     ) {
     }
 }

--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -13,6 +13,7 @@ use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadata;
 use Patchlevel\EventSourcing\Snapshot\SnapshotNotFound;
 use Patchlevel\EventSourcing\Snapshot\SnapshotStore;
+use Patchlevel\EventSourcing\Snapshot\SnapshotVersionInvalid;
 use Patchlevel\EventSourcing\Store\Store;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -76,6 +77,14 @@ final class DefaultRepository implements Repository
                 $this->logger->debug(
                     sprintf(
                         'snapshot for aggregate "%s" with the id "%s" not found',
+                        $aggregateClass,
+                        $id
+                    )
+                );
+            } catch (SnapshotVersionInvalid) {
+                $this->logger->debug(
+                    sprintf(
+                        'snapshot for aggregate "%s" with the id "%s" is invalid',
                         $aggregateClass,
                         $id
                     )

--- a/src/Snapshot/DefaultSnapshotStore.php
+++ b/src/Snapshot/DefaultSnapshotStore.php
@@ -109,7 +109,7 @@ final class DefaultSnapshotStore implements SnapshotStore
     /**
      * @param class-string<AggregateRoot> $aggregateClass
      */
-    private function version(string $aggregateClass): string|int|null
+    private function version(string $aggregateClass): ?string
     {
         return $aggregateClass::metadata()->snapshotVersion;
     }

--- a/src/Snapshot/SnapshotVersionInvalid.php
+++ b/src/Snapshot/SnapshotVersionInvalid.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Snapshot;
+
+use function sprintf;
+
+final class SnapshotVersionInvalid extends SnapshotException
+{
+    public function __construct(string $key)
+    {
+        parent::__construct(
+            sprintf(
+                'snapshot version with the key "%s" is invalid',
+                $key
+            )
+        );
+    }
+}

--- a/tests/Unit/Fixture/ProfileWithSnapshot.php
+++ b/tests/Unit/Fixture/ProfileWithSnapshot.php
@@ -12,7 +12,7 @@ use Patchlevel\EventSourcing\Attribute\Snapshot;
 use Patchlevel\EventSourcing\Attribute\SuppressMissingApply;
 
 #[Aggregate('profile_with_snapshot')]
-#[Snapshot('memory', batch: 2, version: 1)]
+#[Snapshot('memory', batch: 2, version: '1')]
 #[SuppressMissingApply([ProfileVisited::class])]
 final class ProfileWithSnapshot extends AggregateRoot
 {

--- a/tests/Unit/Fixture/ProfileWithSnapshot.php
+++ b/tests/Unit/Fixture/ProfileWithSnapshot.php
@@ -12,7 +12,7 @@ use Patchlevel\EventSourcing\Attribute\Snapshot;
 use Patchlevel\EventSourcing\Attribute\SuppressMissingApply;
 
 #[Aggregate('profile_with_snapshot')]
-#[Snapshot('memory', batch: 2)]
+#[Snapshot('memory', batch: 2, version: 1)]
 #[SuppressMissingApply([ProfileVisited::class])]
 final class ProfileWithSnapshot extends AggregateRoot
 {

--- a/tests/Unit/Snapshot/DefaultSnapshotStoreTest.php
+++ b/tests/Unit/Snapshot/DefaultSnapshotStoreTest.php
@@ -25,7 +25,7 @@ class DefaultSnapshotStoreTest extends TestCase
         $adapter->save(
             'profile_with_snapshot-1',
             [
-                'version' => 1,
+                'version' => '1',
                 'payload' => ['id' => '1', 'email' => 'info@patchlevel.de', 'messages' => [], '_playhead' => 2],
             ]
         )->shouldBeCalled();
@@ -49,7 +49,7 @@ class DefaultSnapshotStoreTest extends TestCase
             'profile_with_snapshot-1'
         )->willReturn(
             [
-                'version' => 1,
+                'version' => '1',
                 'payload' => ['id' => '1', 'email' => 'info@patchlevel.de', 'messages' => [], '_playhead' => 2],
             ]
         );
@@ -86,7 +86,7 @@ class DefaultSnapshotStoreTest extends TestCase
             'profile_with_snapshot-1'
         )->willReturn(
             [
-                'version' => 2,
+                'version' => '2',
                 'payload' => ['id' => '1', 'email' => 'info@patchlevel.de', 'messages' => [], '_playhead' => 2],
             ]
         );


### PR DESCRIPTION
allow snapshots to be versioned using an attribute. If the version doesn't match what is loaded from the store, then the snapshot is discarded and the aggregate is built from scratch.

fix #226 