### PR TITLE
allow to free result after stream closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ phpunit: vendor phpunit-unit phpunit-integration                              	#
 phpunit-integration: vendor                                                    	## run phpunit integration tests
 	vendor/bin/phpunit --testsuite=integration
 
+.PHONY: phpunit-integration-postgres
+phpunit-integration-postgres: vendor                                            ## run phpunit integration tests on postgres
+	DB_URL="pdo-pgsql://postgres:postgres@localhost:5432/eventstore?charset=utf8" vendor/bin/phpunit --testsuite=integration
+
 .PHONY: phpunit-unit
 phpunit-unit: vendor                                             				## run phpunit unit tests
 	XDEBUG_MODE=coverage vendor/bin/phpunit --testsuite=unit

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  postgres:
+    image: postgres:alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=eventstore
+    expose:
+      - 5432

--- a/src/Store/Stream.php
+++ b/src/Store/Stream.php
@@ -12,15 +12,26 @@ interface Stream extends Traversable
 {
     public function close(): void;
 
+    /** @throws StreamClosed */
     public function next(): void;
 
+    /** @throws StreamClosed */
     public function current(): Message|null;
 
+    /** @throws StreamClosed */
     public function end(): bool;
 
-    /** @return positive-int|0|null */
+    /**
+     * @return positive-int|0|null
+     *
+     * @throws StreamClosed
+     */
     public function position(): int|null;
 
-    /** @return positive-int|null */
+    /**
+     * @return positive-int|null
+     *
+     * @throws StreamClosed
+     */
     public function index(): int|null;
 }

--- a/src/Store/StreamClosed.php
+++ b/src/Store/StreamClosed.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+use RuntimeException;
+
+final class StreamClosed extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Stream is already closed.');
+    }
+}

--- a/tests/Integration/Store/StoreTest.php
+++ b/tests/Integration/Store/StoreTest.php
@@ -126,19 +126,25 @@ final class StoreTest extends TestCase
 
         $this->store->save($message);
 
-        $stream = $this->store->load();
+        $stream = null;
 
-        self::assertSame(1, $stream->index());
-        self::assertSame(0, $stream->position());
+        try {
+            $stream = $this->store->load();
 
-        $loadedMessage = $stream->current();
+            self::assertSame(1, $stream->index());
+            self::assertSame(0, $stream->position());
 
-        self::assertInstanceOf(Message::class, $loadedMessage);
-        self::assertNotSame($message, $loadedMessage);
-        self::assertEquals($message->event(), $loadedMessage->event());
-        self::assertEquals($message->header(AggregateHeader::class)->aggregateId, $loadedMessage->header(AggregateHeader::class)->aggregateId);
-        self::assertEquals($message->header(AggregateHeader::class)->aggregateName, $loadedMessage->header(AggregateHeader::class)->aggregateName);
-        self::assertEquals($message->header(AggregateHeader::class)->playhead, $loadedMessage->header(AggregateHeader::class)->playhead);
-        self::assertEquals($message->header(AggregateHeader::class)->recordedOn, $loadedMessage->header(AggregateHeader::class)->recordedOn);
+            $loadedMessage = $stream->current();
+
+            self::assertInstanceOf(Message::class, $loadedMessage);
+            self::assertNotSame($message, $loadedMessage);
+            self::assertEquals($message->event(), $loadedMessage->event());
+            self::assertEquals($message->header(AggregateHeader::class)->aggregateId, $loadedMessage->header(AggregateHeader::class)->aggregateId);
+            self::assertEquals($message->header(AggregateHeader::class)->aggregateName, $loadedMessage->header(AggregateHeader::class)->aggregateName);
+            self::assertEquals($message->header(AggregateHeader::class)->playhead, $loadedMessage->header(AggregateHeader::class)->playhead);
+            self::assertEquals($message->header(AggregateHeader::class)->recordedOn, $loadedMessage->header(AggregateHeader::class)->recordedOn);
+        } finally {
+            $stream?->close();
+        }
     }
 }


### PR DESCRIPTION
It looks like `PDOStatement::closeCursor()` doesn't really work in postgres, but is released via the garbage collector.

Our stream deletes all references after `close` so that the garbage collector can work.

fix pipeline for https://github.com/patchlevel/event-sourcing/pull/526