### PR TITLE
Add event attribute to split the stream

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
+<files psalm-version="4.26.0@6998fabb2bf528b65777bf9941920888d23c03ac">
   <file src="src/Console/Command/OutboxConsumeCommand.php">
     <ArgumentTypeCoercion occurrences="1">
       <code>$sleep</code>
@@ -21,6 +21,9 @@
     </MoreSpecificReturnType>
   </file>
   <file src="src/Repository/DefaultRepository.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$messages[0]-&gt;playhead() - 1</code>
+    </ArgumentTypeCoercion>
     <MixedArgument occurrences="1">
       <code>++$playhead</code>
     </MixedArgument>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
     - Outbox: outbox.md
     - Pipeline: pipeline.md
     - Message Decorator: message_decorator.md
+    - Split Stream: split_stream.md
     - Time / Clock: clock.md
   - Other / Tools:
     - UUID: uuid.md

--- a/docs/pages/split_stream.md
+++ b/docs/pages/split_stream.md
@@ -1,0 +1,40 @@
+# Splitting the eventstream
+
+In some cases the business has rules which implies an restart of the event stream for an aggregate since the past events
+are not relevant for the current state. For example a user decides to end his active subscription and the business rules
+says if the user start a new subscription all past events should not be considered anymore. Another case could be a
+banking scenario. There the business decides to save the current state every quarter for each banking account.
+
+Not only that some businesses requires such an action it also increases the performance for aggregate which would have a
+really long event stream. 
+
+## Flagging an event to split the stream
+
+To use this feature you need to add the `SplitStreamDecorator`. You will also need events which will trigger this
+action. For that you can use the `#[SplitStream]` attribute. As soon this event is saved all passed events gets marked
+as archived and will not be loaded anymore for building the aggregate. This means that all needed data has to be present
+in these events which should trigger the event split.
+
+```php
+#[Event('bank_account.month_passed')]
+#[SplitStream]
+final class MonthPassed
+{
+    public function __construct(
+        #[Normalize(new AccountIdNormalizer())]
+        public AccountId $accountId,
+        public string $name,
+        public int $balanceInCents,
+    ) {
+    }
+}
+```
+
+!!! note
+
+    This archive flag only impacts the Store::load method which is used the build the aggregate from the stream.
+
+!!! warning
+
+    The event needs all data which is relevant the aggregate to be used since all past event will not be loaded! Keep 
+    this in mind if you want to use this feature.

--- a/docs/pages/split_stream.md
+++ b/docs/pages/split_stream.md
@@ -11,9 +11,10 @@ really long event stream.
 ## Flagging an event to split the stream
 
 To use this feature you need to add the `SplitStreamDecorator`. You will also need events which will trigger this
