### PR TITLE
Revert "Only build docs on changes for branches"

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "[0-9]+.[0-9]+.x"
-    paths:
-      - docs
   release:
     types:
       - published


### PR DESCRIPTION
Reverts patchlevel/event-sourcing#315

Due to the changes, the docs are no longer built at all. Therefore, this change must be reversed and another solution must be found.