### PR TITLE
add worker for cli commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ psalm-baseline: vendor                                                          
 
 .PHONY: phpunit
 phpunit: vendor                                                                 ## run phpunit tests
-	vendor/bin/phpunit --colors=always -v $(OPTIONS)
+	vendor/bin/phpunit --colors=always -v
 
 .PHONY: infection
 infection: vendor                                                               ## run infection

--- a/baseline.xml
+++ b/baseline.xml
@@ -1,9 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
+  <file src="src/Console/Command/OutboxConsumeCommand.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$sleep</code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="src/Console/DoctrineHelper.php">
     <ClassNotFinal occurrences="1">
       <code>class DoctrineHelper</code>
     </ClassNotFinal>
+  </file>
+  <file src="src/Console/Worker/DefaultWorker.php">
+    <TypeDoesNotContainType occurrences="1">
+      <code>$this-&gt;shouldStop</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/Console/Worker/Listener/StopWorkerOnSigtermSignalListener.php">
+    <MoreSpecificReturnType occurrences="1">
+      <code>array&lt;class-string, string&gt;</code>
+    </MoreSpecificReturnType>
   </file>
   <file src="src/Repository/DefaultRepository.php">
     <MixedArgument occurrences="1">

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "psr/log": "^2.0.0|^3.0.0",
     "psr/simple-cache": "^2.0.0|^3.0.0",
     "symfony/console": "^5.4.1|^6.0.1",
+    "symfony/event-dispatcher": "^4.4.34|^5.4.0|^6.0.1",
     "symfony/finder": "^4.4.34|^5.4.0|^6.0.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe8c2e965d6c43b4f108d15d9532aebf",
