### PR TITLE
rename handle to subscribe

### DIFF
--- a/docs/pages/event_bus.md
+++ b/docs/pages/event_bus.md
@@ -163,16 +163,16 @@ final class WelcomeListener implements Listener
 ## Subscriber
 
 A `Subscriber` is a listener, except that it has implemented the invoke method itself. 
-Instead, you can define your own and multiple methods and listen for specific events with the attribute `Handle`.
+Instead, you can define your own and multiple methods and listen for specific events with the attribute `Subscribe`.
 
 ```php
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Listener;
 use Patchlevel\EventSourcing\EventBus\Message;
 
 final class WelcomeSubscriber extends Subscriber 
 {
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function onProfileCreated(Message $message): void
     {
         echo 'Welcome!';

--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -156,7 +156,7 @@ Each projector is then responsible for a specific projection and version.
 use Doctrine\DBAL\Connection;
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -181,7 +181,7 @@ final class HotelProjection implements Projector
         return $this->db->fetchAllAssociative('SELECT id, name, guests FROM hotel;')
     }
 
-    #[Handle(HotelCreated::class)]
+    #[Subscribe(HotelCreated::class)]
     public function handleHotelCreated(Message $message): void
     {
         $event = $message->event();
@@ -196,7 +196,7 @@ final class HotelProjection implements Projector
         );
     }
     
-    #[Handle(GuestIsCheckedIn::class)]
+    #[Subscribe(GuestIsCheckedIn::class)]
     public function handleGuestIsCheckedIn(Message $message): void
     {
         $this->db->executeStatement(
@@ -205,7 +205,7 @@ final class HotelProjection implements Projector
         );
     }
     
-    #[Handle(GuestIsCheckedOut::class)]
+    #[Subscribe(GuestIsCheckedOut::class)]
     public function handleGuestIsCheckedOut(Message $message): void
     {
         $this->db->executeStatement(
@@ -237,7 +237,7 @@ final class HotelProjection implements Projector
 In our example we also want to send an email to the head office as soon as a guest is checked in.
 
 ```php
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\EventBus\Subscriber;
 
@@ -248,7 +248,7 @@ final class SendCheckInEmailProcessor extends Subscriber
     ) {
     }
 