-action. For that you can use the `#[SplitStream]` attribute. As soon this event is saved all passed events gets marked
-as archived and will not be loaded anymore for building the aggregate. This means that all needed data has to be present
-in these events which should trigger the event split.
+action. For that you can use the `#[SplitStream]` attribute. We decided that we are not literallty splitting the stream, 
+instead we are marking all past events as archived as soon as this event is saved. Then the past events will not be 
+loaded anymore for building the aggregate. This means that all needed data has to be present in these events which 
+should trigger the event split.
 
 ```php
 #[Event('bank_account.month_passed')]

--- a/src/Aggregate/AggregateRoot.php
+++ b/src/Aggregate/AggregateRoot.php
@@ -75,11 +75,13 @@ abstract class AggregateRoot
     }
 
     /**
-     * @param list<object> $events
+     * @param list<object>   $events
+     * @param 0|positive-int $startPlayhead
      */
-    final public static function createFromEvents(array $events): static
+    final public static function createFromEvents(array $events, int $startPlayhead = 0): static
     {
         $self = new static();
+        $self->playhead = $startPlayhead;
         $self->catchUp($events);
 
         return $self;

--- a/src/Attribute/SplitStream.php
+++ b/src/Attribute/SplitStream.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class SplitStream
+{
+}

--- a/src/EventBus/Decorator/SplitStreamDecorator.php
+++ b/src/EventBus/Decorator/SplitStreamDecorator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\EventBus\Decorator;
+
+use Patchlevel\EventSourcing\EventBus\Message;
+use Patchlevel\EventSourcing\Metadata\Event\EventMetadataFactory;
+
+final class SplitStreamDecorator implements MessageDecorator
+{
+    public function __construct(private readonly EventMetadataFactory $eventMetadataFactory)
+    {
+    }
+
+    public function __invoke(Message $message): Message
+    {
+        $event = $message->event();
+        $metadata = $this->eventMetadataFactory->metadata($event::class);
+
+        if ($metadata->splitStream) {
+            return $message->withNewStreamStart(true);
+        }
+
+        return $message;
+    }
+}

--- a/src/Metadata/AggregateRoot/AttributeAggregateRootMetadataFactory.php
+++ b/src/Metadata/AggregateRoot/AttributeAggregateRootMetadataFactory.php
@@ -223,7 +223,6 @@ final class AttributeAggregateRootMetadataFactory implements AggregateRootMetada
         $properties = [];
 
         foreach ($reflectionClass->getProperties() as $reflectionProperty) {
-            $reflectionProperty->setAccessible(true);
             $fieldName = $reflectionProperty->getName();
 
             $attributeReflectionList = $reflectionProperty->getAttributes(NormalizedName::class);

--- a/src/Metadata/Event/EventMetadata.php
+++ b/src/Metadata/Event/EventMetadata.php
@@ -9,7 +9,8 @@ final class EventMetadata
     public function __construct(
         public readonly string $name,
         /** @var array<string, EventPropertyMetadata> */
-        public readonly array $properties = []
+        public readonly array $properties = [],
+        public readonly bool $splitStream = false,
     ) {
     }
 }

--- a/src/Pipeline/Middleware/RecalculatePlayheadMiddleware.php
+++ b/src/Pipeline/Middleware/RecalculatePlayheadMiddleware.php
@@ -11,7 +11,7 @@ use function array_key_exists;
 
 final class RecalculatePlayheadMiddleware implements Middleware
 {
-    /** @var array<class-string<AggregateRoot>, array<string, int>> */
+    /** @var array<class-string<AggregateRoot>, array<string, positive-int>> */
     private array $index = [];
 
     /**
@@ -32,6 +32,8 @@ final class RecalculatePlayheadMiddleware implements Middleware
 
     /**
      * @param class-string<AggregateRoot> $aggregateClass
+     *
+     * @return positive-int
      */
     private function nextPlayhead(string $aggregateClass, string $aggregateId): int
     {
@@ -40,10 +42,10 @@ final class RecalculatePlayheadMiddleware implements Middleware
         }
 
         if (!array_key_exists($aggregateId, $this->index[$aggregateClass])) {
-            $this->index[$aggregateClass][$aggregateId] = 0;
+            $this->index[$aggregateClass][$aggregateId] = 1;
+        } else {
+            $this->index[$aggregateClass][$aggregateId]++;
         }
-
-        $this->index[$aggregateClass][$aggregateId]++;
 
         return $this->index[$aggregateClass][$aggregateId];
     }

--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -14,7 +14,9 @@ use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadata;
 use Patchlevel\EventSourcing\Snapshot\SnapshotNotFound;
 use Patchlevel\EventSourcing\Snapshot\SnapshotStore;
 use Patchlevel\EventSourcing\Snapshot\SnapshotVersionInvalid;
+use Patchlevel\EventSourcing\Store\SplitEventstreamStore;
 use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Store\TransactionStore;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
@@ -56,7 +58,7 @@ final class DefaultRepository implements Repository
         $this->eventBus = $eventBus;
         $this->aggregateClass = $aggregateClass;
         $this->snapshotStore = $snapshotStore;
-        $this->messageDecorator = $messageDecorator ??  new RecordedOnDecorator(new SystemClock());
+        $this->messageDecorator = $messageDecorator ?? new RecordedOnDecorator(new SystemClock());
         $this->logger = $logger ?? new NullLogger();
         $this->metadata = $aggregateClass::metadata();
     }
@@ -102,7 +104,8 @@ final class DefaultRepository implements Repository
             array_map(
                 static fn (Message $message) => $message->event(),
                 $messages
-            )
+            ),
+            $messages[0]->playhead() - 1
         );
 
         if ($this->snapshotStore && $this->metadata->snapshotStore) {
@@ -133,6 +136,15 @@ final class DefaultRepository implements Repository
         $messageDecorator = $this->messageDecorator;
         $playhead = $aggregate->playhead() - count($events);
 
+        if ($playhead < 0) {
+            throw new PlayheadMismatch(
+                $aggregate::class,
+                $aggregate->aggregateRootId(),
+                $aggregate->playhead(),
+                count($events)
+            );
+        }
+
         $messages = array_map(
             static function (object $event) use ($aggregate, &$playhead, $messageDecorator) {
                 $message = Message::create($event)
@@ -144,6 +156,30 @@ final class DefaultRepository implements Repository
             },
             $events
         );
+
+        if ($this->store instanceof TransactionStore) {
+            $this->store->transactional(function () use ($messages): void {
+                $this->store->save(...$messages);
+
+                if ($this->store instanceof SplitEventstreamStore) {
+                    foreach ($messages as $message) {
+                        if (!$message->newStreamStart()) {
+                            continue;
+                        }
+
+                        $this->store->archiveMessages(
+                            $message->aggregateClass(),
+                            $message->aggregateId(),
+                            $message->playhead()
+                        );
+                    }
+                }
+
+                $this->eventBus->dispatch(...$messages);
+            });
+
+            return;
+        }
 
         $this->store->save(...$messages);
         $this->eventBus->dispatch(...$messages);

--- a/src/Repository/DefaultRepositoryManager.php
+++ b/src/Repository/DefaultRepositoryManager.php
@@ -42,7 +42,7 @@ final class DefaultRepositoryManager implements RepositoryManager
         $this->store = $store;
         $this->eventBus = $eventBus;
         $this->snapshotStore = $snapshotStore;
-        $this->messageDecorator = $messageDecorator ??  new RecordedOnDecorator(new SystemClock());
+        $this->messageDecorator = $messageDecorator ?? new RecordedOnDecorator(new SystemClock());
         $this->logger = $logger ?? new NullLogger();
     }
 

--- a/src/Repository/PlayheadMismatch.php
+++ b/src/Repository/PlayheadMismatch.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Repository;
+
+use function sprintf;
+
+final class PlayheadMismatch extends RepositoryException
+{
+    public function __construct(string $aggregateClass, string $aggregateId, int $playhead, int $eventCount)
+    {
+        parent::__construct(sprintf(
+            'There is a mismatch between the playhead [%s] and the event count [%s] for the aggregate [%s] with the id [%s]',
+            $playhead,
+            $eventCount,
+            $aggregateClass,
+            $aggregateId
+        ));
+    }
+}

--- a/src/Serializer/Hydrator/MetadataAggregateRootHydrator.php
+++ b/src/Serializer/Hydrator/MetadataAggregateRootHydrator.php
@@ -134,7 +134,6 @@ final class MetadataAggregateRootHydrator implements AggregateRootHydrator
     {
         if ($this->playheadReflection === null) {
             $this->playheadReflection = new ReflectionProperty(AggregateRoot::class, 'playhead');
-            $this->playheadReflection->setAccessible(true);
         }
 
         $this->playheadReflection->setValue($aggregateRoot, $playhead);

--- a/src/Store/DoctrineStore.php
+++ b/src/Store/DoctrineStore.php
@@ -21,7 +21,7 @@ use function is_array;
 use function is_int;
 use function is_string;
 
-abstract class DoctrineStore implements Store, TransactionStore, OutboxStore
+abstract class DoctrineStore implements Store, TransactionStore, OutboxStore, SplitEventstreamStore
 {
     private const OUTBOX_TABLE = 'outbox';
 
@@ -169,12 +169,15 @@ abstract class DoctrineStore implements Store, TransactionStore, OutboxStore
         return $normalizedRecordedOn;
     }
 
+    /**
+     * @return positive-int
+     */
     protected static function normalizePlayhead(string|int $playhead, AbstractPlatform $platform): int
     {
         $normalizedPlayhead = Type::getType(Types::INTEGER)->convertToPHPValue($playhead, $platform);
 
-        if (!is_int($normalizedPlayhead)) {
-            throw new InvalidType('playhead', 'int');
+        if (!is_int($normalizedPlayhead) || $normalizedPlayhead <= 0) {
+            throw new InvalidType('playhead', 'positive-int');
         }
 
         return $normalizedPlayhead;

--- a/src/Store/SplitEventstreamStore.php
+++ b/src/Store/SplitEventstreamStore.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
+
+interface SplitEventstreamStore extends TransactionStore
+{
+    /**
+     * @param class-string<AggregateRoot> $aggregate
+     */
+    public function archiveMessages(string $aggregate, string $id, int $untilPlayhead): void;
+}

--- a/tests/Integration/BankAccountSplitStream/AccountId.php
+++ b/tests/Integration/BankAccountSplitStream/AccountId.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream;
+
+final class AccountId
+{
+    private string $id;
+
+    private function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public static function fromString(string $id): self
+    {
+        return new self($id);
+    }
+
+    public function toString(): string
+    {
+        return $this->id;
+    }
+}

--- a/tests/Integration/BankAccountSplitStream/Aggregate/BankAccount.php
+++ b/tests/Integration/BankAccountSplitStream/Aggregate/BankAccount.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Aggregate;
+
+use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Apply;
+use Patchlevel\EventSourcing\Attribute\Normalize;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\AccountId;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events\BalanceAdded;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events\BankAccountCreated;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events\MonthPassed;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Normalizer\AccountIdNormalizer;
+
+#[Aggregate('profile')]
+final class BankAccount extends AggregateRoot
+{
+    #[Normalize(new AccountIdNormalizer())]
+    private AccountId $id;
+    private string $name;
+    private int $balanceInCents;
+    /** @var list<object> */
+    public array $appliedEvents = [];
+
+    public function aggregateRootId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public static function create(AccountId $id, string $name): self
+    {
+        $self = new self();
+        $self->recordThat(new BankAccountCreated($id, $name));
+
+        return $self;
+    }
+
+    /**
+     * @param positive-int $newAddedBalance
+     */
+    public function addBalance(int $newAddedBalance): void
+    {
+        $this->recordThat(new BalanceAdded($this->id, $newAddedBalance));
+    }
+
+    public function beginNewMonth(): void
+    {
+        $this->recordThat(new MonthPassed($this->id, $this->name, $this->balanceInCents));
+    }
+
+    #[Apply(BankAccountCreated::class)]
+    protected function applyBankAccountCreated(BankAccountCreated $event): void
+    {
+        $this->id = $event->accountId;
+        $this->name = $event->name;
+        $this->balanceInCents = 0;
+        $this->appliedEvents[] = $event;
+    }
+
+    #[Apply(BalanceAdded::class)]
+    protected function applyBalanceAdded(BalanceAdded $event): void
+    {
+        $this->balanceInCents += $event->balanceInCents;
+        $this->appliedEvents[] = $event;
+    }
+
+    #[Apply(MonthPassed::class)]
+    protected function applyMonthPassed(MonthPassed $event): void
+    {
+        $this->id = $event->accountId;
+        $this->name = $event->name;
+        $this->balanceInCents = $event->balanceInCents;
+        $this->appliedEvents[] = $event;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function balance(): int
+    {
+        return $this->balanceInCents;
+    }
+}

--- a/tests/Integration/BankAccountSplitStream/Events/BalanceAdded.php
+++ b/tests/Integration/BankAccountSplitStream/Events/BalanceAdded.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+use Patchlevel\EventSourcing\Attribute\Normalize;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\AccountId;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Normalizer\AccountIdNormalizer;
+
+#[Event('bank_account.balance_added')]
+final class BalanceAdded
+{
+    public function __construct(
+        #[Normalize(new AccountIdNormalizer())]
+        public AccountId $accountId,
+        /** @var positive-int */
+        public int $balanceInCents,
+    ) {
+    }
+}

--- a/tests/Integration/BankAccountSplitStream/Events/BankAccountCreated.php
+++ b/tests/Integration/BankAccountSplitStream/Events/BankAccountCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+use Patchlevel\EventSourcing\Attribute\Normalize;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\AccountId;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Normalizer\AccountIdNormalizer;
+
+#[Event('bank_account.created')]
+final class BankAccountCreated
+{
+    public function __construct(
+        #[Normalize(new AccountIdNormalizer())]
+        public AccountId $accountId,
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Integration/BankAccountSplitStream/Events/MonthPassed.php
+++ b/tests/Integration/BankAccountSplitStream/Events/MonthPassed.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+use Patchlevel\EventSourcing\Attribute\Normalize;
+use Patchlevel\EventSourcing\Attribute\SplitStream;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\AccountId;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Normalizer\AccountIdNormalizer;
+
+#[Event('bank_account.month_passed')]
+#[SplitStream]
+final class MonthPassed
+{
+    public function __construct(
+        #[Normalize(new AccountIdNormalizer())]
+        public AccountId $accountId,
+        public string $name,
+        public int $balanceInCents,
+    ) {
+    }
+}

--- a/tests/Integration/BankAccountSplitStream/IntegrationTest.php
+++ b/tests/Integration/BankAccountSplitStream/IntegrationTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream;
+
+use Doctrine\DBAL\Connection;
+use Patchlevel\EventSourcing\Clock\SystemClock;
+use Patchlevel\EventSourcing\EventBus\Decorator\ChainMessageDecorator;
+use Patchlevel\EventSourcing\EventBus\Decorator\RecordedOnDecorator;
+use Patchlevel\EventSourcing\EventBus\Decorator\SplitStreamDecorator;
+use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
+use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
+use Patchlevel\EventSourcing\Projection\MetadataAwareProjectionHandler;
+use Patchlevel\EventSourcing\Projection\ProjectionListener;
+use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
+use Patchlevel\EventSourcing\Schema\DoctrineSchemaManager;
+use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
+use Patchlevel\EventSourcing\Store\MultiTableStore;
+use Patchlevel\EventSourcing\Store\SingleTableStore;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Aggregate\BankAccount;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Projection\BankAccountProjection;
+use Patchlevel\EventSourcing\Tests\Integration\DbalManager;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+
+/**
+ * @coversNothing
+ */
+final class IntegrationTest extends TestCase
+{
+    private Connection $connection;
+
+    public function setUp(): void
+    {
+        $this->connection = DbalManager::createConnection();
+    }
+
+    public function tearDown(): void
+    {
+        $this->connection->close();
+    }
+
+    public function testSingleTableSuccessful(): void
+    {
+        $bankAccountProjection = new BankAccountProjection($this->connection);
+        $projectionRepository = new MetadataAwareProjectionHandler([$bankAccountProjection]);
+
+        $eventStream = new DefaultEventBus();
+        $eventStream->addListener(new ProjectionListener($projectionRepository));
+
+        $store = new SingleTableStore(
+            $this->connection,
+            DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
+            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/Aggregate']),
+            'eventstore'
+        );
+
+        $manager = new DefaultRepositoryManager(
+            new AggregateRootRegistry(['bank_account' => BankAccount::class]),
+            $store,
+            $eventStream,
+            null,
+            new ChainMessageDecorator([
+                new RecordedOnDecorator(new SystemClock()),
+                new SplitStreamDecorator(new AttributeEventMetadataFactory()),
+            ])
+        );
+        $repository = $manager->get(BankAccount::class);
+
+        // create tables
+        $bankAccountProjection->create();
+        (new DoctrineSchemaManager())->create($store);
+
+        $bankAccount = BankAccount::create(AccountId::fromString('1'), 'John');
+        $bankAccount->addBalance(100);
+        $bankAccount->addBalance(500);
+        $repository->save($bankAccount);
+
+        $result = $this->connection->fetchAssociative('SELECT * FROM projection_bank_account WHERE id = ?', ['1']);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('id', $result);
+        self::assertSame('1', $result['id']);
+        self::assertSame('John', $result['name']);
+        self::assertSame(600, $result['balance_in_cents']);
+
+        $manager = new DefaultRepositoryManager(
+            new AggregateRootRegistry(['bank_account' => BankAccount::class]),
+            $store,
+            $eventStream,
+            null,
+            new ChainMessageDecorator([
+                new RecordedOnDecorator(new SystemClock()),
+                new SplitStreamDecorator(new AttributeEventMetadataFactory()),
+            ])
+        );
+        $repository = $manager->get(BankAccount::class);
+        $bankAccount = $repository->load('1');
+
+        self::assertInstanceOf(BankAccount::class, $bankAccount);
+        self::assertSame('1', $bankAccount->aggregateRootId());
+        self::assertSame(3, $bankAccount->playhead());
+        self::assertSame('John', $bankAccount->name());
+        self::assertSame(600, $bankAccount->balance());
+        self::assertSame(3, count($bankAccount->appliedEvents));
+
+        $bankAccount->beginNewMonth();
+        $bankAccount->addBalance(200);
+        $repository->save($bankAccount);
+
+        $result = $this->connection->fetchAssociative('SELECT * FROM projection_bank_account WHERE id = ?', ['1']);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('id', $result);
+        self::assertSame('1', $result['id']);
+        self::assertSame('John', $result['name']);
+        self::assertSame(800, $result['balance_in_cents']);
+
+        $manager = new DefaultRepositoryManager(
+            new AggregateRootRegistry(['bank_account' => BankAccount::class]),
+            $store,
+            $eventStream,
+            null,
+            new ChainMessageDecorator([
+                new RecordedOnDecorator(new SystemClock()),
+                new SplitStreamDecorator(new AttributeEventMetadataFactory()),
+            ])
+        );
+        $repository = $manager->get(BankAccount::class);
+        $bankAccount = $repository->load('1');
+
+        self::assertInstanceOf(BankAccount::class, $bankAccount);
+        self::assertSame('1', $bankAccount->aggregateRootId());
+        self::assertSame(5, $bankAccount->playhead());
+        self::assertSame('John', $bankAccount->name());
+        self::assertSame(800, $bankAccount->balance());
+        self::assertSame(2, count($bankAccount->appliedEvents));
+    }
+
+    public function testMultiTableSuccessful(): void
+    {
+        $bankAccountProjection = new BankAccountProjection($this->connection);
+        $projectionRepository = new MetadataAwareProjectionHandler([$bankAccountProjection]);
+
+        $eventStream = new DefaultEventBus();
+        $eventStream->addListener(new ProjectionListener($projectionRepository));
+
+        $store = new MultiTableStore(
+            $this->connection,
+            DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
+            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/Aggregate']),
+        );
+
+        $manager = new DefaultRepositoryManager(
+            new AggregateRootRegistry(['bank_account' => BankAccount::class]),
+            $store,
+            $eventStream,
+            null,
+            new ChainMessageDecorator([
+                new RecordedOnDecorator(new SystemClock()),
+                new SplitStreamDecorator(new AttributeEventMetadataFactory()),
+            ])
+        );
+        $repository = $manager->get(BankAccount::class);
+
+        // create tables
+        $bankAccountProjection->create();
+        (new DoctrineSchemaManager())->create($store);
+
+        $bankAccount = BankAccount::create(AccountId::fromString('1'), 'John');
+        $bankAccount->addBalance(100);
+        $bankAccount->addBalance(500);
+        $repository->save($bankAccount);
+
+        $result = $this->connection->fetchAssociative('SELECT * FROM projection_bank_account WHERE id = ?', ['1']);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('id', $result);
+        self::assertSame('1', $result['id']);
+        self::assertSame('John', $result['name']);
+        self::assertSame(600, $result['balance_in_cents']);
+
+        $manager = new DefaultRepositoryManager(
+            new AggregateRootRegistry(['bank_account' => BankAccount::class]),
+            $store,
+            $eventStream,
+            null,
+            new ChainMessageDecorator([
+                new RecordedOnDecorator(new SystemClock()),
+                new SplitStreamDecorator(new AttributeEventMetadataFactory()),
+            ])
+        );
+        $repository = $manager->get(BankAccount::class);
+        $bankAccount = $repository->load('1');
+
+        self::assertInstanceOf(BankAccount::class, $bankAccount);
+        self::assertSame('1', $bankAccount->aggregateRootId());
+        self::assertSame(3, $bankAccount->playhead());
+        self::assertSame('John', $bankAccount->name());
+        self::assertSame(600, $bankAccount->balance());
+        self::assertSame(3, count($bankAccount->appliedEvents));
+
+        $bankAccount->beginNewMonth();
+        $bankAccount->addBalance(200);
+        $repository->save($bankAccount);
+
+        $result = $this->connection->fetchAssociative('SELECT * FROM projection_bank_account WHERE id = ?', ['1']);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('id', $result);
+        self::assertSame('1', $result['id']);
+        self::assertSame('John', $result['name']);
+        self::assertSame(800, $result['balance_in_cents']);
+
+        $manager = new DefaultRepositoryManager(
+            new AggregateRootRegistry(['bank_account' => BankAccount::class]),
+            $store,
+            $eventStream,
+            null,
+            new ChainMessageDecorator([
+                new RecordedOnDecorator(new SystemClock()),
+                new SplitStreamDecorator(new AttributeEventMetadataFactory()),
+            ])
+        );
+        $repository = $manager->get(BankAccount::class);
+        $bankAccount = $repository->load('1');
+
+        self::assertInstanceOf(BankAccount::class, $bankAccount);
+        self::assertSame('1', $bankAccount->aggregateRootId());
+        self::assertSame(5, $bankAccount->playhead());
+        self::assertSame('John', $bankAccount->name());
+        self::assertSame(800, $bankAccount->balance());
+        self::assertSame(2, count($bankAccount->appliedEvents));
+    }
+}

--- a/tests/Integration/BankAccountSplitStream/IntegrationTest.php
+++ b/tests/Integration/BankAccountSplitStream/IntegrationTest.php
@@ -21,6 +21,9 @@ use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\MultiTableStore;
 use Patchlevel\EventSourcing\Store\SingleTableStore;
 use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Aggregate\BankAccount;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events\BalanceAdded;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events\BankAccountCreated;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events\MonthPassed;
 use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Projection\BankAccountProjection;
 use Patchlevel\EventSourcing\Tests\Integration\DbalManager;
 use PHPUnit\Framework\TestCase;
@@ -107,6 +110,9 @@ final class IntegrationTest extends TestCase
         self::assertSame('John', $bankAccount->name());
         self::assertSame(600, $bankAccount->balance());
         self::assertSame(3, count($bankAccount->appliedEvents));
+        self::assertInstanceOf(BankAccountCreated::class, $bankAccount->appliedEvents[0]);
+        self::assertInstanceOf(BalanceAdded::class, $bankAccount->appliedEvents[1]);
+        self::assertInstanceOf(BalanceAdded::class, $bankAccount->appliedEvents[2]);
 
         $bankAccount->beginNewMonth();
         $bankAccount->addBalance(200);
@@ -139,6 +145,8 @@ final class IntegrationTest extends TestCase
         self::assertSame('John', $bankAccount->name());
         self::assertSame(800, $bankAccount->balance());
         self::assertSame(2, count($bankAccount->appliedEvents));
+        self::assertInstanceOf(MonthPassed::class, $bankAccount->appliedEvents[0]);
+        self::assertInstanceOf(BalanceAdded::class, $bankAccount->appliedEvents[1]);
     }
 
     public function testMultiTableSuccessful(): void
@@ -203,6 +211,9 @@ final class IntegrationTest extends TestCase
         self::assertSame('John', $bankAccount->name());
         self::assertSame(600, $bankAccount->balance());
         self::assertSame(3, count($bankAccount->appliedEvents));
+        self::assertInstanceOf(BankAccountCreated::class, $bankAccount->appliedEvents[0]);
+        self::assertInstanceOf(BalanceAdded::class, $bankAccount->appliedEvents[1]);
+        self::assertInstanceOf(BalanceAdded::class, $bankAccount->appliedEvents[2]);
 
         $bankAccount->beginNewMonth();
         $bankAccount->addBalance(200);
@@ -235,5 +246,7 @@ final class IntegrationTest extends TestCase
         self::assertSame('John', $bankAccount->name());
         self::assertSame(800, $bankAccount->balance());
         self::assertSame(2, count($bankAccount->appliedEvents));
+        self::assertInstanceOf(MonthPassed::class, $bankAccount->appliedEvents[0]);
+        self::assertInstanceOf(BalanceAdded::class, $bankAccount->appliedEvents[1]);
     }
 }

--- a/tests/Integration/BankAccountSplitStream/Normalizer/AccountIdNormalizer.php
+++ b/tests/Integration/BankAccountSplitStream/Normalizer/AccountIdNormalizer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Normalizer;
+
+use InvalidArgumentException;
+use Patchlevel\EventSourcing\Serializer\Normalizer\Normalizer;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\AccountId;
+
+use function is_string;
+
+final class AccountIdNormalizer implements Normalizer
+{
+    public function normalize(mixed $value): string
+    {
+        if (!$value instanceof AccountId) {
+            throw new InvalidArgumentException();
+        }
+
+        return $value->toString();
+    }
+
+    public function denormalize(mixed $value): ?AccountId
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value)) {
+            throw new InvalidArgumentException();
+        }
+
+        return AccountId::fromString($value);
+    }
+}

--- a/tests/Integration/BankAccountSplitStream/Projection/BankAccountProjection.php
+++ b/tests/Integration/BankAccountSplitStream/Projection/BankAccountProjection.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Projection;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Table;
+use Patchlevel\EventSourcing\Attribute\Create;
+use Patchlevel\EventSourcing\Attribute\Drop;
+use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\EventBus\Message;
+use Patchlevel\EventSourcing\Projection\Projection;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events\BalanceAdded;
+use Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream\Events\BankAccountCreated;
+
+final class BankAccountProjection implements Projection
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    #[Create]
+    public function create(): void
+    {
+        $table = new Table('projection_bank_account');
+        $table->addColumn('id', 'string');
+        $table->addColumn('name', 'string');
+        $table->addColumn('balance_in_cents', 'integer');
+        $table->setPrimaryKey(['id']);
+
+        $this->connection->createSchemaManager()->createTable($table);
+    }
+
+    #[Drop]
+    public function drop(): void
+    {
+        $this->connection->createSchemaManager()->dropTable('projection_bank_account');
+    }
+
+    #[Handle(BankAccountCreated::class)]
+    public function handleBankAccountCreated(Message $message): void
+    {
+        $event = $message->event();
+
+        $this->connection->executeStatement(
+            'INSERT INTO projection_bank_account (id, name, balance_in_cents) VALUES(:id, :name, 0);',
+            [
+                'id' => $event->accountId->toString(),
+                'name' => $event->name,
+            ]
+        );
+    }
+
+    #[Handle(BalanceAdded::class)]
+    public function handleBalanceAdded(Message $message): void
+    {
+        $event = $message->event();
+
+        $this->connection->executeStatement(
+            'UPDATE projection_bank_account SET balance_in_cents = balance_in_cents + :balance WHERE id = :id;',
+            [
+                'id' => $event->accountId->toString(),
+                'balance' => $event->balanceInCents,
+            ]
+        );
+    }
+}

--- a/tests/Unit/Fixture/ProfileCreated.php
+++ b/tests/Unit/Fixture/ProfileCreated.php
@@ -14,7 +14,7 @@ final class ProfileCreated
         #[Normalize(new ProfileIdNormalizer())]
         public ProfileId $profileId,
         #[Normalize(new EmailNormalizer())]
-        public Email $email
+        public Email $email,
     ) {
     }
 }

--- a/tests/Unit/Fixture/SplittingEvent.php
+++ b/tests/Unit/Fixture/SplittingEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+use Patchlevel\EventSourcing\Attribute\SplitStream;
+
+#[SplitStream]
+#[Event('splitting_event')]
+final class SplittingEvent
+{
+    public function __construct(
+        public Email $email,
+        public int $visits,
+    ) {
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AttributeAggregateMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/AttributeAggregateMetadataFactoryTest.php
@@ -18,6 +18,7 @@ use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyIntersecti
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyMultipleApply;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyNoType;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithEmptyApply;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\SplittingEvent;
 use PHPUnit\Framework\TestCase;
 
 final class AttributeAggregateMetadataFactoryTest extends TestCase
@@ -32,6 +33,7 @@ final class AttributeAggregateMetadataFactoryTest extends TestCase
                 ProfileCreated::class => 'applyProfileCreated',
                 ProfileVisited::class => 'applyProfileCreated',
                 NameChanged::class => 'applyNameChanged',
+                SplittingEvent::class => 'applySplittingEvent',
             ],
             $metadata->applyMethods
         );

--- a/tests/Unit/Store/MultiTableStoreTest.php
+++ b/tests/Unit/Store/MultiTableStoreTest.php
@@ -6,8 +6,12 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Store;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Statement;
+use Doctrine\DBAL\Types\Types;
+use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Serializer\SerializedEvent;
@@ -17,6 +21,7 @@ use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
@@ -33,10 +38,14 @@ final class MultiTableStoreTest extends TestCase
 
         $connection = $this->prophesize(Connection::class);
         $connection->fetchAllAssociative(
-            'SELECT * FROM profile WHERE aggregate_id = :id AND playhead > :playhead',
+            'SELECT * FROM profile WHERE (aggregate_id = :id) AND (playhead > :playhead) AND (archived = :archived)',
             [
                 'id' => '1',
                 'playhead' => 0,
+                'archived' => false,
+            ],
+            [
+                'archived' => Types::BOOLEAN,
             ]
         )->willReturn([]);
         $connection->createQueryBuilder()->willReturn($queryBuilder);
@@ -61,16 +70,20 @@ final class MultiTableStoreTest extends TestCase
 
         $connection = $this->prophesize(Connection::class);
         $connection->fetchAllAssociative(
-            'SELECT * FROM profile WHERE aggregate_id = :id AND playhead > :playhead',
+            'SELECT * FROM profile WHERE (aggregate_id = :id) AND (playhead > :playhead) AND (archived = :archived)',
             [
                 'id' => '1',
                 'playhead' => 0,
+                'archived' => false,
+            ],
+            [
+                'archived' => Types::BOOLEAN,
             ]
         )->willReturn(
             [
                 [
                     'aggregate_id' => '1',
-                    'playhead' => '0',
+                    'playhead' => '1',
                     'event' => 'profile.created',
                     'payload' => '{"profileId": "1", "email": "s"}',
                     'recorded_on' => '2021-02-17 10:00:00',
@@ -104,7 +117,7 @@ final class MultiTableStoreTest extends TestCase
 
         self::assertInstanceOf(ProfileCreated::class, $message->event());
         self::assertSame('1', $message->aggregateId());
-        self::assertSame(0, $message->playhead());
+        self::assertSame(1, $message->playhead());
         self::assertEquals(new DateTimeImmutable('2021-02-17 10:00:00'), $message->recordedOn());
     }
 
@@ -177,5 +190,103 @@ final class MultiTableStoreTest extends TestCase
         );
 
         $store->transactional($callback);
+    }
+
+    public function testSaveWithOneEvent(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withAggregateClass(Profile::class)
+            ->withAggregateId('1')
+            ->withPlayhead(1)
+            ->withRecordedOn($recordedOn)
+            ->withNewStreamStart(false)
+            ->withArchived(false);
+
+        $innerMockedConnection = $this->prophesize(Connection::class);
+
+        $platform = $this->prophesize(AbstractPlatform::class);
+        $innerMockedConnection->getDatabasePlatform()->willReturn($platform->reveal());
+
+        $innerMockedConnection->insert(
+            'eventstore_metadata',
+            [
+                'aggregate' => 'profile',
+                'aggregate_id' => '1',
+                'playhead' => 1,
+            ]
+        )->shouldBeCalledOnce();
+
+        $innerMockedConnection->lastInsertId()->shouldBeCalledOnce()->willReturn('2');
+
+        $innerMockedConnection->insert(
+            'profile',
+            [
+                'id' => '2',
+                'aggregate_id' => '1',
+                'playhead' => 1,
+                'event' => 'profile_created',
+                'payload' => '',
+                'recorded_on' => $recordedOn,
+                'new_stream_start' => false,
+                'archived' => false,
+                'custom_headers' => [],
+            ],
+            [
+                'recorded_on' => 'datetimetz_immutable',
+                'custom_headers' => 'json',
+                'archived' => Types::BOOLEAN,
+                'new_stream_start' => Types::BOOLEAN,
+            ],
+        )->shouldBeCalledOnce();
+
+        $driver = $this->prophesize(Driver::class);
+        $driver->connect(Argument::any())->willReturn($innerMockedConnection->reveal());
+
+        $serializer = $this->prophesize(EventSerializer::class);
+        $serializer->serialize($message->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent('profile_created', ''));
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->transactional(Argument::any())->will(
+            /**
+             * @param array{0: callable} $args
+             */
+            static fn (array $args): mixed => $args[0]($innerMockedConnection->reveal())
+        );
+
+        $multiTableStore = new MultiTableStore(
+            $mockedConnection->reveal(),
+            $serializer->reveal(),
+            new AggregateRootRegistry(['profile' => Profile::class]),
+            'eventstore_metadata'
+        );
+        $multiTableStore->save($message);
+    }
+
+    public function testArchiveMessages(): void
+    {
+        $serializer = $this->prophesize(EventSerializer::class);
+
+        $statement = $this->prophesize(Statement::class);
+        $statement->bindValue('aggregate_id', '1')->shouldBeCalledOnce();
+        $statement->bindValue('playhead', 1)->shouldBeCalledOnce();
+        $statement->executeQuery()->shouldBeCalledOnce();
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->prepare(
+            'UPDATE profile 
+            SET archived = true
+            WHERE aggregate_id = :aggregate_id
+            AND playhead < :playhead
+            AND archived = false'
+        )->shouldBeCalledOnce()->willReturn($statement->reveal());
+
+        $multiTableStore = new MultiTableStore(
+            $mockedConnection->reveal(),
+            $serializer->reveal(),
+            new AggregateRootRegistry(['profile' => Profile::class]),
+            'eventstore_metadata'
+        );
+        $multiTableStore->archiveMessages(Profile::class, '1', 1);
     }
 }

--- a/tests/Unit/Store/SingleTableStoreTest.php
+++ b/tests/Unit/Store/SingleTableStoreTest.php
@@ -6,8 +6,12 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Store;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Statement;
+use Doctrine\DBAL\Types\Types;
+use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Serializer\SerializedEvent;
@@ -17,6 +21,7 @@ use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
@@ -33,11 +38,15 @@ final class SingleTableStoreTest extends TestCase
 
         $connection = $this->prophesize(Connection::class);
         $connection->fetchAllAssociative(
-            'SELECT * FROM eventstore WHERE aggregate = :aggregate AND aggregate_id = :id AND playhead > :playhead',
+            'SELECT * FROM eventstore WHERE (aggregate = :aggregate) AND (aggregate_id = :id) AND (playhead > :playhead) AND (archived = :archived)',
             [
                 'aggregate' => 'profile',
                 'id' => '1',
                 'playhead' => 0,
+                'archived' => false,
+            ],
+            [
+                'archived' => Types::BOOLEAN,
             ]
         )->willReturn([]);
         $connection->createQueryBuilder()->willReturn($queryBuilder);
@@ -62,17 +71,21 @@ final class SingleTableStoreTest extends TestCase
 
         $connection = $this->prophesize(Connection::class);
         $connection->fetchAllAssociative(
-            'SELECT * FROM eventstore WHERE aggregate = :aggregate AND aggregate_id = :id AND playhead > :playhead',
+            'SELECT * FROM eventstore WHERE (aggregate = :aggregate) AND (aggregate_id = :id) AND (playhead > :playhead) AND (archived = :archived)',
             [
                 'aggregate' => 'profile',
                 'id' => '1',
                 'playhead' => 0,
+                'archived' => false,
+            ],
+            [
+                'archived' => Types::BOOLEAN,
             ]
         )->willReturn(
             [
                 [
                     'aggregate_id' => '1',
-                    'playhead' => '0',
+                    'playhead' => '1',
                     'event' => 'profile.created',
                     'payload' => '{"profileId": "1", "email": "s"}',
                     'recorded_on' => '2021-02-17 10:00:00',
@@ -106,7 +119,7 @@ final class SingleTableStoreTest extends TestCase
 
         self::assertInstanceOf(ProfileCreated::class, $message->event());
         self::assertSame('1', $message->aggregateId());
-        self::assertSame(0, $message->playhead());
+        self::assertSame(1, $message->playhead());
         self::assertEquals(new DateTimeImmutable('2021-02-17 10:00:00'), $message->recordedOn());
     }
 
@@ -179,5 +192,94 @@ final class SingleTableStoreTest extends TestCase
         );
 
         $store->transactional($callback);
+    }
+
+    public function testSaveWithOneEvent(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withAggregateClass(Profile::class)
+            ->withAggregateId('1')
+            ->withPlayhead(1)
+            ->withRecordedOn($recordedOn)
+            ->withNewStreamStart(false)
+            ->withArchived(false);
+
+        $innerMockedConnection = $this->prophesize(Connection::class);
+
+        $platform = $this->prophesize(AbstractPlatform::class);
+        $innerMockedConnection->getDatabasePlatform()->willReturn($platform->reveal());
+
+        $innerMockedConnection->insert(
+            'eventstore',
+            [
+                'aggregate' => 'profile',
+                'aggregate_id' => '1',
+                'playhead' => 1,
+                'event' => 'profile_created',
+                'payload' => '',
+                'recorded_on' => $recordedOn,
+                'new_stream_start' => false,
+                'archived' => false,
+                'custom_headers' => [],
+            ],
+            [
+                'recorded_on' => 'datetimetz_immutable',
+                'custom_headers' => 'json',
+                'archived' => Types::BOOLEAN,
+                'new_stream_start' => Types::BOOLEAN,
+            ]
+        )->shouldBeCalledOnce();
+
+        $driver = $this->prophesize(Driver::class);
+        $driver->connect(Argument::any())->willReturn($innerMockedConnection->reveal());
+
+        $serializer = $this->prophesize(EventSerializer::class);
+        $serializer->serialize($message->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent('profile_created', ''));
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->transactional(Argument::any())->will(
+            /**
+             * @param array{0: callable} $args
+             */
+            static fn (array $args): mixed => $args[0]($innerMockedConnection->reveal())
+        );
+
+        $singleTableStore = new SingleTableStore(
+            $mockedConnection->reveal(),
+            $serializer->reveal(),
+            new AggregateRootRegistry(['profile' => Profile::class]),
+            'eventstore'
+        );
+        $singleTableStore->save($message);
+    }
+
+    public function testArchiveMessages(): void
+    {
+        $serializer = $this->prophesize(EventSerializer::class);
+
+        $statement = $this->prophesize(Statement::class);
+        $statement->bindValue('aggregate', 'profile')->shouldBeCalledOnce();
+        $statement->bindValue('aggregate_id', '1')->shouldBeCalledOnce();
+        $statement->bindValue('playhead', 1)->shouldBeCalledOnce();
+        $statement->executeQuery()->shouldBeCalledOnce();
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->prepare(
+            'UPDATE eventstore 
+            SET archived = true
+            WHERE aggregate = :aggregate
+            AND aggregate_id = :aggregate_id
+            AND playhead < :playhead
+            AND archived = false'
+        )->shouldBeCalledOnce()->willReturn($statement->reveal());
+
+        $singleTableStore = new SingleTableStore(
+            $mockedConnection->reveal(),
+            $serializer->reveal(),
+            new AggregateRootRegistry(['profile' => Profile::class]),
+            'eventstore'
+        );
+        $singleTableStore->archiveMessages(Profile::class, '1', 1);
     }
 }


### PR DESCRIPTION
Add the possibility to split the stream on a given event with the attribute SplitStream. If an event with this marker attribute is going to be saved, then all past events get archived. Then only the non archived events get loaded to rebuild the aggregate. That means that those marked events need to hold all data needed to re-create the aggregate to the same state as it is in the moment. If this is not given the whole system is going to break.

Why are we doing this? There is for one a performance boost if we are having really big stream for aggregates it could take some time to recreate them if we are going through millions of events. With this we can like start again from one event. Some businesses also require some kind of monthly or yearly reset of the stream.