+    "content-hash": "af6bb13572d1ccfc977d6321e28f24a1",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -450,6 +450,56 @@
             "time": "2021-11-05T16:47:00+00:00"
         },
         {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "3.0.0",
             "source": {
@@ -696,6 +746,168 @@
             "homepage": "https://symfony.com",
             "support": {
                 "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T11:15:52+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "a0449a7ad7daa0f7c0acd508259f80544ab5a347"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a0449a7ad7daa0f7c0acd508259f80544ab5a347",
+                "reference": "a0449a7ad7daa0f7c0acd508259f80544ab5a347",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/event-dispatcher-contracts": "^2|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<5.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/stopwatch": "^5.4|^6.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-05T16:51:07+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "02ff5eea2f453731cfbc6bc215e456b781480448"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/02ff5eea2f453731cfbc6bc215e456b781480448",
+                "reference": "02ff5eea2f453731cfbc6bc215e456b781480448",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -6655,5 +6867,5 @@
     "platform-dev": {
         "ext-pdo_sqlite": "~8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: src/Console/DoctrineHelper.php
 
 		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: src/Console/Worker/DefaultWorker.php
+
+		-
 			message: "#^Parameter \\#2 \\$data of method Patchlevel\\\\EventSourcing\\\\Serializer\\\\Hydrator\\\\AggregateRootHydrator\\:\\:hydrate\\(\\) expects array\\<string, mixed\\>, mixed given\\.$#"
 			count: 1
 			path: src/Snapshot/DefaultSnapshotStore.php

--- a/src/Console/Command/OutboxConsumeCommand.php
+++ b/src/Console/Command/OutboxConsumeCommand.php
@@ -5,12 +5,21 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Console\Command;
 
 use Patchlevel\EventSourcing\Console\InputHelper;
+use Patchlevel\EventSourcing\Console\InvalidArgumentGiven;
+use Patchlevel\EventSourcing\Console\Worker\Bytes;
+use Patchlevel\EventSourcing\Console\Worker\DefaultWorker;
+use Patchlevel\EventSourcing\Console\Worker\Listener\StopWorkerOnIterationLimitListener;
+use Patchlevel\EventSourcing\Console\Worker\Listener\StopWorkerOnMemoryLimitListener;
+use Patchlevel\EventSourcing\Console\Worker\Listener\StopWorkerOnSigtermSignalListener;
+use Patchlevel\EventSourcing\Console\Worker\Listener\StopWorkerOnTimeLimitListener;
 use Patchlevel\EventSourcing\Outbox\OutboxConsumer;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 #[AsCommand(
     'event-sourcing:outbox:consume',
@@ -18,22 +27,108 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 final class OutboxConsumeCommand extends Command
 {
-    public function __construct(private OutboxConsumer $consumer)
-    {
+    public function __construct(
+        private readonly OutboxConsumer $consumer
+    ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
         $this
-            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'How many messages should be consumed in one run');
+            ->addOption(
+                'limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'How many messages should be consumed in one run (deprecated: use "message-limit" option)'
+            )
+            ->addOption(
+                'message-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'How many messages should be consumed in one run',
+                100
+            )
+            ->addOption(
+                'run-limit',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'The maximum number of runs this command should execute',
+                1
+            )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'How much memory consumption should the worker be terminated'
+            )
+            ->addOption(
+                'time-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'What is the maximum time the worker can run in seconds'
+            )
+            ->addOption(
+                'sleep',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'How much time should elapse before the next job is executed in microseconds',
+                1000
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $limit = InputHelper::nullableInt($input->getOption('limit'));
+        $legacyLimit = InputHelper::nullableInt($input->getOption('limit'));
+        $messageLimit = InputHelper::int($input->getOption('message-limit'));
+        $runLimit = InputHelper::nullableInt($input->getOption('run-limit'));
+        $memoryLimit = InputHelper::nullableString($input->getOption('memory-limit'));
+        $timeLimit = InputHelper::nullableInt($input->getOption('time-limit'));
+        $sleep = InputHelper::int($input->getOption('sleep'));
 
-        $this->consumer->consume($limit);
+        // legacy limit option to message-limit
+        if ($legacyLimit !== null) {
+            $messageLimit = $legacyLimit;
+        }
+
+        $logger = new ConsoleLogger($output);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addSubscriber(new StopWorkerOnSigtermSignalListener($logger));
+
+        if ($runLimit) {
+            if ($runLimit <= 0) {
+                throw new InvalidArgumentGiven($runLimit, 'null|positive-int');
+            }
+
+            $eventDispatcher->addSubscriber(new StopWorkerOnIterationLimitListener($runLimit, $logger));
+        }
+
+        if ($memoryLimit) {
+            $eventDispatcher->addSubscriber(new StopWorkerOnMemoryLimitListener(Bytes::parseFromString($memoryLimit), $logger));
+        }
+
+        if ($timeLimit) {
+            if ($timeLimit <= 0) {
+                throw new InvalidArgumentGiven($timeLimit, 'null|positive-int');
+            }
+
+            $eventDispatcher->addSubscriber(new StopWorkerOnTimeLimitListener($timeLimit, $logger));
+        }
+
+        $worker = new DefaultWorker(
+            function () use ($messageLimit): void {
+                $this->consumer->consume($messageLimit);
+            },
+            $eventDispatcher,
+            $logger
+        );
+
+        if ($sleep < 0) {
+            throw new InvalidArgumentGiven($sleep, '0|positive-int');
+        }
+
+        $worker->run($sleep);
 
         return 0;
     }

--- a/src/Console/InputHelper.php
+++ b/src/Console/InputHelper.php
@@ -33,6 +33,19 @@ final class InputHelper
         return $value;
     }
 
+    public static function int(mixed $value): int
+    {
+        if (!is_string($value) && !is_int($value)) {
+            throw new InvalidArgumentGiven($value, 'int');
+        }
+
+        if (!is_numeric($value)) {
+            throw new InvalidArgumentGiven($value, 'int');
+        }
+
+        return (int)$value;
+    }
+
     public static function nullableInt(mixed $value): ?int
     {
         if ($value === null) {

--- a/src/Console/Worker/Bytes.php
+++ b/src/Console/Worker/Bytes.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker;
+
+use function array_key_exists;
+use function preg_match;
+use function strtoupper;
+
+final class Bytes
+{
+    private const SIZES = [
+        'B' => 1,
+        'KB' => 1_024,
+        'MB' => 1_048_576,
+        'GB' => 1_073_741_824,
+    ];
+
+    public function __construct(
+        private readonly int $bytes
+    ) {
+    }
+
+    public function value(): int
+    {
+        return $this->bytes;
+    }
+
+    public static function parseFromString(string $string): self
+    {
+        if (!preg_match('/^([0-9]+)([a-z]+)?$/i', $string, $matches)) {
+            throw new InvalidFormat($string);
+        }
+
+        $number = (int)$matches[1];
+        $unit = strtoupper($matches[2] ?? 'B');
+
+        if (!array_key_exists($unit, self::SIZES)) {
+            throw new InvalidFormat($string);
+        }
+
+        return new self($number * self::SIZES[$unit]);
+    }
+}

--- a/src/Console/Worker/DefaultWorker.php
+++ b/src/Console/Worker/DefaultWorker.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker;
+
+use Closure;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerRunningEvent;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerStartedEvent;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerStoppedEvent;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+use function max;
+use function microtime;
+use function usleep;
+
+final class DefaultWorker implements Worker
+{
+    private bool $shouldStop = false;
+
+    public function __construct(
+        private readonly Closure $job,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ?LoggerInterface $logger = null
+    ) {
+    }
+
+    public function run(int $sleepTimer = 1000): void
+    {
+        $this->logger?->debug('Worker starting');
+
+        $this->eventDispatcher->dispatch(new WorkerStartedEvent($this));
+
+        while (!$this->shouldStop) {
+            $this->logger?->debug('Worker starting job run');
+
+            $startTime = microtime(true);
+
+            ($this->job)();
+
+            $ranTime = (int)(microtime(true) - $startTime);
+
+            $this->logger?->debug('Worker finished job run ({ranTime}ms)', ['ranTime' => $ranTime]);
+
+            $this->eventDispatcher->dispatch(new WorkerRunningEvent($this));
+
+            if ($this->shouldStop) {
+                break;
+            }
+
+            $sleepFor = max($sleepTimer - $ranTime, 0);
+
+            if ($sleepFor <= 0) {
+                continue;
+            }
+
+            $this->logger?->debug('Worker sleep for {sleepTimer}ms', ['sleepTimer' => $sleepFor]);
+            usleep($sleepFor);
+        }
+
+        $this->logger?->debug('Worker stopped');
+
+        $this->eventDispatcher->dispatch(new WorkerStoppedEvent($this));
+
+        $this->logger?->debug('Worker terminated');
+    }
+
+    public function stop(): void
+    {
+        $this->logger?->debug('Worker received stop signal');
+        $this->shouldStop = true;
+    }
+}

--- a/src/Console/Worker/Event/WorkerRunningEvent.php
+++ b/src/Console/Worker/Event/WorkerRunningEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker\Event;
+
+use Patchlevel\EventSourcing\Console\Worker\Worker;
+
+final class WorkerRunningEvent
+{
+    public function __construct(
+        public readonly Worker $worker
+    ) {
+    }
+}

--- a/src/Console/Worker/Event/WorkerStartedEvent.php
+++ b/src/Console/Worker/Event/WorkerStartedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker\Event;
+
+use Patchlevel\EventSourcing\Console\Worker\Worker;
+
+final class WorkerStartedEvent
+{
+    public function __construct(
+        public readonly Worker $worker
+    ) {
+    }
+}

--- a/src/Console/Worker/Event/WorkerStoppedEvent.php
+++ b/src/Console/Worker/Event/WorkerStoppedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker\Event;
+
+use Patchlevel\EventSourcing\Console\Worker\Worker;
+
+final class WorkerStoppedEvent
+{
+    public function __construct(
+        public readonly Worker $worker
+    ) {
+    }
+}

--- a/src/Console/Worker/InvalidFormat.php
+++ b/src/Console/Worker/InvalidFormat.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class InvalidFormat extends InvalidArgumentException
+{
+    public function __construct(string $message)
+    {
+        parent::__construct(sprintf('Invalid byte format received (got: "%s"). The format must consist of a number and a unit. The following units are allowed: B, KB, MB, GB', $message));
+    }
+}

--- a/src/Console/Worker/Listener/StopWorkerOnIterationLimitListener.php
+++ b/src/Console/Worker/Listener/StopWorkerOnIterationLimitListener.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker\Listener;
+
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerRunningEvent;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerStartedEvent;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class StopWorkerOnIterationLimitListener implements EventSubscriberInterface
+{
+    private int $iteration = 0;
+
+    /**
+     * @param positive-int $maximumNumberOfIteration
+     */
+    public function __construct(
+        private readonly int $maximumNumberOfIteration,
+        private readonly ?LoggerInterface $logger = null
+    ) {
+    }
+
+    public function onWorkerStarted(): void
+    {
+        $this->iteration = 0;
+    }
+
+    public function onWorkerRunning(WorkerRunningEvent $event): void
+    {
+        $this->iteration++;
+
+        if ($this->iteration < $this->maximumNumberOfIteration) {
+            return;
+        }
+
+        $event->worker->stop();
+
+        $this->logger?->info(
+            'Worker stopped due to maximum iteration of {count}',
+            ['count' => $this->maximumNumberOfIteration]
+        );
+    }
+
+    /**
+     * @return array<class-string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerStartedEvent::class => 'onWorkerStarted',
+            WorkerRunningEvent::class => 'onWorkerRunning',
+        ];
+    }
+}

--- a/src/Console/Worker/Listener/StopWorkerOnMemoryLimitListener.php
+++ b/src/Console/Worker/Listener/StopWorkerOnMemoryLimitListener.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker\Listener;
+
+use Patchlevel\EventSourcing\Console\Worker\Bytes;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerRunningEvent;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use function memory_get_usage;
+
+final class StopWorkerOnMemoryLimitListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly Bytes $memoryLimit,
+        private readonly ?LoggerInterface $logger = null
+    ) {
+    }
+
+    public function onWorkerRunning(WorkerRunningEvent $event): void
+    {
+        $usedMemory = $this->usedMemory();
+
+        if ($usedMemory->value() <= $this->memoryLimit->value()) {
+            return;
+        }
+
+        $this->logger?->info(
+            'Worker stopped due to memory limit of {limit} bytes exceeded ({memory} bytes used)',
+            ['limit' => $this->memoryLimit->value(), 'memory' => $usedMemory->value()]
+        );
+
+        $event->worker->stop();
+    }
+
+    private function usedMemory(): Bytes
+    {
+        return new Bytes(memory_get_usage(true));
+    }
+
+    /**
+     * @return array<class-string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [WorkerRunningEvent::class => 'onWorkerRunning'];
+    }
+}

--- a/src/Console/Worker/Listener/StopWorkerOnSigtermSignalListener.php
+++ b/src/Console/Worker/Listener/StopWorkerOnSigtermSignalListener.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker\Listener;
+
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerStartedEvent;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use function function_exists;
+use function pcntl_signal;
+
+use const SIGTERM;
+
+final class StopWorkerOnSigtermSignalListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly ?LoggerInterface $logger = null
+    ) {
+    }
+
+    public function onWorkerStarted(WorkerStartedEvent $event): void
+    {
+        pcntl_signal(SIGTERM, function () use ($event): void {
+            $this->logger?->info('Received SIGTERM signal.');
+            $event->worker->stop();
+        });
+    }
+
+    /**
+     * @return array<class-string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        if (!function_exists('pcntl_signal')) {
+            return [];
+        }
+
+        return [WorkerStartedEvent::class => 'onWorkerStarted'];
+    }
+}

--- a/src/Console/Worker/Listener/StopWorkerOnTimeLimitListener.php
+++ b/src/Console/Worker/Listener/StopWorkerOnTimeLimitListener.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker\Listener;
+
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerRunningEvent;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerStartedEvent;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use function microtime;
+
+final class StopWorkerOnTimeLimitListener implements EventSubscriberInterface
+{
+    private float $endTime = 0;
+
+    /**
+     * @param positive-int $timeLimitInSeconds
+     */
+    public function __construct(
+        private readonly int $timeLimitInSeconds,
+        private readonly ?LoggerInterface $logger = null
+    ) {
+    }
+
+    public function onWorkerStarted(): void
+    {
+        $this->endTime = microtime(true) + $this->timeLimitInSeconds;
+    }
+
+    public function onWorkerRunning(WorkerRunningEvent $event): void
+    {
+        if ($this->endTime >= microtime(true)) {
+            return;
+        }
+
+        $event->worker->stop();
+        $this->logger?->info(
+            'Worker stopped due to time limit of {timeLimit}s exceeded',
+            ['timeLimit' => $this->timeLimitInSeconds]
+        );
+    }
+
+    /**
+     * @return array<class-string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerStartedEvent::class => 'onWorkerStarted',
+            WorkerRunningEvent::class => 'onWorkerRunning',
+        ];
+    }
+}

--- a/src/Console/Worker/Worker.php
+++ b/src/Console/Worker/Worker.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Worker;
+
+interface Worker
+{
+    /**
+     * @param 0|positive-int $sleepTimer sleepTimer in microseconds
+     */
+    public function run(int $sleepTimer = 1000): void;
+
+    public function stop(): void;
+}

--- a/tests/Unit/Console/Command/OutboxConsumeCommandTest.php
+++ b/tests/Unit/Console/Command/OutboxConsumeCommandTest.php
@@ -12,14 +12,14 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 /** @covers \Patchlevel\EventSourcing\Console\Command\OutboxConsumeCommand */
-final class OutboxConsumerCommandTest extends TestCase
+final class OutboxConsumeCommandTest extends TestCase
 {
     use ProphecyTrait;
 
     public function testSuccessful(): void
     {
         $consumer = $this->prophesize(OutboxConsumer::class);
-        $consumer->consume(null)->shouldBeCalled();
+        $consumer->consume(100)->shouldBeCalled();
 
         $command = new OutboxConsumeCommand(
             $consumer->reveal(),
@@ -33,16 +33,40 @@ final class OutboxConsumerCommandTest extends TestCase
         self::assertSame(0, $exitCode);
     }
 
-    public function testSuccessfulWithLimit(): void
+    public function testSuccessfulWithLegacyLimit(): void
     {
         $consumer = $this->prophesize(OutboxConsumer::class);
-        $consumer->consume(100)->shouldBeCalled();
+        $consumer->consume(200)->shouldBeCalled();
 
         $command = new OutboxConsumeCommand(
             $consumer->reveal(),
         );
 
-        $input = new ArrayInput(['--limit' => 100]);
+        $input = new ArrayInput(['--limit' => 200]);
+        $output = new BufferedOutput();
+
+        $exitCode = $command->run($input, $output);
+
+        self::assertSame(0, $exitCode);
+    }
+
+    public function testSuccessfulWithAllLimits(): void
+    {
+        $consumer = $this->prophesize(OutboxConsumer::class);
+        $consumer->consume(200)->shouldBeCalled();
+
+        $command = new OutboxConsumeCommand(
+            $consumer->reveal(),
+        );
+
+        $input = new ArrayInput([
+            '--message-limit' => 200,
+            '--run-limit' => 1,
+            '--memory-limit' => '10GB',
+            '--time-limit' => 3600,
+            '--sleep' => 1000,
+        ]);
+
         $output = new BufferedOutput();
 
         $exitCode = $command->run($input, $output);

--- a/tests/Unit/Console/Worker/BytesTest.php
+++ b/tests/Unit/Console/Worker/BytesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Worker;
+
+use Generator;
+use Patchlevel\EventSourcing\Console\Worker\Bytes;
+use Patchlevel\EventSourcing\Console\Worker\InvalidFormat;
+use PHPUnit\Framework\TestCase;
+
+final class BytesTest extends TestCase
+{
+    public function testParseInvalidUnit(): void
+    {
+        $this->expectException(InvalidFormat::class);
+
+        Bytes::parseFromString('505Foo');
+    }
+
+    public function testParseInvalidNegativeNumber(): void
+    {
+        $this->expectException(InvalidFormat::class);
+
+        Bytes::parseFromString('-5GB');
+    }
+
+    /**
+     * @dataProvider validParseDataProvider
+     */
+    public function testValidParse(string $string, int $expectedBytes): void
+    {
+        $bytes = Bytes::parseFromString($string);
+
+        self::assertSame($expectedBytes, $bytes->value());
+    }
+
+    /**
+     * @return Generator<array-key, array{string, int}>
+     */
+    public function validParseDataProvider(): Generator
+    {
+        yield ['50', 50];
+        yield ['50B', 50];
+        yield ['50b', 50];
+        yield ['50KB', 51_200];
+        yield ['50kb', 51_200];
+        yield ['50Kb', 51_200];
+        yield ['50MB', 52_428_800];
+        yield ['50mb', 52_428_800];
+        yield ['50GB', 53_687_091_200];
+        yield ['50gb', 53_687_091_200];
+    }
+}

--- a/tests/Unit/Console/Worker/DefaultWorkerTest.php
+++ b/tests/Unit/Console/Worker/DefaultWorkerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Worker;
+
+use Patchlevel\EventSourcing\Console\Worker\DefaultWorker;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerRunningEvent;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerStartedEvent;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerStoppedEvent;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class DefaultWorkerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testRunWorker(): void
+    {
+        $evenDispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $evenDispatcher->dispatch(Argument::type(WorkerStartedEvent::class))->shouldBeCalledTimes(1);
+        $evenDispatcher->dispatch(Argument::type(WorkerRunningEvent::class))->shouldBeCalledTimes(1)->will(
+            /** @param array{WorkerRunningEvent} $args */
+            static function (array $args) {
+                $args[0]->worker->stop();
+
+                return $args[0];
+            }
+        );
+        $evenDispatcher->dispatch(Argument::type(WorkerStoppedEvent::class))->shouldBeCalledTimes(1);
+
+        $logger = $this->prophesize(LoggerInterface::class);
+        $logger->debug('Worker starting')->shouldBeCalledTimes(1);
+        $logger->debug('Worker starting job run')->shouldBeCalledTimes(1);
+        $logger->debug('Worker finished job run ({ranTime}ms)', Argument::any())->shouldBeCalledTimes(1);
+        $logger->debug('Worker received stop signal')->shouldBeCalledTimes(1);
+        $logger->debug('Worker stopped')->shouldBeCalledTimes(1);
+        $logger->debug('Worker terminated')->shouldBeCalledTimes(1);
+
+        $worker = new DefaultWorker(static fn () => null, $evenDispatcher->reveal(), $logger->reveal());
+        $worker->run(200);
+    }
+}

--- a/tests/Unit/Console/Worker/Listener/StopWorkerOnIterationLimitListenerTest.php
+++ b/tests/Unit/Console/Worker/Listener/StopWorkerOnIterationLimitListenerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Worker\Listener;
+
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerRunningEvent;
+use Patchlevel\EventSourcing\Console\Worker\Listener\StopWorkerOnIterationLimitListener;
+use Patchlevel\EventSourcing\Console\Worker\Worker;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+final class StopWorkerOnIterationLimitListenerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testShouldNotStop(): void
+    {
+        $workerMock = $this->prophesize(Worker::class);
+        $workerMock->stop()->shouldNotBeCalled();
+        $worker = $workerMock->reveal();
+
+        $listener = new StopWorkerOnIterationLimitListener(10);
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker));
+    }
+
+    public function testShouldStop(): void
+    {
+        $workerMock = $this->prophesize(Worker::class);
+        $workerMock->stop()->shouldBeCalled();
+        $worker = $workerMock->reveal();
+
+        $listener = new StopWorkerOnIterationLimitListener(1);
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker));
+    }
+}

--- a/tests/Unit/Console/Worker/Listener/StopWorkerOnMemoryLimitListenerTest.php
+++ b/tests/Unit/Console/Worker/Listener/StopWorkerOnMemoryLimitListenerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Worker\Listener;
+
+use Patchlevel\EventSourcing\Console\Worker\Bytes;
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerRunningEvent;
+use Patchlevel\EventSourcing\Console\Worker\Listener\StopWorkerOnMemoryLimitListener;
+use Patchlevel\EventSourcing\Console\Worker\Worker;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+final class StopWorkerOnMemoryLimitListenerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testShouldNotStop(): void
+    {
+        $workerMock = $this->prophesize(Worker::class);
+        $workerMock->stop()->shouldNotBeCalled();
+        $worker = $workerMock->reveal();
+
+        $listener = new StopWorkerOnMemoryLimitListener(Bytes::parseFromString('5GB'));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker));
+    }
+
+    public function testShouldStop(): void
+    {
+        $workerMock = $this->prophesize(Worker::class);
+        $workerMock->stop()->shouldBeCalled();
+        $worker = $workerMock->reveal();
+
+        $listener = new StopWorkerOnMemoryLimitListener(Bytes::parseFromString('1KB'));
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker));
+    }
+}