-    #[Handle(GuestIsCheckedIn::class)]
+    #[Subscribe(GuestIsCheckedIn::class)]
     public function onGuestIsCheckedIn(Message $message): void
     {
         $this->mailer->send(

--- a/docs/pages/processor.md
+++ b/docs/pages/processor.md
@@ -50,7 +50,7 @@ final class SendEmailProcessor implements Listener
 You can also create the whole thing as a subscriber too.
 
 ```php
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\EventBus\Subscriber;
 
@@ -61,7 +61,7 @@ final class SendEmailProcessor extends Subscriber
     ) {
     }
 
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function onProfileCreated(Message $message): void
     {
         $this->mailer->send(

--- a/docs/pages/projection.md
+++ b/docs/pages/projection.md
@@ -17,7 +17,7 @@ In this example we always create a new data set in a relational database when a 
 use Doctrine\DBAL\Connection;
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -63,7 +63,7 @@ final class ProfileProjection implements Projector
         );
     }
 
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function handleProfileCreated(Message $message): void
     {
         $profileCreated = $message->event();
@@ -97,8 +97,8 @@ Projectors can have one `create` and `drop` method that is executed when the pro
 In some cases it may be that no schema has to be created for the projection, as the target does it automatically.
 To do this, you must add either the `Create` or `Drop` attribute to the method. The method name itself doesn't matter.
 
-Otherwise, a projector can have any number of handle methods that are called for certain defined events.
-In order to say which method is responsible for which event, you need the `Handle` attribute.
+Otherwise, a projector can subscribe any number of events.
+In order to say which method is responsible for which event, you need the `Subscribe` attribute.
 As the first parameter, you must pass the event class to which the reaction should then take place.
 The method itself must expect a `Message`, which then contains the event. The method name itself doesn't matter.
 

--- a/src/Attribute/Subscribe.php
+++ b/src/Attribute/Subscribe.php
@@ -7,7 +7,7 @@ namespace Patchlevel\EventSourcing\Attribute;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
-final class Handle
+final class Subscribe
 {
     /** @param class-string $eventClass */
     public function __construct(

--- a/src/EventBus/DuplicateSubscribeMethod.php
+++ b/src/EventBus/DuplicateSubscribeMethod.php
@@ -6,7 +6,7 @@ namespace Patchlevel\EventSourcing\EventBus;
 
 use function sprintf;
 
-final class DuplicateHandleMethod extends EventBusException
+final class DuplicateSubscribeMethod extends EventBusException
 {
     /**
      * @param class-string<Subscriber> $subscriber
@@ -16,7 +16,7 @@ final class DuplicateHandleMethod extends EventBusException
     {
         parent::__construct(
             sprintf(
-                'Two methods "%s" and "%s" on the subscriber "%s" want to handle the same event "%s". Only one method can handle an event.',
+                'Two methods "%s" and "%s" on the subscriber "%s" want to subscribe the same event "%s". Only one method can subscribe an event.',
                 $fistMethod,
                 $secondMethod,
                 $subscriber,

--- a/src/EventBus/Subscriber.php
+++ b/src/EventBus/Subscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\EventBus;
 
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use ReflectionClass;
 
 use function array_key_exists;
@@ -12,15 +12,15 @@ use function array_key_exists;
 abstract class Subscriber implements Listener
 {
     /** @var array<class-string, string>|null */
-    private array|null $handleMethods = null;
+    private array|null $subscribeMethods = null;
 
     final public function __invoke(Message $message): void
     {
-        if ($this->handleMethods === null) {
+        if ($this->subscribeMethods === null) {
             $this->init();
         }
 
-        $method = $this->handleMethods[$message->event()::class] ?? null;
+        $method = $this->subscribeMethods[$message->event()::class] ?? null;
 
         if (!$method) {
             return;
@@ -34,25 +34,25 @@ abstract class Subscriber implements Listener
         $reflection = new ReflectionClass(static::class);
         $methods = $reflection->getMethods();
 
-        $this->handleMethods = [];
+        $this->subscribeMethods = [];
 
         foreach ($methods as $method) {
-            $attributes = $method->getAttributes(Handle::class);
+            $attributes = $method->getAttributes(Subscribe::class);
 
             foreach ($attributes as $attribute) {
                 $instance = $attribute->newInstance();
                 $eventClass = $instance->eventClass();
 
-                if (array_key_exists($eventClass, $this->handleMethods)) {
-                    throw new DuplicateHandleMethod(
+                if (array_key_exists($eventClass, $this->subscribeMethods)) {
+                    throw new DuplicateSubscribeMethod(
                         static::class,
                         $eventClass,
-                        $this->handleMethods[$eventClass],
+                        $this->subscribeMethods[$eventClass],
                         $method->getName(),
                     );
                 }
 
-                $this->handleMethods[$eventClass] = $method->getName();
+                $this->subscribeMethods[$eventClass] = $method->getName();
             }
         }
     }

--- a/src/Metadata/Projector/AttributeProjectorMetadataFactory.php
+++ b/src/Metadata/Projector/AttributeProjectorMetadataFactory.php
@@ -6,7 +6,7 @@ namespace Patchlevel\EventSourcing\Metadata\Projector;
 
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
 use ReflectionClass;
 
@@ -28,27 +28,27 @@ final class AttributeProjectorMetadataFactory implements ProjectorMetadataFactor
 
         $methods = $reflector->getMethods();
 
-        $handleMethods = [];
+        $subscribeMethods = [];
         $createMethod = null;
         $dropMethod = null;
 
         foreach ($methods as $method) {
-            $attributes = $method->getAttributes(Handle::class);
+            $attributes = $method->getAttributes(Subscribe::class);
 
             foreach ($attributes as $attribute) {
                 $instance = $attribute->newInstance();
                 $eventClass = $instance->eventClass();
 
-                if (array_key_exists($eventClass, $handleMethods)) {
-                    throw new DuplicateHandleMethod(
+                if (array_key_exists($eventClass, $subscribeMethods)) {
+                    throw new DuplicateSubscribeMethod(
                         $projector,
                         $eventClass,
-                        $handleMethods[$eventClass],
+                        $subscribeMethods[$eventClass],
                         $method->getName(),
                     );
                 }
 
-                $handleMethods[$eventClass] = $method->getName();
+                $subscribeMethods[$eventClass] = $method->getName();
             }
 
             if ($method->getAttributes(Create::class)) {
@@ -79,7 +79,7 @@ final class AttributeProjectorMetadataFactory implements ProjectorMetadataFactor
         }
 
         $metadata = new ProjectorMetadata(
-            $handleMethods,
+            $subscribeMethods,
             $createMethod,
             $dropMethod,
         );

--- a/src/Metadata/Projector/DuplicateSubscribeMethod.php
+++ b/src/Metadata/Projector/DuplicateSubscribeMethod.php
@@ -9,7 +9,7 @@ use Patchlevel\EventSourcing\Projection\Projector\Projector;
 
 use function sprintf;
 
-final class DuplicateHandleMethod extends MetadataException
+final class DuplicateSubscribeMethod extends MetadataException
 {
     /**
      * @param class-string<Projector> $projector
@@ -19,7 +19,7 @@ final class DuplicateHandleMethod extends MetadataException
     {
         parent::__construct(
             sprintf(
-                'Two methods "%s" and "%s" on the projection "%s" want to handle the same event "%s". Only one method can handle an event.',
+                'Two methods "%s" and "%s" on the projection "%s" want to subscribe the same event "%s". Only one method can subscribe an event.',
                 $fistMethod,
                 $secondMethod,
                 $projector,

--- a/src/Metadata/Projector/ProjectorMetadata.php
+++ b/src/Metadata/Projector/ProjectorMetadata.php
@@ -8,7 +8,7 @@ final class ProjectorMetadata
 {
     public function __construct(
         /** @var array<class-string, string> */
-        public readonly array $handleMethods = [],
+        public readonly array $subscribeMethods = [],
         public readonly string|null $createMethod = null,
         public readonly string|null $dropMethod = null,
     ) {

--- a/src/Projection/Projectionist/DefaultProjectionist.php
+++ b/src/Projection/Projectionist/DefaultProjectionist.php
@@ -376,11 +376,11 @@ final class DefaultProjectionist implements Projectionist
             throw ProjectorNotFound::forProjectionId($projection->id());
         }
 
-        $handleMethod = $this->projectorResolver->resolveHandleMethod($projector, $message);
+        $subscribeMethod = $this->projectorResolver->resolveSubscribeMethod($projector, $message);
 
-        if ($handleMethod) {
+        if ($subscribeMethod) {
             try {
-                $handleMethod($message);
+                $subscribeMethod($message);
 
                 $this->logger?->debug(
                     sprintf(

--- a/src/Projection/Projector/MetadataProjectorResolver.php
+++ b/src/Projection/Projector/MetadataProjectorResolver.php
@@ -42,17 +42,17 @@ final class MetadataProjectorResolver implements ProjectorResolver
         return $projector->$method(...);
     }
 
-    public function resolveHandleMethod(Projector $projector, Message $message): Closure|null
+    public function resolveSubscribeMethod(Projector $projector, Message $message): Closure|null
     {
         $event = $message->event();
         $metadata = $this->metadataFactory->metadata($projector::class);
 
-        if (!array_key_exists($event::class, $metadata->handleMethods)) {
+        if (!array_key_exists($event::class, $metadata->subscribeMethods)) {
             return null;
         }
 
-        $handleMethod = $metadata->handleMethods[$event::class];
+        $subscribeMethod = $metadata->subscribeMethods[$event::class];
 
-        return $projector->$handleMethod(...);
+        return $projector->$subscribeMethod(...);
     }
 }

--- a/src/Projection/Projector/ProjectorHelper.php
+++ b/src/Projection/Projector/ProjectorHelper.php
@@ -16,13 +16,13 @@ final class ProjectorHelper
     public function handleMessage(Message $message, Projector ...$projectors): void
     {
         foreach ($projectors as $projector) {
-            $handleMethod = $this->projectorResolver->resolveHandleMethod($projector, $message);
+            $subscribeMethod = $this->projectorResolver->resolveSubscribeMethod($projector, $message);
 
-            if (!$handleMethod) {
+            if (!$subscribeMethod) {
                 continue;
             }
 
-            $handleMethod($message);
+            $subscribeMethod($message);
         }
     }
 

--- a/src/Projection/Projector/ProjectorResolver.php
+++ b/src/Projection/Projector/ProjectorResolver.php
@@ -13,5 +13,5 @@ interface ProjectorResolver
 
     public function resolveDropMethod(Projector $projector): Closure|null;
 
-    public function resolveHandleMethod(Projector $projector, Message $message): Closure|null;
+    public function resolveSubscribeMethod(Projector $projector, Message $message): Closure|null;
 }

--- a/tests/Benchmark/BasicImplementation/Processor/SendEmailProcessor.php
+++ b/tests/Benchmark/BasicImplementation/Processor/SendEmailProcessor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Processor;
 
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\EventBus\Subscriber;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\ProfileCreated;
@@ -12,7 +12,7 @@ use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\SendEmailMock
 
 final class SendEmailProcessor extends Subscriber
 {
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function onProfileCreated(Message $message): void
     {
         SendEmailMock::send();

--- a/tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
+++ b/tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
@@ -7,7 +7,7 @@ namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Projectio
 use Doctrine\DBAL\Connection;
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -39,7 +39,7 @@ final class ProfileProjector implements Projector
         $this->connection->executeStatement('DROP TABLE IF EXISTS projection_profile;');
     }
 
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function handleProfileCreated(Message $message): void
     {
         $profileCreated = $message->event();

--- a/tests/Integration/BankAccountSplitStream/Projection/BankAccountProjection.php
+++ b/tests/Integration/BankAccountSplitStream/Projection/BankAccountProjection.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Table;
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -45,7 +45,7 @@ final class BankAccountProjection implements Projector
         $this->connection->createSchemaManager()->dropTable('projection_bank_account');
     }
 
-    #[Handle(BankAccountCreated::class)]
+    #[Subscribe(BankAccountCreated::class)]
     public function handleBankAccountCreated(Message $message): void
     {
         $event = $message->event();
@@ -59,7 +59,7 @@ final class BankAccountProjection implements Projector
         );
     }
 
-    #[Handle(BalanceAdded::class)]
+    #[Subscribe(BalanceAdded::class)]
     public function handleBalanceAdded(Message $message): void
     {
         $event = $message->event();

--- a/tests/Integration/BasicImplementation/Processor/SendEmailProcessor.php
+++ b/tests/Integration/BasicImplementation/Processor/SendEmailProcessor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Processor;
 
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\EventBus\Subscriber;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\ProfileCreated;
@@ -12,7 +12,7 @@ use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\SendEmailMock
 
 final class SendEmailProcessor extends Subscriber
 {
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function onProfileCreated(Message $message): void
     {
         SendEmailMock::send();

--- a/tests/Integration/BasicImplementation/Projection/ProfileProjection.php
+++ b/tests/Integration/BasicImplementation/Projection/ProfileProjection.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Table;
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -45,7 +45,7 @@ final class ProfileProjection implements Projector
         $this->connection->createSchemaManager()->dropTable('projection_profile');
     }
 
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function handleProfileCreated(Message $message): void
     {
         $profileCreated = $message->event();

--- a/tests/Integration/Outbox/Projection/ProfileProjection.php
+++ b/tests/Integration/Outbox/Projection/ProfileProjection.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Table;
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -43,7 +43,7 @@ final class ProfileProjection implements Projector
         $this->connection->createSchemaManager()->dropTable('projection_profile');
     }
 
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function handleProfileCreated(Message $message): void
     {
         $profileCreated = $message->event();

--- a/tests/Integration/Projectionist/Projection/ProfileProjection.php
+++ b/tests/Integration/Projectionist/Projection/ProfileProjection.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Table;
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -41,7 +41,7 @@ final class ProfileProjection implements Projector
         $this->connection->createSchemaManager()->dropTable($this->tableName());
     }
 
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function handleProfileCreated(Message $message): void
     {
         $profileCreated = $message->event();

--- a/tests/Unit/EventBus/SubscriberTest.php
+++ b/tests/Unit/EventBus/SubscriberTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\EventBus;
 
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
-use Patchlevel\EventSourcing\EventBus\DuplicateHandleMethod;
+use Patchlevel\EventSourcing\EventBus\DuplicateSubscribeMethod;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\EventBus\Subscriber;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
@@ -23,7 +23,7 @@ final class SubscriberTest extends TestCase
         $subscriber = new class extends Subscriber {
             public Message|null $message = null;
 
-            #[Handle(ProfileCreated::class)]
+            #[Subscribe(ProfileCreated::class)]
             public function handle(Message $message): void
             {
                 $this->message = $message;
@@ -48,7 +48,7 @@ final class SubscriberTest extends TestCase
         $subscriber = new class extends Subscriber {
             public Message|null $message = null;
 
-            #[Handle(ProfileVisited::class)]
+            #[Subscribe(ProfileVisited::class)]
             public function handle(Message $message): void
             {
                 $this->message = $message;
@@ -74,13 +74,13 @@ final class SubscriberTest extends TestCase
             public Message|null $a = null;
             public Message|null $b = null;
 
-            #[Handle(ProfileCreated::class)]
+            #[Subscribe(ProfileCreated::class)]
             public function handleA(Message $message): void
             {
                 $this->a = $message;
             }
 
-            #[Handle(ProfileVisited::class)]
+            #[Subscribe(ProfileVisited::class)]
             public function handleB(Message $message): void
             {
                 $this->b = $message;
@@ -113,8 +113,8 @@ final class SubscriberTest extends TestCase
             /** @var list<Message> */
             public array $messages = [];
 
-            #[Handle(ProfileCreated::class)]
-            #[Handle(ProfileVisited::class)]
+            #[Subscribe(ProfileCreated::class)]
+            #[Subscribe(ProfileVisited::class)]
             public function handle(Message $message): void
             {
                 $this->messages[] = $message;
@@ -144,15 +144,15 @@ final class SubscriberTest extends TestCase
 
     public function testDuplicatedEvents(): void
     {
-        $this->expectException(DuplicateHandleMethod::class);
+        $this->expectException(DuplicateSubscribeMethod::class);
 
         $subscriber = new class extends Subscriber {
-            #[Handle(ProfileCreated::class)]
+            #[Subscribe(ProfileCreated::class)]
             public function handleA(Message $message): void
             {
             }
 
-            #[Handle(ProfileCreated::class)]
+            #[Subscribe(ProfileCreated::class)]
             public function handleB(Message $message): void
             {
             }

--- a/tests/Unit/Fixture/Dummy2Projection.php
+++ b/tests/Unit/Fixture/Dummy2Projection.php
@@ -6,7 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
 
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message as EventMessage;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -22,7 +22,7 @@ final class Dummy2Projection implements Projector
         return new ProjectionId('dummy2', 1);
     }
 
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function handleProfileCreated(EventMessage $message): void
     {
         $this->handledMessage = $message;

--- a/tests/Unit/Fixture/DummyProjection.php
+++ b/tests/Unit/Fixture/DummyProjection.php
@@ -6,7 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
 
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message as EventMessage;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -22,7 +22,7 @@ final class DummyProjection implements Projector
         return new ProjectionId('dummy', 1);
     }
 
-    #[Handle(ProfileCreated::class)]
+    #[Subscribe(ProfileCreated::class)]
     public function handleProfileCreated(EventMessage $message): void
     {
         $this->handledMessage = $message;

--- a/tests/Unit/Metadata/Projector/AttributeProjectorMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Projector/AttributeProjectorMetadataFactoryTest.php
@@ -6,7 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Projector;
 
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Metadata\Projector\AttributeProjectorMetadataFactory;
 use Patchlevel\EventSourcing\Metadata\Projector\DuplicateCreateMethod;
 use Patchlevel\EventSourcing\Metadata\Projector\DuplicateDropMethod;
@@ -30,7 +30,7 @@ final class AttributeProjectorMetadataFactoryTest extends TestCase
         $metadataFactory = new AttributeProjectorMetadataFactory();
         $metadata = $metadataFactory->metadata($projection::class);
 
-        self::assertSame([], $metadata->handleMethods);
+        self::assertSame([], $metadata->subscribeMethods);
         self::assertNull($metadata->createMethod);
         self::assertNull($metadata->dropMethod);
     }
@@ -43,7 +43,7 @@ final class AttributeProjectorMetadataFactoryTest extends TestCase
                 return new ProjectionId('foo', 1);
             }
 
-            #[Handle(ProfileVisited::class)]
+            #[Subscribe(ProfileVisited::class)]
             public function handle(): void
             {
             }
@@ -64,7 +64,7 @@ final class AttributeProjectorMetadataFactoryTest extends TestCase
 
         self::assertEquals(
             [ProfileVisited::class => 'handle'],
-            $metadata->handleMethods,
+            $metadata->subscribeMethods,
         );
 
         self::assertSame('create', $metadata->createMethod);
@@ -79,8 +79,8 @@ final class AttributeProjectorMetadataFactoryTest extends TestCase
                 return new ProjectionId('foo', 1);
             }
 
-            #[Handle(ProfileVisited::class)]
-            #[Handle(ProfileCreated::class)]
+            #[Subscribe(ProfileVisited::class)]
+            #[Subscribe(ProfileCreated::class)]
             public function handle(): void
             {
             }
@@ -94,7 +94,7 @@ final class AttributeProjectorMetadataFactoryTest extends TestCase
                 ProfileVisited::class => 'handle',
                 ProfileCreated::class => 'handle',
             ],
-            $metadata->handleMethods,
+            $metadata->subscribeMethods,
         );
     }
 

--- a/tests/Unit/Projection/Projectionist/DefaultProjectionistTest.php
+++ b/tests/Unit/Projection/Projectionist/DefaultProjectionistTest.php
@@ -129,7 +129,7 @@ final class DefaultProjectionistTest extends TestCase
 
         $projectorResolver = $this->prophesize(ProjectorResolver::class);
         $projectorResolver->resolveCreateMethod($projector)->willReturn($projector->create(...));
-        $projectorResolver->resolveHandleMethod($projector, $message)->willReturn($projector->handle(...));
+        $projectorResolver->resolveSubscribeMethod($projector, $message)->willReturn($projector->handle(...));
 
         $projectionist = new DefaultProjectionist(
             $streamableStore->reveal(),
@@ -184,7 +184,7 @@ final class DefaultProjectionistTest extends TestCase
 
         $projectorResolver = $this->prophesize(ProjectorResolver::class);
         $projectorResolver->resolveCreateMethod($projector)->willReturn($projector->create(...));
-        $projectorResolver->resolveHandleMethod($projector, $message)->willReturn($projector->handle(...));
+        $projectorResolver->resolveSubscribeMethod($projector, $message)->willReturn($projector->handle(...));
 
         $projectionist = new DefaultProjectionist(
             $streamableStore->reveal(),
@@ -290,7 +290,7 @@ final class DefaultProjectionistTest extends TestCase
         $projectorRepository->projectors()->willReturn([$projector])->shouldBeCalledOnce();
 
         $projectorResolver = $this->prophesize(ProjectorResolver::class);
-        $projectorResolver->resolveHandleMethod($projector, $message)->willReturn($projector->handle(...));
+        $projectorResolver->resolveSubscribeMethod($projector, $message)->willReturn($projector->handle(...));
 
         $projectionist = new DefaultProjectionist(
             $streamableStore->reveal(),
@@ -339,7 +339,7 @@ final class DefaultProjectionistTest extends TestCase
         $projectorRepository->projectors()->willReturn([$projector])->shouldBeCalledOnce();
 
         $projectorResolver = $this->prophesize(ProjectorResolver::class);
-        $projectorResolver->resolveHandleMethod($projector, $message1)->willReturn($projector->handle(...));
+        $projectorResolver->resolveSubscribeMethod($projector, $message1)->willReturn($projector->handle(...));
 
         $projectionist = new DefaultProjectionist(
             $streamableStore->reveal(),
@@ -401,7 +401,7 @@ final class DefaultProjectionistTest extends TestCase
         $projectorRepository->projectors()->willReturn([$projector1, $projector2])->shouldBeCalledOnce();
 
         $projectorResolver = $this->prophesize(ProjectorResolver::class);
-        $projectorResolver->resolveHandleMethod($projector1, $message)->willReturn($projector1->handle(...));
+        $projectorResolver->resolveSubscribeMethod($projector1, $message)->willReturn($projector1->handle(...));
 
         $projectionist = new DefaultProjectionist(
             $streamableStore->reveal(),
@@ -450,7 +450,7 @@ final class DefaultProjectionistTest extends TestCase
         $projectorRepository->projectors()->willReturn([$projector])->shouldBeCalledOnce();
 
         $projectorResolver = $this->prophesize(ProjectorResolver::class);
-        $projectorResolver->resolveHandleMethod($projector, $message)->willReturn($projector->handle(...));
+        $projectorResolver->resolveSubscribeMethod($projector, $message)->willReturn($projector->handle(...));
 
         $projectionist = new DefaultProjectionist(
             $streamableStore->reveal(),

--- a/tests/Unit/Projection/Projector/MetadataProjectorResolverTest.php
+++ b/tests/Unit/Projection/Projector/MetadataProjectorResolverTest.php
@@ -6,7 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Projection\Projector;
 
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\MetadataProjectorResolver;
@@ -30,7 +30,7 @@ final class MetadataProjectorResolverTest extends TestCase
                 return new ProjectionId('dummy', 1);
             }
 
-            #[Handle(ProfileCreated::class)]
+            #[Subscribe(ProfileCreated::class)]
             public function handleProfileCreated(Message $message): void
             {
                 self::$handledMessage = $message;
@@ -45,7 +45,7 @@ final class MetadataProjectorResolverTest extends TestCase
         );
 
         $resolver = new MetadataProjectorResolver();
-        $result = $resolver->resolveHandleMethod($projection, $message);
+        $result = $resolver->resolveSubscribeMethod($projection, $message);
 
         self::assertIsCallable($result);
 
@@ -70,7 +70,7 @@ final class MetadataProjectorResolverTest extends TestCase
         );
 
         $resolver = new MetadataProjectorResolver();
-        $result = $resolver->resolveHandleMethod($projection, $message);
+        $result = $resolver->resolveSubscribeMethod($projection, $message);
 
         self::assertNull($result);
     }

--- a/tests/Unit/Projection/Projector/ProjectorHelperTest.php
+++ b/tests/Unit/Projection/Projector/ProjectorHelperTest.php
@@ -6,7 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Projection\Projector;
 
 use Patchlevel\EventSourcing\Attribute\Create;
 use Patchlevel\EventSourcing\Attribute\Drop;
-use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionId;
 use Patchlevel\EventSourcing\Projection\Projector\Projector;
@@ -30,7 +30,7 @@ final class ProjectorHelperTest extends TestCase
                 return new ProjectionId('dummy', 1);
             }
 
-            #[Handle(ProfileCreated::class)]
+            #[Subscribe(ProfileCreated::class)]
             public function handleProfileCreated(Message $message): void
             {
                 self::$handledMessage = $message;
@@ -62,7 +62,7 @@ final class ProjectorHelperTest extends TestCase
                 return new ProjectionId('dummy', 1);
             }
 
-            #[Handle(ProfileCreated::class)]
+            #[Subscribe(ProfileCreated::class)]
             public function handleProfileCreated(Message $message): void
             {
                 self::$handledMessage = $message;


### PR DESCRIPTION
"Handle" was sometimes difficult to understand in the context and it was not easy to explain. "Subscribe" describes much better what happens in the background.