### PR TITLE
Downgrade symfony/event-dispatcher to 7.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "psr/log": "^2.0.0|^3.0.0",
     "psr/simple-cache": "^2.0.0|^3.0.0",
     "symfony/console": "^5.4.32|^6.4.1|^7.0.1",
-    "symfony/event-dispatcher": "^5.4.26|^6.4.0|^7.0.1",
+    "symfony/event-dispatcher": "^5.4.26|^6.4.0|^7.0.0",
     "symfony/finder": "^5.4.27|^6.4.0|^7.0.0",
     "symfony/lock": "^5.4.32|^6.4.0|^7.0.0"
   },


### PR DESCRIPTION
Hi, there is no v7.0.1 yet for the event-dispatcher. If you try to install your package on the newest symfony version it fails with:
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires patchlevel/event-sourcing ^2.3 -> satisfiable by patchlevel/event-sourcing[2.3.0].
    - patchlevel/event-sourcing 2.3.0 requires symfony/event-dispatcher ^5.4.26|^6.4.0|^7.0.1 -> found symfony/event-dispatcher[v5.4.26, v6.4.0] but these were not loaded, likely because it conflicts with another require.


Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```