### PR TITLE
add subscriber feature for event bus

### DIFF
--- a/docs/pages/event_bus.md
+++ b/docs/pages/event_bus.md
@@ -144,7 +144,7 @@ This listener is then called for all saved events / messages.
 use Patchlevel\EventSourcing\EventBus\Listener;
 use Patchlevel\EventSourcing\EventBus\Message;
 
-$listener = new class implements Listener 
+final class WelcomeListener implements Listener 
 {
     public function __invoke(Message $message): void
     {
@@ -170,7 +170,7 @@ use Patchlevel\EventSourcing\Attribute\Handle;
 use Patchlevel\EventSourcing\EventBus\Listener;
 use Patchlevel\EventSourcing\EventBus\Message;
 
-$listener = new class extends Subscriber 
+final class WelcomeSubscriber extends Subscriber 
 {
     #[Handle(ProfileCreated::class)]
     public function onProfileCreated(Message $message): void

--- a/docs/pages/event_bus.md
+++ b/docs/pages/event_bus.md
@@ -71,7 +71,7 @@ $message->customHeaders(); // ['application-id' => 'app']
 
 ### Default event bus
 
-The library also delivers a light-weight event bus. This can only register listener and dispatch events.
+The library also delivers a light-weight event bus. This can only register listener/subscriber and dispatch events.
 
 ```php
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
@@ -157,9 +157,25 @@ $listener = new class implements Listener
 
 !!! warning
 
-    If you only want to listen to certain messages, then you have to check it in the `__invoke` method.
+    If you only want to listen to certain messages, 
+    then you have to check it in the `__invoke` method or use the subscriber.
 
-!!! note
+## Subscriber
 
-    Basically, listeners can be categorized according to their tasks. 
-    We have a [processor](./processor.md) and [projections](./projection.md).
+A `Subscriber` is a listener, except that it has implemented the invoke method itself. 
+Instead, you can define your own and multiple methods and listen for specific events with the attribute `Handle`.
+
+```php
+use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\EventBus\Listener;
+use Patchlevel\EventSourcing\EventBus\Message;
+
+$listener = new class extends Subscriber 
+{
+    #[Handle(ProfileCreated::class)]
+    public function onProfileCreated(Message $message): void
+    {
+        echo 'Welcome!';
+    }
+}
+```

--- a/docs/pages/event_bus.md
+++ b/docs/pages/event_bus.md
@@ -71,7 +71,7 @@ $message->customHeaders(); // ['application-id' => 'app']
 
 ### Default event bus
 
-The library also delivers a light-weight event bus. This can only register listener/subscriber and dispatch events.
+The library also delivers a light-weight event bus for which you can register listeners/subscribers and dispatch events.
 
 ```php
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;

--- a/docs/pages/processor.md
+++ b/docs/pages/processor.md
@@ -3,17 +3,19 @@
 The `processor` is a kind of [event bus](./event_bus.md) listener that can execute actions on certain events.
 A process can be for example used to send an email when a profile has been created:
 
+## Listener
+
+Here is an example with a listener.
+
 ```php
 use Patchlevel\EventSourcing\EventBus\Listener;
 use Patchlevel\EventSourcing\EventBus\Message;
 
-final class SendEmailListener implements Listener
+final class SendEmailProcessor implements Listener
 {
-    private Mailer $mailer;
-
-    private function __construct(Mailer $mailer) 
-    {
-        $this->mailer = $mailer;
+    public function __construct(
+        private readonly Mailer $mailer
+    ) {
     }
 
     public function __invoke(Message $message): void
@@ -25,7 +27,7 @@ final class SendEmailListener implements Listener
         }
 
         $this->mailer->send(
-            $event->email(),
+            $event->email,
             'Profile created',
             '...'
         );
@@ -35,4 +37,42 @@ final class SendEmailListener implements Listener
 
 !!! warning
 
-    If you only want to listen to certain events, then you have to check it in the `__invoke` method.
+    If you only want to listen to certain events, 
+    then you have to check it in the `__invoke` method or use the subscriber.
+
+!!! tip
+
+    You can find out more about the event bus [here](event_bus.md).
+
+
+## Subscriber
+
+You can also create the whole thing as a subscriber too.
+
+```php
+use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\EventBus\Message;
+use Patchlevel\EventSourcing\EventBus\Subscriber;
+
+final class SendEmailProcessor extends Subscriber
+{
+    public function __construct(
+        private readonly Mailer $mailer
+    ) {
+    }
+
+    #[Handle(ProfileCreated::class)]
+    public function onProfileCreated(Message $message): void
+    {
+        $this->mailer->send(
+            $message->event()->email,
+            'Profile created',
+            '...'
+        );
+    }
+}
+```
+
+!!! tip
+
+    You can find out more about the event bus [here](event_bus.md).

--- a/src/EventBus/DuplicateHandleMethod.php
+++ b/src/EventBus/DuplicateHandleMethod.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\EventBus;
+
+use function sprintf;
+
+final class DuplicateHandleMethod extends EventBusException
+{
+    /**
+     * @param class-string<Subscriber> $subscriber
+     * @param class-string             $event
+     */
+    public function __construct(string $subscriber, string $event, string $fistMethod, string $secondMethod)
+    {
+        parent::__construct(
+            sprintf(
+                'Two methods "%s" and "%s" on the subscriber "%s" want to handle the same event "%s". Only one method can handle an event.',
+                $fistMethod,
+                $secondMethod,
+                $subscriber,
+                $event
+            )
+        );
+    }
+}

--- a/src/EventBus/Subscriber.php
+++ b/src/EventBus/Subscriber.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\EventBus;
+
+use Patchlevel\EventSourcing\Attribute\Handle;
+use ReflectionClass;
+
+use function array_key_exists;
+
+abstract class Subscriber implements Listener
+{
+    /** @var array<class-string, string>|null */
+    private ?array $handleMethods = null;
+
+    final public function __invoke(Message $message): void
+    {
+        if ($this->handleMethods === null) {
+            $this->init();
+        }
+
+        $method = $this->handleMethods[$message->event()::class] ?? null;
+
+        if (!$method) {
+            return;
+        }
+
+        $this->$method($message);
+    }
+
+    private function init(): void
+    {
+        $reflection = new ReflectionClass(static::class);
+        $methods = $reflection->getMethods();
+
+        $this->handleMethods = [];
+
+        foreach ($methods as $method) {
+            $attributes = $method->getAttributes(Handle::class);
+
+            foreach ($attributes as $attribute) {
+                $instance = $attribute->newInstance();
+                $eventClass = $instance->eventClass();
+
+                if (array_key_exists($eventClass, $this->handleMethods)) {
+                    throw new DuplicateHandleMethod(
+                        static::class,
+                        $eventClass,
+                        $this->handleMethods[$eventClass],
+                        $method->getName()
+                    );
+                }
+
+                $this->handleMethods[$eventClass] = $method->getName();
+            }
+        }
+    }
+}

--- a/tests/Benchmark/BasicImplementation/Processor/SendEmailProcessor.php
+++ b/tests/Benchmark/BasicImplementation/Processor/SendEmailProcessor.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Processor;
 
-use Patchlevel\EventSourcing\EventBus\Listener;
+use Patchlevel\EventSourcing\Attribute\Handle;
 use Patchlevel\EventSourcing\EventBus\Message;
+use Patchlevel\EventSourcing\EventBus\Subscriber;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\SendEmailMock;
 
-final class SendEmailProcessor implements Listener
+final class SendEmailProcessor extends Subscriber
 {
-    public function __invoke(Message $message): void
+    #[Handle(ProfileCreated::class)]
+    public function onProfileCreated(Message $message): void
     {
-        if (!$message->event() instanceof ProfileCreated) {
-            return;
-        }
-
         SendEmailMock::send();
     }
 }

--- a/tests/Integration/BasicImplementation/Processor/SendEmailProcessor.php
+++ b/tests/Integration/BasicImplementation/Processor/SendEmailProcessor.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Processor;
 
-use Patchlevel\EventSourcing\EventBus\Listener;
+use Patchlevel\EventSourcing\Attribute\Handle;
 use Patchlevel\EventSourcing\EventBus\Message;
+use Patchlevel\EventSourcing\EventBus\Subscriber;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\SendEmailMock;
 
-final class SendEmailProcessor implements Listener
+final class SendEmailProcessor extends Subscriber
 {
-    public function __invoke(Message $message): void
+    #[Handle(ProfileCreated::class)]
+    public function onProfileCreated(Message $message): void
     {
-        if (!$message->event() instanceof ProfileCreated) {
-            return;
-        }
-
         SendEmailMock::send();
     }
 }

--- a/tests/Unit/EventBus/SubscriberTest.php
+++ b/tests/Unit/EventBus/SubscriberTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\EventBus;
+
+use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
+use Patchlevel\EventSourcing\EventBus\DuplicateHandleMethod;
+use Patchlevel\EventSourcing\EventBus\Message;
+use Patchlevel\EventSourcing\EventBus\Subscriber;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use PHPUnit\Framework\TestCase;
+
+/** @covers \Patchlevel\EventSourcing\EventBus\Subscriber */
+final class SubscriberTest extends TestCase
+{
+    public function testSubscribeEvent(): void
+    {
+        $subscriber = new class extends Subscriber {
+            public ?Message $message = null;
+
+            #[Handle(ProfileCreated::class)]
+            public function handle(Message $message): void
+            {
+                $this->message = $message;
+            }
+        };
+
+        $message = new Message(
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('info@patchlevel.de')
+            )
+        );
+
+        $eventBus = new DefaultEventBus([$subscriber]);
+        $eventBus->dispatch($message);
+
+        self::assertSame($message, $subscriber->message);
+    }
+
+    public function testSubscribeWrongEvent(): void
+    {
+        $subscriber = new class extends Subscriber {
+            public ?Message $message = null;
+
+            #[Handle(ProfileVisited::class)]
+            public function handle(Message $message): void
+            {
+                $this->message = $message;
+            }
+        };
+
+        $message = new Message(
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('info@patchlevel.de')
+            )
+        );
+
+        $eventBus = new DefaultEventBus([$subscriber]);
+        $eventBus->dispatch($message);
+
+        self::assertNull($subscriber->message);
+    }
+
+    public function testSubscribeMultipleEvents(): void
+    {
+        $subscriber = new class extends Subscriber {
+            public ?Message $a = null;
+            public ?Message $b = null;
+
+            #[Handle(ProfileCreated::class)]
+            public function handleA(Message $message): void
+            {
+                $this->a = $message;
+            }
+
+            #[Handle(ProfileVisited::class)]
+            public function handleB(Message $message): void
+            {
+                $this->b = $message;
+            }
+        };
+
+        $message1 = new Message(
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('info@patchlevel.de')
+            )
+        );
+
+        $message2 = new Message(
+            new ProfileVisited(
+                ProfileId::fromString('1')
+            )
+        );
+
+        $eventBus = new DefaultEventBus([$subscriber]);
+        $eventBus->dispatch($message1, $message2);
+
+        self::assertSame($message1, $subscriber->a);
+        self::assertSame($message2, $subscriber->b);
+    }
+
+    public function testSubscribeMultipleEventsOnSameMethod(): void
+    {
+        $subscriber = new class extends Subscriber {
+            /** @var list<Message> */
+            public array $messages = [];
+
+            #[Handle(ProfileCreated::class)]
+            #[Handle(ProfileVisited::class)]
+            public function handle(Message $message): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+
+        $message1 = new Message(
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('info@patchlevel.de')
+            )
+        );
+
+        $message2 = new Message(
+            new ProfileVisited(
+                ProfileId::fromString('1')
+            )
+        );
+
+        $eventBus = new DefaultEventBus([$subscriber]);
+        $eventBus->dispatch($message1, $message2);
+
+        self::assertCount(2, $subscriber->messages);
+        self::assertSame($message1, $subscriber->messages[0]);
+        self::assertSame($message2, $subscriber->messages[1]);
+    }
+
+    public function testDuplicatedEvents(): void
+    {
+        $this->expectException(DuplicateHandleMethod::class);
+
+        $subscriber = new class extends Subscriber {
+            #[Handle(ProfileCreated::class)]
+            public function handleA(Message $message): void
+            {
+            }
+
+            #[Handle(ProfileCreated::class)]
+            public function handleB(Message $message): void
+            {
+            }
+        };
+
+        $message = new Message(
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('info@patchlevel.de')
+            )
+        );
+
+        $eventBus = new DefaultEventBus();
+        $eventBus->addListener($subscriber);
+        $eventBus->dispatch($message);
+    }
+}


### PR DESCRIPTION
example:

```php
use Patchlevel\EventSourcing\Attribute\Handle;
use Patchlevel\EventSourcing\EventBus\Message;
use Patchlevel\EventSourcing\EventBus\Subscriber;

final class SendCheckInEmailProcessor extends Subscriber
{
    public function __construct(
        private readonly Mailer $mailer
    ) {
    }

    #[Handle(GuestIsCheckedIn::class)]
    public function onGuestIsCheckedIn(Message $message): void
    {
        $this->mailer->send(
            'hq@patchlevel.de',
            'Guest is checked in',
            sprintf('A new guest named "%s" is checked in', $message->event()->guestName)
        );
    }
}
```