### PR TITLE
remove from option so that the library handles the base branch

### DIFF
--- a/.github/workflows/backward-compatibility-check.yml
+++ b/.github/workflows/backward-compatibility-check.yml
@@ -44,4 +44,4 @@ jobs:
           working-directory: 'tools'
 
       - name: "Check for BC breaks"
-        run: "tools/vendor/bin/roave-backward-compatibility-check --format=github-actions --install-development-dependencies --from=origin/${{ github.base_ref }}"
+        run: "tools/vendor/bin/roave-backward-compatibility-check --format=github-actions --install-development-dependencies"


### PR DESCRIPTION
As long as we use semver branches and tags this should work. See https://github.com/Roave/BackwardCompatibilityCheck#usage