### PR TITLE
update supported databases

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,8 +37,8 @@ jobs:
                 operating-system:
                     - "ubuntu-latest"
                 postgres-version:
-                  - "10.22"
-                  - "11.17"
+                  - "10.22-alpine"
+                  - "11.17-alpine"
                   - "12.12"
                   - "13.8"
                   - "14.5"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,9 +37,11 @@ jobs:
                 operating-system:
                     - "ubuntu-latest"
                 postgres-version:
-                  - "9.4"
-                  - "13"
-                  - "14"
+                  - "10.22"
+                  - "11.17"
+                  - "12.12"
+                  - "13.8"
+                  - "14.5"
 
         env:
             DB_URL: 'postgresql://postgres:postgres@localhost:5432/eventstore?charset=utf8'
@@ -89,9 +91,9 @@ jobs:
           operating-system:
             - "ubuntu-latest"
           mariadb-version:
-            - "10.0"
-            - "10.2"
-            - "10.5"
+            - "10.3"
+            - "10.6"
+            - "10.9"
 
       env:
         DB_URL: 'mysql://root@127.0.0.1:3306/eventstore?charset=utf8'

--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ composer require patchlevel/event-sourcing
 
 * [Symfony](https://github.com/patchlevel/event-sourcing-bundle)
 * [Psalm](https://github.com/patchlevel/event-sourcing-psalm-plugin)
+
+## Supported databases
+
+We officially only support the databases and versions listed in the table, as these are tested in the CI.
+Since the package is based on doctrine dbal, other databases such as OracleDB and MSSQL may also work.
+But we can only really support the databases if we can also automatically ensure that they don't break due to changes.
+
+| Database    | Version                         |
+|-------------|---------------------------------|
+| PostgresSQL | 10.22, 11.17, 12.12, 13.8, 14.5 |
+| MariaDB     | 10.3, 10.6, 10.9                |
+| MySQL       | 5.7, 8.0                        |
+| SQLite      | 3.x                             |


### PR DESCRIPTION
I adjusted the CI and the readme with the database versions we support.
The versions I took from wikipedia and only those that are not EOL.

* https://en.wikipedia.org/wiki/PostgreSQL#Release_history
* https://en.wikipedia.org/wiki/MariaDB#Versioning
* https://en.wikipedia.org/wiki/MySQL#Release_history