### PR TITLE
make the event bus optional

### DIFF
--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -267,7 +267,6 @@ After we have defined everything, we still have to plug the whole thing together
 
 ```php
 use Doctrine\DBAL\DriverManager;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\Projection\Engine\DefaultSubscriptionEngine;
 use Patchlevel\EventSourcing\Projection\Store\DoctrineSubscriptionStore;
 use Patchlevel\EventSourcing\Projection\Subscriber\MetadataSubscriberAccessorRepository;
@@ -306,12 +305,9 @@ $projectionist = new DefaultSubscriptionEngine(
     $projectorRepository,
 );
 
-$eventBus = DefaultEventBus::create();
-
 $repositoryManager = new DefaultRepositoryManager(
     $aggregateRegistry,
     $eventStore,
-    $eventBus,
 );
 
 $hotelRepository = $repositoryManager->get(Hotel::class);

--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -49,8 +49,8 @@ final class DefaultRepository implements Repository
     /** @param AggregateRootMetadata<T> $metadata */
     public function __construct(
         private Store $store,
-        private EventBus $eventBus,
         private readonly AggregateRootMetadata $metadata,
+        private EventBus|null $eventBus = null,
         private SnapshotStore|null $snapshotStore = null,
         private MessageDecorator|null $messageDecorator = null,
         ClockInterface|null $clock = null,
@@ -267,7 +267,7 @@ final class DefaultRepository implements Repository
                 }
 
                 $this->archive(...$messages);
-                $this->eventBus->dispatch(...$messages);
+                $this->eventBus?->dispatch(...$messages);
             });
 
             $this->aggregateIsValid[$aggregate] = true;

--- a/src/Repository/DefaultRepositoryManager.php
+++ b/src/Repository/DefaultRepositoryManager.php
@@ -32,7 +32,7 @@ final class DefaultRepositoryManager implements RepositoryManager
     public function __construct(
         private AggregateRootRegistry $aggregateRootRegistry,
         private Store $store,
-        private EventBus $eventBus,
+        private EventBus|null $eventBus = null,
         private SnapshotStore|null $snapshotStore = null,
         private MessageDecorator|null $messageDecorator = null,
         ClockInterface|null $clock = null,
@@ -66,8 +66,8 @@ final class DefaultRepositoryManager implements RepositoryManager
 
         return $this->instances[$aggregateClass] = new DefaultRepository(
             $this->store,
-            $this->eventBus,
             $this->metadataFactory->metadata($aggregateClass),
+            $this->eventBus,
             $this->snapshotStore,
             $this->messageDecorator,
             $this->clock,

--- a/tests/Benchmark/SimpleSetupBench.php
+++ b/tests/Benchmark/SimpleSetupBench.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Benchmark;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
-use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
@@ -23,7 +21,6 @@ use PhpBench\Attributes as Bench;
 final class SimpleSetupBench
 {
     private Store $store;
-    private EventBus $bus;
     private Repository $repository;
 
     private AggregateRootId $id;
@@ -31,8 +28,6 @@ final class SimpleSetupBench
     public function setUp(): void
     {
         $connection = DbalManager::createConnection();
-
-        $this->bus = DefaultEventBus::create();
 
         $this->store = new DoctrineDbalStore(
             $connection,
@@ -44,7 +39,7 @@ final class SimpleSetupBench
             'eventstore',
         );
 
-        $this->repository = new DefaultRepository($this->store, $this->bus, Profile::metadata());
+        $this->repository = new DefaultRepository($this->store, Profile::metadata());
 
         $schemaDirector = new DoctrineSchemaDirector(
             $connection,

--- a/tests/Benchmark/SnapshotsBench.php
+++ b/tests/Benchmark/SnapshotsBench.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Benchmark;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
-use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
@@ -26,7 +24,6 @@ use PhpBench\Attributes as Bench;
 final class SnapshotsBench
 {
     private Store $store;
-    private EventBus $bus;
     private SnapshotStore $snapshotStore;
     private Repository $repository;
 
@@ -37,8 +34,6 @@ final class SnapshotsBench
     public function setUp(): void
     {
         $connection = DbalManager::createConnection();
-
-        $this->bus = DefaultEventBus::create();
 
         $this->store = new DoctrineDbalStore(
             $connection,
@@ -54,7 +49,7 @@ final class SnapshotsBench
 
         $this->snapshotStore = new DefaultSnapshotStore(['default' => $this->adapter]);
 
-        $this->repository = new DefaultRepository($this->store, $this->bus, Profile::metadata(), $this->snapshotStore);
+        $this->repository = new DefaultRepository($this->store, Profile::metadata(), null, $this->snapshotStore);
 
         $schemaDirector = new DoctrineSchemaDirector(
             $connection,

--- a/tests/Benchmark/SplitStreamBench.php
+++ b/tests/Benchmark/SplitStreamBench.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Benchmark;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
-use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
@@ -27,7 +25,6 @@ use function sprintf;
 final class SplitStreamBench
 {
     private Store $store;
-    private EventBus $bus;
     private Repository $repository;
 
     private AggregateRootId $id;
@@ -35,8 +32,6 @@ final class SplitStreamBench
     public function setUp(): void
     {
         $connection = DbalManager::createConnection();
-
-        $this->bus = DefaultEventBus::create();
 
         $this->store = new DoctrineDbalStore(
             $connection,
@@ -50,8 +45,8 @@ final class SplitStreamBench
 
         $this->repository = new DefaultRepository(
             $this->store,
-            $this->bus,
             Profile::metadata(),
+            null,
             null,
             new SplitStreamDecorator(
                 new AttributeEventMetadataFactory(),

--- a/tests/Benchmark/SubscriptionEngineBench.php
+++ b/tests/Benchmark/SubscriptionEngineBench.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Benchmark;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
-use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
@@ -30,7 +28,6 @@ use PhpBench\Attributes as Bench;
 final class SubscriptionEngineBench
 {
     private Store $store;
-    private EventBus $bus;
     private Repository $repository;
 
     private SubscriptionEngine $subscriptionEngine;
@@ -40,8 +37,6 @@ final class SubscriptionEngineBench
     public function setUp(): void
     {
         $connection = DbalManager::createConnection();
-
-        $this->bus = DefaultEventBus::create();
 
         $this->store = new DoctrineDbalStore(
             $connection,
@@ -55,7 +50,7 @@ final class SubscriptionEngineBench
             'eventstore',
         );
 
-        $this->repository = new DefaultRepository($this->store, $this->bus, Profile::metadata());
+        $this->repository = new DefaultRepository($this->store, Profile::metadata());
 
         $subscriptionStore = new DoctrineSubscriptionStore(
             $connection,

--- a/tests/Benchmark/blackfire.php
+++ b/tests/Benchmark/blackfire.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\DriverManager;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
@@ -26,8 +25,6 @@ $connection = DriverManager::getConnection([
     'path' => DB_PATH,
 ]);
 
-$bus = DefaultEventBus::create();
-
 $store = new DoctrineDbalStore(
     $connection,
     DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
@@ -38,7 +35,7 @@ $store = new DoctrineDbalStore(
     'eventstore',
 );
 
-$repository = new DefaultRepository($store, $bus, Profile::metadata());
+$repository = new DefaultRepository($store, Profile::metadata());
 
 $schemaDirector = new DoctrineSchemaDirector(
     $connection,

--- a/tests/Integration/BankAccountSplitStream/IntegrationTest.php
+++ b/tests/Integration/BankAccountSplitStream/IntegrationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream;
 
 use Doctrine\DBAL\Connection;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
@@ -63,12 +62,10 @@ final class IntegrationTest extends TestCase
             new MetadataSubscriberAccessorRepository([$bankAccountProjector]),
         );
 
-        $eventBus = DefaultEventBus::create([$bankAccountProjector]);
-
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
             $store,
-            $eventBus,
+            null,
             null,
             new ChainMessageDecorator([
                 new SplitStreamDecorator(new AttributeEventMetadataFactory()),
@@ -91,6 +88,8 @@ final class IntegrationTest extends TestCase
         $bankAccount->addBalance(500);
         $repository->save($bankAccount);
 
+        $engine->run();
+
         $result = $this->connection->fetchAssociative('SELECT * FROM projection_bank_account WHERE id = ?', ['1']);
 
         self::assertIsArray($result);
@@ -102,7 +101,7 @@ final class IntegrationTest extends TestCase
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
             $store,
-            $eventBus,
+            null,
             null,
             new ChainMessageDecorator([
                 new SplitStreamDecorator(new AttributeEventMetadataFactory()),
@@ -125,6 +124,8 @@ final class IntegrationTest extends TestCase
         $bankAccount->addBalance(200);
         $repository->save($bankAccount);
 
+        $engine->run();
+
         $result = $this->connection->fetchAssociative('SELECT * FROM projection_bank_account WHERE id = ?', ['1']);
 
         self::assertIsArray($result);
@@ -136,7 +137,7 @@ final class IntegrationTest extends TestCase
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
             $store,
-            $eventBus,
+            null,
             null,
             new ChainMessageDecorator([
                 new SplitStreamDecorator(new AttributeEventMetadataFactory()),

--- a/tests/Integration/Pipeline/PipelineChangeStoreTest.php
+++ b/tests/Integration/Pipeline/PipelineChangeStoreTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Integration\Pipeline;
 
 use Doctrine\DBAL\Connection;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Pipeline\Middleware\ExcludeEventMiddleware;
 use Patchlevel\EventSourcing\Pipeline\Middleware\RecalculatePlayheadMiddleware;
@@ -78,8 +77,8 @@ final class PipelineChangeStoreTest extends TestCase
 
         $newSchemaDirector->create();
 
-        $oldRepository = new DefaultRepository($oldStore, DefaultEventBus::create(), Profile::metadata());
-        $newRepository = new DefaultRepository($newStore, DefaultEventBus::create(), Profile::metadata());
+        $oldRepository = new DefaultRepository($oldStore, Profile::metadata());
+        $newRepository = new DefaultRepository($newStore, Profile::metadata());
 
         $profileId = ProfileId::fromString('1');
         $profile = Profile::create($profileId);

--- a/tests/Integration/Subscription/SubscriptionTest.php
+++ b/tests/Integration/Subscription/SubscriptionTest.php
@@ -11,7 +11,6 @@ use Patchlevel\EventSourcing\Debug\Trace\TraceableSubscriberAccessorRepository;
 use Patchlevel\EventSourcing\Debug\Trace\TraceDecorator;
 use Patchlevel\EventSourcing\Debug\Trace\TraceHeader;
 use Patchlevel\EventSourcing\Debug\Trace\TraceStack;
-use Patchlevel\EventSourcing\EventBus\DefaultEventBus;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
@@ -81,7 +80,6 @@ final class SubscriptionTest extends TestCase
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['profile' => Profile::class]),
             $store,
-            DefaultEventBus::create(),
         );
 
         $repository = $manager->get(Profile::class);
@@ -210,7 +208,6 @@ final class SubscriptionTest extends TestCase
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['profile' => Profile::class]),
             $store,
-            DefaultEventBus::create(),
         );
 
         $subscriber = new ErrorProducerSubscriber();
@@ -337,7 +334,7 @@ final class SubscriptionTest extends TestCase
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['profile' => Profile::class]),
             $store,
-            DefaultEventBus::create(),
+            null,
             null,
             new TraceDecorator($traceStack),
         );
@@ -450,7 +447,6 @@ final class SubscriptionTest extends TestCase
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['profile' => Profile::class]),
             $store,
-            DefaultEventBus::create(),
         );
 
         $repository = $manager->get(Profile::class);
@@ -612,7 +608,6 @@ final class SubscriptionTest extends TestCase
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['profile' => Profile::class]),
             $store,
-            DefaultEventBus::create(),
         );
 
         $repository = $manager->get(Profile::class);


### PR DESCRIPTION
The event bus is no longer required to react to events in the form of a processor or projector. We now have the option to handle everything with the subscription engine. That's why the event bus should no longer be required, but optional.