### PR TITLE
prerelease are not the latest doc version, exclude them

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@v0.7.0
         with:
           repository: ${{ github.repository }}
-          excludes: draft
+          excludes: draft,prerelease
 
       - name: Normalize current versions
         id: current


### PR DESCRIPTION
fix #438