### PR TITLE
Prevent saving of broken aggregates

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -73,6 +73,9 @@
     <MixedOperand>
       <code>$playhead</code>
     </MixedOperand>
+    <PropertyTypeCoercion>
+      <code>new WeakMap()</code>
+    </PropertyTypeCoercion>
   </file>
   <file src="src/Serializer/Upcast/Upcast.php">
     <MixedAssignment>

--- a/src/Repository/AggregateDetached.php
+++ b/src/Repository/AggregateDetached.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Repository;
+
+use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
+
+use function sprintf;
+
+final class AggregateDetached extends RepositoryException
+{
+    /** @param class-string<AggregateRoot> $aggregateClass */
+    public function __construct(string $aggregateClass, string $aggregateId)
+    {
+        parent::__construct(
+            sprintf(
+                'Aggregate %s with the id "%s" was not loaded from this repository. you have to load the aggregate again.',
+                $aggregateClass,
+                $aggregateId,
+            ),
+        );
+    }
+}

--- a/src/Repository/AggregateUnknown.php
+++ b/src/Repository/AggregateUnknown.php
@@ -8,14 +8,14 @@ use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
 
 use function sprintf;
 
-final class AggregateDetached extends RepositoryException
+final class AggregateUnknown extends RepositoryException
 {
     /** @param class-string<AggregateRoot> $aggregateClass */
     public function __construct(string $aggregateClass, string $aggregateId)
     {
         parent::__construct(
             sprintf(
-                'An error occurred while saving the aggregate "%s" with the ID "%s", causing the uncommitted events to be lost. Please reload the aggregate.',
+                'The aggregate %s with the ID "%s" was not loaded from this repository. Please reload the aggregate.',
                 $aggregateClass,
                 $aggregateId,
             ),

--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -22,6 +22,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
 use Traversable;
+use WeakMap;
 
 use function array_map;
 use function assert;
@@ -37,6 +38,9 @@ final class DefaultRepository implements Repository
     private Clock $clock;
     private LoggerInterface $logger;
 
+    /** @var WeakMap<T, bool> */
+    private WeakMap $managed;
+
     /** @param AggregateRootMetadata<T> $metadata */
     public function __construct(
         private Store $store,
@@ -49,6 +53,7 @@ final class DefaultRepository implements Repository
     ) {
         $this->clock = $clock ?? new SystemClock();
         $this->logger = $logger ?? new NullLogger();
+        $this->managed = new WeakMap();
     }
 
     /** @return T */
@@ -101,6 +106,8 @@ final class DefaultRepository implements Repository
             $this->saveSnapshot($aggregate, $stream);
         }
 
+        $this->managed[$aggregate] = true;
+
         return $aggregate;
     }
 
@@ -119,49 +126,61 @@ final class DefaultRepository implements Repository
     {
         $this->assertRightAggregate($aggregate);
 
-        $events = $aggregate->releaseEvents();
-        $eventCount = count($events);
+        try {
+            $events = $aggregate->releaseEvents();
+            $eventCount = count($events);
 
-        if ($eventCount === 0) {
-            return;
-        }
+            $playhead = $aggregate->playhead() - $eventCount;
 
-        $playhead = $aggregate->playhead() - $eventCount;
+            if (($this->managed[$aggregate] ?? false) === false && $playhead !== 0) {
+                throw new AggregateDetached($aggregate::class, $aggregate->aggregateRootId());
+            }
 
-        if ($playhead < 0) {
-            throw new PlayheadMismatch(
-                $aggregate::class,
-                $aggregate->aggregateRootId(),
-                $aggregate->playhead(),
-                $eventCount,
-            );
-        }
+            if ($eventCount === 0) {
+                return;
+            }
 
-        $messageDecorator = $this->messageDecorator;
-        $clock = $this->clock;
+            if ($playhead < 0) {
+                throw new PlayheadMismatch(
+                    $aggregate::class,
+                    $aggregate->aggregateRootId(),
+                    $aggregate->playhead(),
+                    $eventCount,
+                );
+            }
 
-        $messages = array_map(
-            static function (object $event) use ($aggregate, &$playhead, $messageDecorator, $clock): Message {
-                $message = Message::create($event)
-                    ->withAggregateClass($aggregate::class)
-                    ->withAggregateId($aggregate->aggregateRootId())
-                    ->withPlayhead(++$playhead)
-                    ->withRecordedOn($clock->now());
+            $messageDecorator = $this->messageDecorator;
+            $clock = $this->clock;
 
-                if (!$messageDecorator instanceof MessageDecorator) {
+            $messages = array_map(
+                static function (object $event) use ($aggregate, &$playhead, $messageDecorator, $clock) {
+                    $message = Message::create($event)
+                        ->withAggregateClass($aggregate::class)
+                        ->withAggregateId($aggregate->aggregateRootId())
+                        ->withPlayhead(++$playhead)
+                        ->withRecordedOn($clock->now());
+
+                    if ($messageDecorator) {
+                        return $messageDecorator($message);
+                    }
+
                     return $message;
-                }
+                },
+                $events,
+            );
 
-                return $messageDecorator($message);
-            },
-            $events,
-        );
+            $this->store->transactional(function () use ($messages): void {
+                $this->store->save(...$messages);
+                $this->archive(...$messages);
+                $this->eventBus->dispatch(...$messages);
+            });
 
-        $this->store->transactional(function () use ($messages): void {
-            $this->store->save(...$messages);
-            $this->archive(...$messages);
-            $this->eventBus->dispatch(...$messages);
-        });
+            $this->managed[$aggregate] = true;
+        } catch (Throwable $exception) {
+            $this->managed[$aggregate] = false;
+
+            throw $exception;
+        }
     }
 
     /**
@@ -184,6 +203,8 @@ final class DefaultRepository implements Repository
         $stream = $this->store->load($criteria);
 
         if ($stream->current() === null) {
+            $this->managed[$aggregate] = true;
+
             return $aggregate;
         }
 
@@ -194,6 +215,8 @@ final class DefaultRepository implements Repository
         }
 
         $this->saveSnapshot($aggregate, $stream);
+
+        $this->managed[$aggregate] = true;
 
         return $aggregate;
     }

--- a/tests/Unit/Repository/DefaultRepositoryTest.php
+++ b/tests/Unit/Repository/DefaultRepositoryTest.php
@@ -11,6 +11,7 @@ use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
 use Patchlevel\EventSourcing\Repository\AggregateDetached;
 use Patchlevel\EventSourcing\Repository\AggregateNotFound;
+use Patchlevel\EventSourcing\Repository\AggregateUnknown;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\WrongAggregate;
 use Patchlevel\EventSourcing\Snapshot\SnapshotNotFound;
@@ -336,7 +337,7 @@ final class DefaultRepositoryTest extends TestCase
         $repository->save($aggregate);
     }
 
-    public function testDetachedExceptionByError(): void
+    public function testDetachedException(): void
     {
         $store = $this->prophesize(Store::class);
         $store->save(
@@ -373,9 +374,9 @@ final class DefaultRepositoryTest extends TestCase
         $repository->save($aggregate);
     }
 
-    public function testDetachedExceptionByUnknown(): void
+    public function testUnknownException(): void
     {
-        $this->expectException(AggregateDetached::class);
+        $this->expectException(AggregateUnknown::class);
 
         $store = $this->prophesize(Store::class);
         $store->save(
@@ -395,7 +396,10 @@ final class DefaultRepositoryTest extends TestCase
             ProfileId::fromString('1'),
             Email::fromString('hallo@patchlevel.de'),
         );
+
         $aggregate->releaseEvents();
+
+        $aggregate->visitProfile(ProfileId::fromString('2'));
 
         $repository->save($aggregate);
     }


### PR DESCRIPTION
fix #313

I found another option.

We remember all aggregates loaded from the repository. As soon as an error occurs when saving, the aggregate is marked as faulty. This aggregate can then no longer be saved because the events have disappeared and the aggregate must be reloaded. Happens eg. if the aggregate was changed at the same time from another process.

Thus, each aggregate must be saved from the same repository from which it was loaded. The RepositoryFactory already ensures that you always get the same repository. But otherwise there shouldn't really be a case where you have two different repositories. Possibly if you have tried to cache/serialize aggregates yourself. Which we also prevent now.

With new aggregates, the playhead is offset against the number of events. If it gets there exactly, then these aggregates may also be stored.

This change prevents you from somehow storing invalid aggregates and thus never corrupting the data.