### PR TITLE
Fix current version normalization

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -41,7 +41,7 @@ jobs:
         id: current
         uses: actions/github-script@v6
         with:
-          script: return context.ref.match(/([0-9]+\.[0-9]+)\.x/i)[1];
+          script: return context.ref.match(/([0-9]+\.[0-9]+)\.(x|[0-9]+)/i)[1];
           result-encoding: string
 
       - name: Normalize latest versions


### PR DESCRIPTION
This will allow the `docs-build` workflow to work with branch names like `0.0.x` and also tagged releases like `0.0.0`.
Should solve #302 