### PR TITLE
fix show command & add 'end'/'next' method in stream interface

### DIFF
--- a/src/Console/Command/ShowCommand.php
+++ b/src/Console/Command/ShowCommand.php
@@ -62,11 +62,19 @@ final class ShowCommand extends Command
         do {
             $i = 0;
 
-            foreach ($stream as $message) {
+            while (!$stream->end()) {
                 $i++;
                 $currentCount++;
 
+                $message = $stream->current();
+
+                if (!$message) {
+                    break 2;
+                }
+
                 $console->message($this->serializer, $message);
+
+                $stream->next();
 
                 if ($i >= $limit) {
                     break;

--- a/src/Store/ArrayStream.php
+++ b/src/Store/ArrayStream.php
@@ -65,6 +65,16 @@ final class ArrayStream implements Stream, IteratorAggregate
         return $this->index;
     }
 
+    public function next(): void
+    {
+        $this->iterator->next();
+    }
+
+    public function end(): bool
+    {
+        return !$this->iterator->valid();
+    }
+
     public function current(): Message|null
     {
         return $this->iterator->current() ?: null;

--- a/src/Store/DoctrineDbalStoreStream.php
+++ b/src/Store/DoctrineDbalStoreStream.php
@@ -42,6 +42,16 @@ final class DoctrineDbalStoreStream implements Stream, IteratorAggregate
         $this->result->free();
     }
 
+    public function next(): void
+    {
+        $this->generator->next();
+    }
+
+    public function end(): bool
+    {
+        return !$this->generator->valid();
+    }
+
     public function current(): Message|null
     {
         return $this->generator->current() ?: null;

--- a/src/Store/Stream.php
+++ b/src/Store/Stream.php
@@ -12,7 +12,11 @@ interface Stream extends Traversable
 {
     public function close(): void;
 
+    public function next(): void;
+
     public function current(): Message|null;
+
+    public function end(): bool;
 
     /** @return positive-int|0|null */
     public function position(): int|null;

--- a/tests/Unit/Store/ArrayStreamTest.php
+++ b/tests/Unit/Store/ArrayStreamTest.php
@@ -26,13 +26,14 @@ final class ArrayStreamTest extends TestCase
         self::assertSame(null, $stream->position());
         self::assertSame(null, $stream->current());
         self::assertSame(null, $stream->index());
+        self::assertSame(true, $stream->end());
 
         $array = iterator_to_array($stream);
 
         self::assertSame([], $array);
     }
 
-    public function testWithMessages(): void
+    public function testOneMessage(): void
     {
         $message = Message::create(
             new ProfileCreated(
@@ -48,17 +49,17 @@ final class ArrayStreamTest extends TestCase
         self::assertSame(1, $stream->index());
         self::assertSame(0, $stream->position());
         self::assertSame($message, $stream->current());
+        self::assertSame(false, $stream->end());
 
-        $array = iterator_to_array($stream);
+        $stream->next();
 
         self::assertSame(1, $stream->index());
         self::assertSame(0, $stream->position());
         self::assertSame(null, $stream->current());
-
-        self::assertSame($messages, $array);
+        self::assertSame(true, $stream->end());
     }
 
-    public function testPosition(): void
+    public function testMultipleMessages(): void
     {
         $messages = [
             Message::create(
@@ -85,10 +86,28 @@ final class ArrayStreamTest extends TestCase
 
         self::assertSame(1, $stream->index());
         self::assertSame(0, $stream->position());
+        self::assertSame($messages[0], $stream->current());
+        self::assertSame(false, $stream->end());
 
-        iterator_to_array($stream);
+        $stream->next();
+
+        self::assertSame(2, $stream->index());
+        self::assertSame(1, $stream->position());
+        self::assertSame($messages[1], $stream->current());
+        self::assertSame(false, $stream->end());
+
+        $stream->next();
 
         self::assertSame(3, $stream->index());
         self::assertSame(2, $stream->position());
+        self::assertSame($messages[2], $stream->current());
+        self::assertSame(false, $stream->end());
+
+        $stream->next();
+
+        self::assertSame(3, $stream->index());
+        self::assertSame(2, $stream->position());
+        self::assertSame(null, $stream->current());
+        self::assertSame(true, $stream->end());
     }
 }


### PR DESCRIPTION
I can't use foreach in this context because foreach always starts from the beginning. And that even leads to an error since we're working with generators. I fixed the problem by adding the necessary methods to the interface so that the command works as intended.