### PR TITLE
Only build docs on changes for branches

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9]+.x"
+    paths:
+      - docs
   release:
     types:
       - published


### PR DESCRIPTION
We dont need to recreate the current doc page if there are no changes made. For publishing releases we still generate the docs even if we did not change something in the docs, which is highly unlikely but still considered.

Would also make this patch for the bundle if this here is merged.