### PR TITLE
execute archive logic only once

### DIFF
--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -281,17 +281,25 @@ final class DefaultRepository implements Repository
             return;
         }
 
+        $lastMessageWithNewStreamStart = null;
+
         foreach ($messages as $message) {
             if (!$message->newStreamStart()) {
                 continue;
             }
 
-            $this->store->archiveMessages(
-                $message->aggregateClass(),
-                $message->aggregateId(),
-                $message->playhead(),
-            );
+            $lastMessageWithNewStreamStart = $message;
         }
+
+        if ($lastMessageWithNewStreamStart === null) {
+            return;
+        }
+
+        $this->store->archiveMessages(
+            $lastMessageWithNewStreamStart->aggregateClass(),
+            $lastMessageWithNewStreamStart->aggregateId(),
+            $lastMessageWithNewStreamStart->playhead(),
+        );
     }
 
     /** @return Traversable<object> */


### PR DESCRIPTION
Previously, the archiving logic was always executed when a SplitStream event was detected. If there were `n` of them when saving, the logic was executed `n` times. This is very pointless as the logic archives all events in the past. Through optimization, the logic is only executed once, for the last event.