### PR TITLE
use aggregate name in message to decouple components

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -192,7 +192,7 @@
     <InvalidArgument>
       <code><![CDATA[[
                 'foo' => 'bar',
-                'aggregateClass' => Profile::class,
+                'aggregateName' => 'profile',
                 'aggregateId' => '1',
                 'playhead' => 3,
                 'recordedOn' => $recordedAt,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,7 +6,7 @@ parameters:
 			path: src/Console/DoctrineHelper.php
 
 		-
-			message: "#^Method Patchlevel\\\\EventSourcing\\\\EventBus\\\\Message\\:\\:headers\\(\\) should return array\\{aggregateClass\\?\\: class\\-string\\<Patchlevel\\\\EventSourcing\\\\Aggregate\\\\AggregateRoot\\>, aggregateId\\?\\: string, playhead\\?\\: int\\<1, max\\>, recordedOn\\?\\: DateTimeImmutable, newStreamStart\\?\\: bool, archived\\?\\: bool\\} but returns non\\-empty\\-array\\<string, mixed\\>\\.$#"
+			message: "#^Method Patchlevel\\\\EventSourcing\\\\EventBus\\\\Message\\:\\:headers\\(\\) should return array\\{aggregateName\\?\\: string, aggregateId\\?\\: string, playhead\\?\\: int\\<1, max\\>, recordedOn\\?\\: DateTimeImmutable, newStreamStart\\?\\: bool, archived\\?\\: bool\\} but returns non\\-empty\\-array\\<string, mixed\\>\\.$#"
 			count: 1
 			path: src/EventBus/Message.php
 

--- a/src/Console/OutputStyle.php
+++ b/src/Console/OutputStyle.php
@@ -24,14 +24,14 @@ final class OutputStyle extends SymfonyStyle
 
         $this->horizontalTable([
             'eventClass',
-            'aggregateClass',
+            'aggregateName',
             'aggregateId',
             'playhead',
             'recordedOn',
         ], [
             [
                 $event::class,
-                $message->aggregateClass(),
+                $message->aggregateName(),
                 $message->aggregateId(),
                 $message->playhead(),
                 $message->recordedOn()->format(DateTimeInterface::ATOM),

--- a/src/EventBus/HeaderNotFound.php
+++ b/src/EventBus/HeaderNotFound.php
@@ -14,9 +14,9 @@ final class HeaderNotFound extends EventBusException
         parent::__construct(sprintf('message header "%s" is not defined', $name));
     }
 
-    public static function aggregateClass(): self
+    public static function aggregateName(): self
     {
-        return new self(Message::HEADER_AGGREGATE_CLASS);
+        return new self(Message::HEADER_AGGREGATE_NAME);
     }
 
     public static function aggregateId(): self

--- a/src/EventBus/Message.php
+++ b/src/EventBus/Message.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\EventBus;
 
 use DateTimeImmutable;
-use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
 
 use function array_key_exists;
 
@@ -13,7 +12,7 @@ use function array_key_exists;
  * @template-covariant T of object
  * @psalm-immutable
  * @psalm-type Headers = array{
- *     aggregateClass?: class-string<AggregateRoot>,
+ *     aggregateName?: string,
  *     aggregateId?: string,
  *     playhead?: positive-int,
  *     recordedOn?: DateTimeImmutable,
@@ -23,15 +22,14 @@ use function array_key_exists;
  */
 final class Message
 {
-    public const HEADER_AGGREGATE_CLASS = 'aggregateClass';
+    public const HEADER_AGGREGATE_NAME = 'aggregateName';
     public const HEADER_AGGREGATE_ID = 'aggregateId';
     public const HEADER_PLAYHEAD = 'playhead';
     public const HEADER_RECORDED_ON = 'recordedOn';
     public const HEADER_ARCHIVED = 'archived';
     public const HEADER_NEW_STREAM_START = 'newStreamStart';
 
-    /** @var class-string<AggregateRoot>|null */
-    private string|null $aggregateClass = null;
+    private string|null $aggregateName = null;
     private string|null $aggregateId = null;
     /** @var positive-int|null  */
     private int|null $playhead = null;
@@ -66,27 +64,22 @@ final class Message
         return $this->event;
     }
 
-    /**
-     * @return class-string<AggregateRoot>
-     *
-     * @throws HeaderNotFound
-     */
-    public function aggregateClass(): string
+    /** @throws HeaderNotFound */
+    public function aggregateName(): string
     {
-        $value = $this->aggregateClass;
+        $value = $this->aggregateName;
 
         if ($value === null) {
-            throw HeaderNotFound::aggregateClass();
+            throw HeaderNotFound::aggregateName();
         }
 
         return $value;
     }
 
-    /** @param class-string<AggregateRoot> $value */
-    public function withAggregateClass(string $value): self
+    public function withAggregateName(string $value): self
     {
         $message = clone $this;
-        $message->aggregateClass = $value;
+        $message->aggregateName = $value;
 
         return $message;
     }
@@ -220,8 +213,8 @@ final class Message
     {
         $headers = $this->customHeaders;
 
-        if ($this->aggregateClass !== null) {
-            $headers[self::HEADER_AGGREGATE_CLASS] = $this->aggregateClass;
+        if ($this->aggregateName !== null) {
+            $headers[self::HEADER_AGGREGATE_NAME] = $this->aggregateName;
         }
 
         if ($this->aggregateId !== null) {
@@ -247,8 +240,8 @@ final class Message
     {
         $message = self::create($event);
 
-        if (array_key_exists(self::HEADER_AGGREGATE_CLASS, $headers)) {
-            $message = $message->withAggregateClass($headers[self::HEADER_AGGREGATE_CLASS]);
+        if (array_key_exists(self::HEADER_AGGREGATE_NAME, $headers)) {
+            $message = $message->withAggregateName($headers[self::HEADER_AGGREGATE_NAME]);
         }
 
         if (array_key_exists(self::HEADER_AGGREGATE_ID, $headers)) {
@@ -272,7 +265,7 @@ final class Message
         }
 
         unset(
-            $headers[self::HEADER_AGGREGATE_CLASS],
+            $headers[self::HEADER_AGGREGATE_NAME],
             $headers[self::HEADER_AGGREGATE_ID],
             $headers[self::HEADER_PLAYHEAD],
             $headers[self::HEADER_RECORDED_ON],

--- a/src/Store/ArchivableStore.php
+++ b/src/Store/ArchivableStore.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Store;
 
-use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
-
 interface ArchivableStore
 {
-    /** @param class-string<AggregateRoot> $aggregate */
-    public function archiveMessages(string $aggregate, string $id, int $untilPlayhead): void;
+    public function archiveMessages(string $aggregateName, string $aggregateId, int $untilPlayhead): void;
 }

--- a/src/Store/Criteria.php
+++ b/src/Store/Criteria.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Store;
 
-use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
-
 final class Criteria
 {
     public function __construct(
-        /** @var class-string<AggregateRoot>|null */
-        public readonly string|null $aggregateClass = null,
+        public readonly string|null $aggregateName = null,
         public readonly string|null $aggregateId = null,
         public readonly int|null $fromIndex = null,
         public readonly int|null $fromPlayhead = null,

--- a/src/Store/CriteriaBuilder.php
+++ b/src/Store/CriteriaBuilder.php
@@ -4,21 +4,17 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Store;
 
-use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
-
 final class CriteriaBuilder
 {
-    /** @var class-string<AggregateRoot>|null */
-    private string|null $aggregateClass = null;
+    private string|null $aggregateName = null;
     private string|null $aggregateId = null;
     private int|null $fromIndex = null;
     private int|null $fromPlayhead = null;
     private bool|null $archived = null;
 
-    /** @param class-string<AggregateRoot>|null $aggregateClass */
-    public function aggregateClass(string|null $aggregateClass): self
+    public function aggregateName(string|null $aggregateName): self
     {
-        $this->aggregateClass = $aggregateClass;
+        $this->aggregateName = $aggregateName;
 
         return $this;
     }
@@ -54,7 +50,7 @@ final class CriteriaBuilder
     public function build(): Criteria
     {
         return new Criteria(
-            $this->aggregateClass,
+            $this->aggregateName,
             $this->aggregateId,
             $this->fromIndex,
             $this->fromPlayhead,

--- a/tests/Benchmark/SimpleSetupBench.php
+++ b/tests/Benchmark/SimpleSetupBench.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\DriverManager;
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\EventBus\EventBus;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
@@ -50,7 +49,6 @@ final class SimpleSetupBench
         $this->store = new DoctrineDbalStore(
             $connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
-            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/BasicImplementation/Aggregate']),
             'eventstore',
         );
 

--- a/tests/Benchmark/SnapshotsBench.php
+++ b/tests/Benchmark/SnapshotsBench.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\DriverManager;
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\EventBus\EventBus;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
@@ -56,7 +55,6 @@ final class SnapshotsBench
         $this->store = new DoctrineDbalStore(
             $connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
-            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/BasicImplementation/Aggregate']),
             'eventstore',
         );
 

--- a/tests/Benchmark/SplitStreamBench.php
+++ b/tests/Benchmark/SplitStreamBench.php
@@ -10,7 +10,6 @@ use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
 use Patchlevel\EventSourcing\EventBus\Decorator\SplitStreamDecorator;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\EventBus\EventBus;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
@@ -55,7 +54,6 @@ final class SplitStreamBench
         $this->store = new DoctrineDbalStore(
             $connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
-            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/BasicImplementation/Aggregate']),
             'eventstore',
         );
 

--- a/tests/Benchmark/SyncProjectionistBench.php
+++ b/tests/Benchmark/SyncProjectionistBench.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\DriverManager;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\Lock\DoctrineDbalStoreSchemaAdapter;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Projection\Projection\Store\InMemoryStore;
 use Patchlevel\EventSourcing\Projection\Projectionist\DefaultProjectionist;
 use Patchlevel\EventSourcing\Projection\Projectionist\SyncProjectionistEventBusWrapper;
@@ -58,7 +57,6 @@ final class SyncProjectionistBench
         $this->store = new DoctrineDbalStore(
             $connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
-            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/BasicImplementation/Aggregate']),
             'eventstore',
         );
 

--- a/tests/Benchmark/blackfire.php
+++ b/tests/Benchmark/blackfire.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\DriverManager;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
@@ -31,7 +30,6 @@ $bus = DefaultEventBus::create();
 $store = new DoctrineDbalStore(
     $connection,
     DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
-    (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/BasicImplementation/Aggregate']),
     'eventstore',
 );
 

--- a/tests/Integration/BankAccountSplitStream/IntegrationTest.php
+++ b/tests/Integration/BankAccountSplitStream/IntegrationTest.php
@@ -9,7 +9,6 @@ use Patchlevel\EventSourcing\EventBus\Decorator\ChainMessageDecorator;
 use Patchlevel\EventSourcing\EventBus\Decorator\SplitStreamDecorator;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionCriteria;
 use Patchlevel\EventSourcing\Projection\Projection\Store\InMemoryStore;
@@ -52,7 +51,6 @@ final class IntegrationTest extends TestCase
         $store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
-            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/Aggregate']),
             'eventstore',
         );
 

--- a/tests/Integration/BasicImplementation/BasicIntegrationTest.php
+++ b/tests/Integration/BasicImplementation/BasicIntegrationTest.php
@@ -7,7 +7,6 @@ namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation;
 use Doctrine\DBAL\Connection;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Projection\Projection\ProjectionCriteria;
 use Patchlevel\EventSourcing\Projection\Projection\Store\InMemoryStore;
 use Patchlevel\EventSourcing\Projection\Projectionist\DefaultProjectionist;
@@ -49,7 +48,6 @@ final class BasicIntegrationTest extends TestCase
         $store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
-            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/Aggregate']),
             'eventstore',
         );
 
@@ -122,7 +120,6 @@ final class BasicIntegrationTest extends TestCase
         $store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
-            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/Aggregate']),
             'eventstore',
         );
 

--- a/tests/Integration/Outbox/OutboxTest.php
+++ b/tests/Integration/Outbox/OutboxTest.php
@@ -6,7 +6,6 @@ namespace Patchlevel\EventSourcing\Tests\Integration\Outbox;
 
 use Doctrine\DBAL\Connection;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Outbox\DoctrineOutboxStore;
 use Patchlevel\EventSourcing\Outbox\EventBusPublisher;
 use Patchlevel\EventSourcing\Outbox\OutboxEventBus;
@@ -49,19 +48,16 @@ final class OutboxTest extends TestCase
     public function testSuccessful(): void
     {
         $serializer = DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']);
-        $registry = (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/Aggregate']);
 
         $store = new DoctrineDbalStore(
             $this->connection,
             $serializer,
-            $registry,
             'eventstore',
         );
 
         $outboxStore = new DoctrineOutboxStore(
             $this->connection,
             $serializer,
-            $registry,
             'outbox',
         );
 
@@ -115,7 +111,7 @@ final class OutboxTest extends TestCase
         $message = $messages[0];
 
         self::assertSame('1', $message->aggregateId());
-        self::assertSame(Profile::class, $message->aggregateClass());
+        self::assertSame('profile', $message->aggregateName());
         self::assertSame(1, $message->playhead());
         self::assertEquals(
             new ProfileCreated(ProfileId::fromString('1'), 'John'),

--- a/tests/Integration/Pipeline/PipelineChangeStoreTest.php
+++ b/tests/Integration/Pipeline/PipelineChangeStoreTest.php
@@ -6,7 +6,6 @@ namespace Patchlevel\EventSourcing\Tests\Integration\Pipeline;
 
 use Doctrine\DBAL\Connection;
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Pipeline\Middleware\ExcludeEventMiddleware;
 use Patchlevel\EventSourcing\Pipeline\Middleware\RecalculatePlayheadMiddleware;
 use Patchlevel\EventSourcing\Pipeline\Middleware\ReplaceEventMiddleware;
@@ -45,12 +44,10 @@ final class PipelineChangeStoreTest extends TestCase
     public function testSuccessful(): void
     {
         $serializer = DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']);
-        $aggregateRootRegistry = (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/Aggregate']);
 
         $oldStore = new DoctrineDbalStore(
             $this->connectionOld,
             $serializer,
-            $aggregateRootRegistry,
             'eventstore',
         );
 
@@ -64,7 +61,6 @@ final class PipelineChangeStoreTest extends TestCase
         $newStore = new DoctrineDbalStore(
             $this->connectionNew,
             $serializer,
-            $aggregateRootRegistry,
             'eventstore',
         );
 

--- a/tests/Integration/Projectionist/ProjectionistTest.php
+++ b/tests/Integration/Projectionist/ProjectionistTest.php
@@ -46,7 +46,6 @@ final class ProjectionistTest extends TestCase
         $store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
-            (new AttributeAggregateRootRegistryFactory())->create([__DIR__ . '/Aggregate']),
             'eventstore',
         );
 
@@ -101,7 +100,6 @@ final class ProjectionistTest extends TestCase
         $store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
-            $aggregateRegistry,
             'eventstore',
         );
 

--- a/tests/Integration/Store/StoreTest.php
+++ b/tests/Integration/Store/StoreTest.php
@@ -7,7 +7,6 @@ namespace Patchlevel\EventSourcing\Tests\Integration\Store;
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Patchlevel\EventSourcing\EventBus\Message;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\DoctrineDbalStore;
@@ -31,7 +30,6 @@ final class StoreTest extends TestCase
         $this->store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
-            new AggregateRootRegistry(['profile' => Profile::class]),
             'eventstore',
         );
 
@@ -52,12 +50,12 @@ final class StoreTest extends TestCase
     {
         $messages = [
             Message::create(new ProfileCreated(ProfileId::fromString('test'), 'test'))
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('test')
                 ->withPlayhead(1)
                 ->withRecordedOn(new DateTimeImmutable('2020-01-01 00:00:00')),
             Message::create(new ProfileCreated(ProfileId::fromString('test'), 'test'))
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('test')
                 ->withPlayhead(2)
                 ->withRecordedOn(new DateTimeImmutable('2020-01-02 00:00:00')),
@@ -92,7 +90,7 @@ final class StoreTest extends TestCase
     public function testLoad(): void
     {
         $message = Message::create(new ProfileCreated(ProfileId::fromString('test'), 'test'))
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('test')
             ->withPlayhead(1)
             ->withRecordedOn(new DateTimeImmutable('2020-01-01 00:00:00'));

--- a/tests/Unit/Console/Command/OutboxInfoCommandTest.php
+++ b/tests/Unit/Console/Command/OutboxInfoCommandTest.php
@@ -11,7 +11,6 @@ use Patchlevel\EventSourcing\Outbox\OutboxStore;
 use Patchlevel\EventSourcing\Serializer\Encoder\Encoder;
 use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Serializer\SerializedEvent;
-use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +30,7 @@ final class OutboxInfoCommandTest extends TestCase
         $store = $this->prophesize(OutboxStore::class);
         $store->retrieveOutboxMessages(null)->willReturn([
             Message::create($event)
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('1')
                 ->withPlayhead(1)
                 ->withRecordedOn(new DateTimeImmutable()),
@@ -69,7 +68,7 @@ final class OutboxInfoCommandTest extends TestCase
         $store = $this->prophesize(OutboxStore::class);
         $store->retrieveOutboxMessages(100)->willReturn([
             Message::create($event)
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('1')
                 ->withPlayhead(1)
                 ->withRecordedOn(new DateTimeImmutable()),

--- a/tests/Unit/Console/Command/ShowAggregateCommandTest.php
+++ b/tests/Unit/Console/Command/ShowAggregateCommandTest.php
@@ -38,7 +38,7 @@ final class ShowAggregateCommandTest extends TestCase
         $store->load(new Criteria(Profile::class, '1'))->willReturn(
             new ArrayStream([
                 Message::create($event)
-                    ->withAggregateClass(Profile::class)
+                    ->withAggregateName('profile')
                     ->withAggregateId('1')
                     ->withPlayhead(1)
                     ->withRecordedOn(new DateTimeImmutable()),
@@ -214,7 +214,7 @@ final class ShowAggregateCommandTest extends TestCase
         $store->load(new Criteria(Profile::class, '1'))->willReturn(
             new ArrayStream([
                 Message::create($event)
-                    ->withAggregateClass(Profile::class)
+                    ->withAggregateName('profile')
                     ->withAggregateId('1')
                     ->withPlayhead(1)
                     ->withRecordedOn(new DateTimeImmutable()),

--- a/tests/Unit/Console/OutputStyleTest.php
+++ b/tests/Unit/Console/OutputStyleTest.php
@@ -11,7 +11,6 @@ use Patchlevel\EventSourcing\Serializer\Encoder\Encoder;
 use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Serializer\SerializedEvent;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
-use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\TestCase;
@@ -41,7 +40,7 @@ final class OutputStyleTest extends TestCase
         ));
 
         $message = Message::create($event)
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(1)
             ->withRecordedOn(new DateTimeImmutable());

--- a/tests/Unit/EventBus/HeaderNotFoundTest.php
+++ b/tests/Unit/EventBus/HeaderNotFoundTest.php
@@ -10,11 +10,11 @@ use PHPUnit\Framework\TestCase;
 /** @covers \Patchlevel\EventSourcing\EventBus\HeaderNotFound */
 final class HeaderNotFoundTest extends TestCase
 {
-    public function testAggregateClass(): void
+    public function testAggregateName(): void
     {
         self::assertSame(
-            'message header "aggregateClass" is not defined',
-            HeaderNotFound::aggregateClass()->getMessage(),
+            'message header "aggregateName" is not defined',
+            HeaderNotFound::aggregateName()->getMessage(),
         );
     }
 

--- a/tests/Unit/EventBus/MessageTest.php
+++ b/tests/Unit/EventBus/MessageTest.php
@@ -9,7 +9,6 @@ use Generator;
 use Patchlevel\EventSourcing\EventBus\HeaderNotFound;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
-use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -34,9 +33,9 @@ final class MessageTest extends TestCase
     {
         $message = Message::create(new class {
         })
-            ->withAggregateClass(Profile::class);
+            ->withAggregateName('profile');
 
-        self::assertSame(Profile::class, $message->aggregateClass());
+        self::assertSame('profile', $message->aggregateName());
     }
 
     public function testCreateMessageWithAggregateIdHeader(): void
@@ -143,7 +142,7 @@ final class MessageTest extends TestCase
 
         $message = Message::create(new class {
         })
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(3)
             ->withRecordedOn($recordedAt)
@@ -154,7 +153,7 @@ final class MessageTest extends TestCase
         self::assertSame(
             [
                 'foo' => 'bar',
-                'aggregateClass' => Profile::class,
+                'aggregateName' => 'profile',
                 'aggregateId' => '1',
                 'playhead' => 3,
                 'recordedOn' => $recordedAt,
@@ -187,7 +186,7 @@ final class MessageTest extends TestCase
             },
             [
                 'foo' => 'bar',
-                'aggregateClass' => Profile::class,
+                'aggregateName' => 'profile',
                 'aggregateId' => '1',
                 'playhead' => 3,
                 'recordedOn' => $recordedAt,
@@ -199,7 +198,7 @@ final class MessageTest extends TestCase
         self::assertSame(
             [
                 'foo' => 'bar',
-                'aggregateClass' => Profile::class,
+                'aggregateName' => 'profile',
                 'aggregateId' => '1',
                 'playhead' => 3,
                 'recordedOn' => $recordedAt,
@@ -224,7 +223,7 @@ final class MessageTest extends TestCase
     /** @return Generator<string, array{string}> */
     public static function provideHeaderNotFound(): Generator
     {
-        yield 'aggregateClass' => ['aggregateClass'];
+        yield 'aggregateName' => ['aggregateName'];
         yield 'aggregateId' => ['aggregateId'];
         yield 'playhead' => ['playhead'];
         yield 'recordedOn' => ['recordedOn'];

--- a/tests/Unit/Outbox/DoctrineOutboxStoreTest.php
+++ b/tests/Unit/Outbox/DoctrineOutboxStoreTest.php
@@ -14,13 +14,11 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Patchlevel\EventSourcing\EventBus\Message;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Outbox\DoctrineOutboxStore;
 use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Serializer\SerializedEvent;
 use Patchlevel\EventSourcing\Store\WrongQueryResult;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
-use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +34,7 @@ final class DoctrineOutboxStoreTest extends TestCase
     {
         $recordedOn = new DateTimeImmutable();
         $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(1)
             ->withRecordedOn($recordedOn)
@@ -73,7 +71,6 @@ final class DoctrineOutboxStoreTest extends TestCase
         $doctrineOutboxStore = new DoctrineOutboxStore(
             $mockedConnection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
         );
 
         $doctrineOutboxStore->saveOutboxMessage($message);
@@ -83,7 +80,7 @@ final class DoctrineOutboxStoreTest extends TestCase
     {
         $recordedOn = new DateTimeImmutable();
         $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(1)
             ->withRecordedOn($recordedOn)
@@ -110,7 +107,6 @@ final class DoctrineOutboxStoreTest extends TestCase
         $doctrineOutboxStore = new DoctrineOutboxStore(
             $mockedConnection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
         );
 
         $doctrineOutboxStore->markOutboxMessageConsumed($message);
@@ -132,7 +128,6 @@ final class DoctrineOutboxStoreTest extends TestCase
         $doctrineOutboxStore = new DoctrineOutboxStore(
             $connection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
         );
 
         $result = $doctrineOutboxStore->countOutboxMessages();
@@ -155,7 +150,6 @@ final class DoctrineOutboxStoreTest extends TestCase
         $doctrineOutboxStore = new DoctrineOutboxStore(
             $connection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
         );
 
         $this->expectException(WrongQueryResult::class);
@@ -183,7 +177,6 @@ final class DoctrineOutboxStoreTest extends TestCase
         $doctrineOutboxStore = new DoctrineOutboxStore(
             $connection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
         );
 
         $messages = $doctrineOutboxStore->retrieveOutboxMessages();
@@ -195,7 +188,7 @@ final class DoctrineOutboxStoreTest extends TestCase
         $recordedOn = new DateTimeImmutable();
         $event = new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s'));
         $message = Message::create($event)
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(1)
             ->withRecordedOn($recordedOn)
@@ -233,7 +226,6 @@ final class DoctrineOutboxStoreTest extends TestCase
         $doctrineOutboxStore = new DoctrineOutboxStore(
             $connection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
         );
 
         $messages = $doctrineOutboxStore->retrieveOutboxMessages();
@@ -248,7 +240,6 @@ final class DoctrineOutboxStoreTest extends TestCase
         $doctrineOutboxStore = new DoctrineOutboxStore(
             $connection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
         );
 
         $table = $this->prophesize(Table::class);

--- a/tests/Unit/Pipeline/Middleware/RecalculatePlayheadMiddlewareTest.php
+++ b/tests/Unit/Pipeline/Middleware/RecalculatePlayheadMiddlewareTest.php
@@ -7,7 +7,6 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Pipeline\Middleware;
 use Patchlevel\EventSourcing\EventBus\Message;
 use Patchlevel\EventSourcing\Pipeline\Middleware\RecalculatePlayheadMiddleware;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
-use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\TestCase;
@@ -25,14 +24,14 @@ final class RecalculatePlayheadMiddlewareTest extends TestCase
         );
 
         $message = Message::create($event)
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(5);
 
         $result = $middleware($message);
 
         self::assertCount(1, $result);
-        self::assertSame(Profile::class, $result[0]->aggregateClass());
+        self::assertSame('profile', $result[0]->aggregateName());
         self::assertSame(1, $result[0]->playhead());
     }
 
@@ -46,7 +45,7 @@ final class RecalculatePlayheadMiddlewareTest extends TestCase
         );
 
         $message = Message::create($event)
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(1);
 
@@ -65,24 +64,24 @@ final class RecalculatePlayheadMiddlewareTest extends TestCase
         );
 
         $message = Message::create($event)
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(5);
         $result = $middleware($message);
 
         self::assertCount(1, $result);
-        self::assertSame(Profile::class, $result[0]->aggregateClass());
+        self::assertSame('profile', $result[0]->aggregateName());
         self::assertSame(1, $result[0]->playhead());
 
         $message = Message::create($event)
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(8);
 
         $result = $middleware($message);
 
         self::assertCount(1, $result);
-        self::assertSame(Profile::class, $result[0]->aggregateClass());
+        self::assertSame('profile', $result[0]->aggregateName());
         self::assertSame(2, $result[0]->playhead());
     }
 
@@ -96,17 +95,17 @@ final class RecalculatePlayheadMiddlewareTest extends TestCase
         );
 
         $message = Message::create($event)
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(5);
         $result = $middleware($message);
 
         self::assertCount(1, $result);
-        self::assertSame(Profile::class, $result[0]->aggregateClass());
+        self::assertSame('profile', $result[0]->aggregateName());
         self::assertSame(1, $result[0]->playhead());
 
         $message = Message::create($event)
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(8);
 
@@ -114,7 +113,7 @@ final class RecalculatePlayheadMiddlewareTest extends TestCase
         $result = $middleware($message);
 
         self::assertCount(1, $result);
-        self::assertSame(Profile::class, $result[0]->aggregateClass());
+        self::assertSame('profile', $result[0]->aggregateName());
         self::assertSame(1, $result[0]->playhead());
     }
 }

--- a/tests/Unit/Pipeline/PipelineTest.php
+++ b/tests/Unit/Pipeline/PipelineTest.php
@@ -11,7 +11,6 @@ use Patchlevel\EventSourcing\Pipeline\Pipeline;
 use Patchlevel\EventSourcing\Pipeline\Source\InMemorySource;
 use Patchlevel\EventSourcing\Pipeline\Target\InMemoryTarget;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
-use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
@@ -106,7 +105,7 @@ final class PipelineTest extends TestCase
                     Email::fromString('hallo@patchlevel.de'),
                 ),
             )
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('1')
                 ->withPlayhead(1),
 
@@ -115,7 +114,7 @@ final class PipelineTest extends TestCase
                     ProfileId::fromString('1'),
                 ),
             )
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('1')
                 ->withPlayhead(2),
 
@@ -124,7 +123,7 @@ final class PipelineTest extends TestCase
                     ProfileId::fromString('1'),
                 ),
             )
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('1')
                 ->withPlayhead(3),
 
@@ -134,7 +133,7 @@ final class PipelineTest extends TestCase
                     Email::fromString('hallo@patchlevel.de'),
                 ),
             )
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('2')
                 ->withPlayhead(1),
 
@@ -143,7 +142,7 @@ final class PipelineTest extends TestCase
                     ProfileId::fromString('2'),
                 ),
             )
-                ->withAggregateClass(Profile::class)
+                ->withAggregateName('profile')
                 ->withAggregateId('2')
                 ->withPlayhead(2),
         ];

--- a/tests/Unit/Repository/DefaultRepositoryTest.php
+++ b/tests/Unit/Repository/DefaultRepositoryTest.php
@@ -45,7 +45,7 @@ final class DefaultRepositoryTest extends TestCase
         $store = $this->prophesize(Store::class);
         $store->save(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -56,7 +56,7 @@ final class DefaultRepositoryTest extends TestCase
                 return $message->playhead() === 1;
             }),
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -76,7 +76,7 @@ final class DefaultRepositoryTest extends TestCase
         $eventBus = $this->prophesize(EventBus::class);
         $eventBus->dispatch(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -87,7 +87,7 @@ final class DefaultRepositoryTest extends TestCase
                 return $message->playhead() === 1;
             }),
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -120,7 +120,7 @@ final class DefaultRepositoryTest extends TestCase
         $store = $this->prophesize(Store::class);
         $store->save(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -134,7 +134,7 @@ final class DefaultRepositoryTest extends TestCase
 
         $store->save(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -154,7 +154,7 @@ final class DefaultRepositoryTest extends TestCase
         $eventBus = $this->prophesize(EventBus::class);
         $eventBus->dispatch(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -168,7 +168,7 @@ final class DefaultRepositoryTest extends TestCase
 
         $eventBus->dispatch(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -203,7 +203,7 @@ final class DefaultRepositoryTest extends TestCase
         $store = $this->prophesize(Store::class);
         $store->save(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -227,7 +227,7 @@ final class DefaultRepositoryTest extends TestCase
         $eventBus = $this->prophesize(EventBus::class);
         $eventBus->dispatch(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -293,7 +293,7 @@ final class DefaultRepositoryTest extends TestCase
         $store = $this->prophesize(Store::class);
         $store->save(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -313,7 +313,7 @@ final class DefaultRepositoryTest extends TestCase
         $eventBus = $this->prophesize(EventBus::class);
         $eventBus->dispatch(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -488,7 +488,7 @@ final class DefaultRepositoryTest extends TestCase
         $store->willImplement(ArchivableStore::class);
         $store->save(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -499,7 +499,7 @@ final class DefaultRepositoryTest extends TestCase
                 return $message->playhead() === 1;
             }),
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -510,7 +510,7 @@ final class DefaultRepositoryTest extends TestCase
                 return $message->playhead() === 2;
             }),
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -521,7 +521,7 @@ final class DefaultRepositoryTest extends TestCase
                 return $message->playhead() === 3;
             }),
         )->shouldBeCalled();
-        $store->archiveMessages(Profile::class, '1', 3)->shouldBeCalledOnce();
+        $store->archiveMessages('profile', '1', 3)->shouldBeCalledOnce();
         $store->transactional(Argument::any())->will(
             /** @param array{0: callable} $args */
             static fn (array $args): mixed => $args[0]()
@@ -530,7 +530,7 @@ final class DefaultRepositoryTest extends TestCase
         $eventBus = $this->prophesize(EventBus::class);
         $eventBus->dispatch(
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -541,7 +541,7 @@ final class DefaultRepositoryTest extends TestCase
                 return $message->playhead() === 1;
             }),
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -552,7 +552,7 @@ final class DefaultRepositoryTest extends TestCase
                 return $message->playhead() === 2;
             }),
             Argument::that(static function (Message $message) {
-                if ($message->aggregateClass() !== Profile::class) {
+                if ($message->aggregateName() !== 'profile') {
                     return false;
                 }
 
@@ -586,7 +586,7 @@ final class DefaultRepositoryTest extends TestCase
     {
         $store = $this->prophesize(Store::class);
         $store->load(new Criteria(
-            Profile::class,
+            'profile',
             '1',
         ))->willReturn(new ArrayStream([
             Message::create(
@@ -617,7 +617,7 @@ final class DefaultRepositoryTest extends TestCase
     {
         $store = $this->prophesize(Store::class);
         $store->load(new Criteria(
-            Profile::class,
+            'profile',
             '1',
         ))->willReturn(
             new ArrayStream([
@@ -659,7 +659,7 @@ final class DefaultRepositoryTest extends TestCase
 
         $store = $this->prophesize(Store::class);
         $store->load(new Criteria(
-            Profile::class,
+            'profile',
             '1',
         ))->willReturn(new ArrayStream());
 
@@ -678,7 +678,7 @@ final class DefaultRepositoryTest extends TestCase
     {
         $store = $this->prophesize(Store::class);
         $store->count(new Criteria(
-            Profile::class,
+            'profile',
             '1',
         ))->willReturn(1);
 
@@ -697,7 +697,7 @@ final class DefaultRepositoryTest extends TestCase
     {
         $store = $this->prophesize(Store::class);
         $store->count(new Criteria(
-            Profile::class,
+            'profile',
             '1',
         ))->willReturn(0);
 
@@ -723,7 +723,7 @@ final class DefaultRepositoryTest extends TestCase
 
         $store = $this->prophesize(Store::class);
         $store->load(new Criteria(
-            ProfileWithSnapshot::class,
+            'profile_with_snapshot',
             '1',
             null,
             1,
@@ -757,7 +757,7 @@ final class DefaultRepositoryTest extends TestCase
         $store = $this->prophesize(Store::class);
         $store->load(
             new Criteria(
-                ProfileWithSnapshot::class,
+                'profile_with_snapshot',
                 '1',
             ),
         )->willReturn(
@@ -816,7 +816,7 @@ final class DefaultRepositoryTest extends TestCase
         $store = $this->prophesize(Store::class);
         $store->load(
             new Criteria(
-                ProfileWithSnapshot::class,
+                'profile_with_snapshot',
                 '1',
                 null,
                 1,
@@ -867,7 +867,7 @@ final class DefaultRepositoryTest extends TestCase
     public function testLoadAggregateWithoutSnapshot(): void
     {
         $store = $this->prophesize(Store::class);
-        $store->load(new Criteria(ProfileWithSnapshot::class, '1'))
+        $store->load(new Criteria('profile_with_snapshot', '1'))
             ->willReturn(new ArrayStream([
                 Message::create(
                     new ProfileCreated(

--- a/tests/Unit/Store/DoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/DoctrineDbalStoreTest.php
@@ -18,13 +18,11 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use EmptyIterator;
 use Patchlevel\EventSourcing\EventBus\Message;
-use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Serializer\SerializedEvent;
 use Patchlevel\EventSourcing\Store\CriteriaBuilder;
 use Patchlevel\EventSourcing\Store\DoctrineDbalStore;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
-use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\Attributes\RequiresPhp;
@@ -74,13 +72,12 @@ final class DoctrineDbalStoreTest extends TestCase
         $doctrineDbalStore = new DoctrineDbalStore(
             $connection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
             'eventstore',
         );
 
         $stream = $doctrineDbalStore->load(
             (new CriteriaBuilder())
-                ->aggregateClass(Profile::class)
+                ->aggregateName('profile')
                 ->aggregateId('1')
                 ->fromPlayhead(0)
                 ->archived(false)
@@ -144,13 +141,12 @@ final class DoctrineDbalStoreTest extends TestCase
         $doctrineDbalStore = new DoctrineDbalStore(
             $connection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
             'eventstore',
         );
 
         $stream = $doctrineDbalStore->load(
             (new CriteriaBuilder())
-                ->aggregateClass(Profile::class)
+                ->aggregateName('profile')
                 ->aggregateId('1')
                 ->fromPlayhead(0)
                 ->archived(false)
@@ -190,7 +186,6 @@ final class DoctrineDbalStoreTest extends TestCase
         $store = new DoctrineDbalStore(
             $connection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
             'eventstore',
         );
 
@@ -201,7 +196,7 @@ final class DoctrineDbalStoreTest extends TestCase
     {
         $recordedOn = new DateTimeImmutable();
         $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
-            ->withAggregateClass(Profile::class)
+            ->withAggregateName('profile')
             ->withAggregateId('1')
             ->withPlayhead(1)
             ->withRecordedOn($recordedOn)
@@ -236,7 +231,6 @@ final class DoctrineDbalStoreTest extends TestCase
         $singleTableStore = new DoctrineDbalStore(
             $mockedConnection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
             'eventstore',
         );
         $singleTableStore->save($message);
@@ -266,9 +260,8 @@ final class DoctrineDbalStoreTest extends TestCase
         $singleTableStore = new DoctrineDbalStore(
             $mockedConnection->reveal(),
             $serializer->reveal(),
-            new AggregateRootRegistry(['profile' => Profile::class]),
             'eventstore',
         );
-        $singleTableStore->archiveMessages(Profile::class, '1', 1);
+        $singleTableStore->archiveMessages('profile', '1', 1);
     }
 }


### PR DESCRIPTION
The aggregate class was removed from the message and replaced with the aggregate name. This means that other components are more decoupled from the aggregate.