### PR TITLE
Fix problem with database names using hyphens

### DIFF
--- a/src/Console/DoctrineHelper.php
+++ b/src/Console/DoctrineHelper.php
@@ -60,11 +60,15 @@ class DoctrineHelper
 
     public function createDatabase(Connection $connection, string $databaseName): void
     {
-        $connection->createSchemaManager()->createDatabase($databaseName);
+        $connection->createSchemaManager()->createDatabase(
+            $connection->getDatabasePlatform()->quoteSingleIdentifier($databaseName)
+        );
     }
 
     public function dropDatabase(Connection $connection, string $databaseName): void
     {
-        $connection->createSchemaManager()->dropDatabase($databaseName);
+        $connection->createSchemaManager()->dropDatabase(
+            $connection->getDatabasePlatform()->quoteSingleIdentifier($databaseName)
+        );
     }
 }

--- a/tests/Unit/Console/DoctrineHelperTest.php
+++ b/tests/Unit/Console/DoctrineHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Unit\Console;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use InvalidArgumentException;
 use Patchlevel\EventSourcing\Console\DoctrineHelper;
@@ -66,9 +67,10 @@ final class DoctrineHelperTest extends TestCase
         $helper = new DoctrineHelper();
 
         $schemaManager = $this->prophesize(AbstractSchemaManager::class);
-        $schemaManager->createDatabase('test')->shouldBeCalled();
+        $schemaManager->createDatabase('`test`')->shouldBeCalled();
 
         $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new MySQLPlatform());
         $connection->createSchemaManager()->willReturn($schemaManager);
 
         $helper->createDatabase($connection->reveal(), 'test');
@@ -79,9 +81,10 @@ final class DoctrineHelperTest extends TestCase
         $helper = new DoctrineHelper();
 
         $schemaManager = $this->prophesize(AbstractSchemaManager::class);
-        $schemaManager->dropDatabase('test')->shouldBeCalled();
+        $schemaManager->dropDatabase('`test`')->shouldBeCalled();
 
         $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new MySQLPlatform());
         $connection->createSchemaManager()->willReturn($schemaManager);
 
         $helper->dropDatabase($connection->reveal(), 'test');


### PR DESCRIPTION
Hi. First off all. Awesome lib. Thanks <3

While working to get it running, I noticed that there is a problem when creating a database where the name has hyphens in it. Using this, the name must be used with backticks.