### PR TITLE
Solve issue with adding events to bus

### DIFF
--- a/src/EventBus/DefaultEventBus.php
+++ b/src/EventBus/DefaultEventBus.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\EventBus;
 
+use function array_merge;
 use function array_shift;
 
 final class DefaultEventBus implements EventBus
@@ -27,7 +28,7 @@ final class DefaultEventBus implements EventBus
 
     public function dispatch(Message ...$messages): void
     {
-        $this->queue += $messages;
+        $this->queue = array_merge($this->queue, $messages);
 
         if ($this->processing) {
             return;


### PR DESCRIPTION
This will fix an issue that happens if during an event listener another event might end up in the queue. This is because `array += array` does behave in another way than what might be expected.

Simple reproduction using php: https://3v4l.org/bGcG3#v8.1.11 Here `array_merge` would be the correct way.