--- a/tests/Unit/Console/Worker/Listener/StopWorkerOnTimeLimitListenerTest.php
+++ b/tests/Unit/Console/Worker/Listener/StopWorkerOnTimeLimitListenerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Worker\Listener;
+
+use Patchlevel\EventSourcing\Console\Worker\Event\WorkerRunningEvent;
+use Patchlevel\EventSourcing\Console\Worker\Listener\StopWorkerOnTimeLimitListener;
+use Patchlevel\EventSourcing\Console\Worker\Worker;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+use function sleep;
+
+final class StopWorkerOnTimeLimitListenerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testShouldNotStop(): void
+    {
+        $workerMock = $this->prophesize(Worker::class);
+        $workerMock->stop()->shouldNotBeCalled();
+        $worker = $workerMock->reveal();
+
+        $listener = new StopWorkerOnTimeLimitListener(10);
+        $listener->onWorkerStarted();
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker));
+    }
+
+    public function testShouldStop(): void
+    {
+        $workerMock = $this->prophesize(Worker::class);
+        $workerMock->stop()->shouldBeCalled();
+        $worker = $workerMock->reveal();
+
+        $listener = new StopWorkerOnTimeLimitListener(1);
+        $listener->onWorkerStarted();
+
+        sleep(1);
+
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker));
+    }
+}


### PR DESCRIPTION
* resolve #292

This PR adds a worker system, which is also used by the outbox consumer.

You can configure the worker and define one or more stop rules:

* When the memory limit has been reached
* After a certain time
* After a certain number of runs
* When SIGTERM is sent (ctrl+c)

The process is ended in the middle, but only at the end of a run.

Furthermore, you can also set how many ms should be waited between the runs.