### PR TITLE
Argument resolver for subscriber

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -115,15 +115,14 @@
     </PossiblyNullPropertyFetch>
   </file>
   <file src="src/Subscription/Subscriber/MetadataSubscriberAccessor.php">
+    <MixedAssignment>
+      <code><![CDATA[$arguments[]]]></code>
+    </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[$method]]></code>
       <code><![CDATA[$method]]></code>
       <code><![CDATA[$method]]></code>
     </MixedMethodCall>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[$this->subscriber->$method(...)]]></code>
-      <code><![CDATA[Closure(Message):void]]></code>
-    </MixedReturnTypeCoercion>
   </file>
   <file src="tests/Benchmark/BasicImplementation/Profile.php">
     <PropertyNotSetInConstructor>
@@ -134,7 +133,6 @@
   </file>
   <file src="tests/Benchmark/PersonalDataBench.php">
     <MissingConstructor>
-      <code><![CDATA[$bus]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$repository]]></code>
       <code><![CDATA[$store]]></code>
@@ -142,7 +140,6 @@
   </file>
   <file src="tests/Benchmark/SimpleSetupBench.php">
     <MissingConstructor>
-      <code><![CDATA[$bus]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$repository]]></code>
       <code><![CDATA[$store]]></code>
@@ -151,7 +148,6 @@
   <file src="tests/Benchmark/SnapshotsBench.php">
     <MissingConstructor>
       <code><![CDATA[$adapter]]></code>
-      <code><![CDATA[$bus]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$repository]]></code>
       <code><![CDATA[$snapshotStore]]></code>
@@ -163,7 +159,6 @@
       <code><![CDATA[$this->id]]></code>
     </ArgumentTypeCoercion>
     <MissingConstructor>
-      <code><![CDATA[$bus]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$repository]]></code>
       <code><![CDATA[$store]]></code>
@@ -171,7 +166,6 @@
   </file>
   <file src="tests/Benchmark/SubscriptionEngineBench.php">
     <MissingConstructor>
-      <code><![CDATA[$bus]]></code>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$repository]]></code>
       <code><![CDATA[$store]]></code>
@@ -200,13 +194,6 @@
     <PropertyNotSetInConstructor>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$name]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="tests/Integration/Pipeline/Aggregate/Profile.php">
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$id]]></code>
-      <code><![CDATA[$privacy]]></code>
-      <code><![CDATA[$visited]]></code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Integration/Store/Profile.php">
@@ -290,13 +277,6 @@
     <PropertyNotSetInConstructor>
       <code><![CDATA[$id]]></code>
     </PropertyNotSetInConstructor>
-  </file>
-  <file src="tests/Unit/Pipeline/Source/InMemorySourceTest.php">
-    <InvalidMethodCall>
-      <code><![CDATA[current]]></code>
-      <code><![CDATA[current]]></code>
-      <code><![CDATA[next]]></code>
-    </InvalidMethodCall>
   </file>
   <file src="tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php">
     <PossiblyUndefinedArrayOffset>

--- a/baseline.xml
+++ b/baseline.xml
@@ -121,7 +121,7 @@
     <MixedMethodCall>
       <code><![CDATA[$method]]></code>
       <code><![CDATA[$method]]></code>
-      <code><![CDATA[$method]]></code>
+      <code><![CDATA[$methodName]]></code>
     </MixedMethodCall>
   </file>
   <file src="tests/Benchmark/BasicImplementation/Profile.php">
@@ -277,6 +277,14 @@
     <PropertyNotSetInConstructor>
       <code><![CDATA[$id]]></code>
     </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php">
+    <MissingParamType>
+      <code><![CDATA[$message]]></code>
+    </MissingParamType>
+    <ReservedWord>
+      <code><![CDATA[ProfileVisited&ProfileCreated $event]]></code>
+    </ReservedWord>
   </file>
   <file src="tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php">
     <PossiblyUndefinedArrayOffset>

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -143,6 +143,7 @@ deptrac:
       - Metadata
       - Subscription
     Subscription:
+      - Aggregate
       - Attribute
       - Clock
       - Message

--- a/src/Metadata/Subscriber/ArgumentMetadata.php
+++ b/src/Metadata/Subscriber/ArgumentMetadata.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Metadata\Subscriber;
+
+final class ArgumentMetadata
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $type,
+    ) {
+    }
+}

--- a/src/Metadata/Subscriber/ArgumentTypeNotSupported.php
+++ b/src/Metadata/Subscriber/ArgumentTypeNotSupported.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\MetadataException;
+
+use function sprintf;
+
+final class ArgumentTypeNotSupported extends MetadataException
+{
+    public static function missingType(string $class, string $method, string $argumentName): self
+    {
+        return new self(
+            sprintf(
+                'Argument type for method "%s" in class "%s" is not supported. Argument "%s" must have a type.',
+                $method,
+                $class,
+                $argumentName,
+            ),
+        );
+    }
+
+    public static function onlyNamedTypeSupported(string $class, string $method, string $argumentName): self
+    {
+        return new self(
+            sprintf(
+                'Argument type for method "%s" in class "%s" is not supported. Argument "%s" must not have a union or intersection type.',
+                $method,
+                $class,
+                $argumentName,
+            ),
+        );
+    }
+}

--- a/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
+++ b/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
@@ -12,7 +12,6 @@ use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
-use RuntimeException;
 
 use function array_key_exists;
 
@@ -102,8 +101,20 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
         foreach ($method->getParameters() as $parameter) {
             $type = $parameter->getType();
 
+            if ($type === null) {
+                throw ArgumentTypeNotSupported::missingType(
+                    $method->getDeclaringClass()->getName(),
+                    $method->getName(),
+                    $parameter->getName(),
+                );
+            }
+
             if (!$type instanceof ReflectionNamedType) {
-                throw new RuntimeException('parameter type is required');
+                throw ArgumentTypeNotSupported::onlyNamedTypeSupported(
+                    $method->getDeclaringClass()->getName(),
+                    $method->getName(),
+                    $parameter->getName(),
+                );
             }
 
             $arguments[] = new ArgumentMetadata(

--- a/src/Metadata/Subscriber/SubscribeMethodMetadata.php
+++ b/src/Metadata/Subscriber/SubscribeMethodMetadata.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Metadata\Subscriber;
+
+final class SubscribeMethodMetadata
+{
+    /** @param list<ArgumentMetadata> $arguments */
+    public function __construct(
+        public readonly string $name,
+        public readonly array $arguments = [],
+    ) {
+    }
+}

--- a/src/Metadata/Subscriber/SubscriberMetadata.php
+++ b/src/Metadata/Subscriber/SubscriberMetadata.php
@@ -13,7 +13,7 @@ final class SubscriberMetadata
         public readonly string $id,
         public readonly string $group = Subscription::DEFAULT_GROUP,
         public readonly RunMode $runMode = RunMode::FromBeginning,
-        /** @var array<class-string|"*", list<string>> */
+        /** @var array<class-string|"*", list<SubscribeMethodMetadata>> */
         public readonly array $subscribeMethods = [],
         public readonly string|null $setupMethod = null,
         public readonly string|null $teardownMethod = null,

--- a/src/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolver.php
+++ b/src/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
+
+use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+
+use function in_array;
+
+final class AggregateIdArgumentResolver implements ArgumentResolver
+{
+    public function resolve(ArgumentMetadata $argument, Message $message): string
+    {
+        return $message->header(AggregateHeader::class)->aggregateId;
+    }
+
+    public function support(ArgumentMetadata $argument, string $eventClass): bool
+    {
+        return $argument->type === 'string' && in_array($argument->name, ['aggregateId', 'aggregateRootId']);
+    }
+}

--- a/src/Subscription/Subscriber/ArgumentResolver/ArgumentResolver.php
+++ b/src/Subscription/Subscriber/ArgumentResolver/ArgumentResolver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+
+interface ArgumentResolver
+{
+    public function resolve(ArgumentMetadata $argument, Message $message): mixed;
+
+    public function support(ArgumentMetadata $argument, string $eventClass): bool;
+}

--- a/src/Subscription/Subscriber/ArgumentResolver/EventArgumentResolver.php
+++ b/src/Subscription/Subscriber/ArgumentResolver/EventArgumentResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+
+use function class_exists;
+use function is_a;
+
+final class EventArgumentResolver implements ArgumentResolver
+{
+    public function resolve(ArgumentMetadata $argument, Message $message): object
+    {
+        return $message->event();
+    }
+
+    public function support(ArgumentMetadata $argument, string $eventClass): bool
+    {
+        return class_exists($argument->type) && is_a($eventClass, $argument->type, true);
+    }
+}

--- a/src/Subscription/Subscriber/ArgumentResolver/MessageArgumentResolver.php
+++ b/src/Subscription/Subscriber/ArgumentResolver/MessageArgumentResolver.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+
+final class MessageArgumentResolver implements ArgumentResolver
+{
+    public function resolve(ArgumentMetadata $argument, Message $message): Message
+    {
+        return $message;
+    }
+
+    public function support(ArgumentMetadata $argument, string $eventClass): bool
+    {
+        return $argument->type === Message::class;
+    }
+}

--- a/src/Subscription/Subscriber/ArgumentResolver/RecordedOnArgumentResolver.php
+++ b/src/Subscription/Subscriber/ArgumentResolver/RecordedOnArgumentResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
+
+use DateTimeImmutable;
+use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+
+final class RecordedOnArgumentResolver implements ArgumentResolver
+{
+    public function resolve(ArgumentMetadata $argument, Message $message): DateTimeImmutable
+    {
+        return $message->header(AggregateHeader::class)->recordedOn;
+    }
+
+    public function support(ArgumentMetadata $argument, string $eventClass): bool
+    {
+        return $argument->type === DateTimeImmutable::class;
+    }
+}

--- a/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
@@ -7,8 +7,10 @@ namespace Patchlevel\EventSourcing\Subscription\Subscriber;
 use Closure;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscribeMethodMetadata;
 use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadata;
 use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\ArgumentResolver;
 
 use function array_key_exists;
 use function array_map;
@@ -19,9 +21,11 @@ final class MetadataSubscriberAccessor implements SubscriberAccessor
     /** @var array<class-string, list<Closure(Message):void>> */
     private array $subscribeCache = [];
 
+    /** @param list<ArgumentResolver> $argumentResolvers */
     public function __construct(
         private readonly object $subscriber,
         private readonly SubscriberMetadata $metadata,
+        private readonly array $argumentResolvers,
     ) {
     }
 
@@ -79,11 +83,59 @@ final class MetadataSubscriberAccessor implements SubscriberAccessor
         );
 
         $this->subscribeCache[$eventClass] = array_map(
-            /** @return Closure(Message):void */
-            fn (string $method) => $this->subscriber->$method(...),
+            fn (SubscribeMethodMetadata $method): Closure => $this->createClosure($eventClass, $method),
             $methods,
         );
 
         return $this->subscribeCache[$eventClass];
+    }
+
+    /**
+     * @param class-string $eventClass
+     *
+     * @return Closure(Message):void
+     */
+    private function createClosure(string $eventClass, SubscribeMethodMetadata $method): Closure
+    {
+        $resolvers = $this->resolvers($eventClass, $method);
+        $methodName = $method->name;
+
+        return function (Message $message) use ($methodName, $resolvers): void {
+            $arguments = [];
+
+            foreach ($resolvers as $resolver) {
+                $arguments[] = $resolver($message);
+            }
+
+            $this->subscriber->$methodName(...$arguments);
+        };
+    }
+
+    /**
+     * @param class-string $eventClass
+     *
+     * @return list<Closure(Message):mixed>
+     */
+    private function resolvers(string $eventClass, SubscribeMethodMetadata $method): array
+    {
+        $resolvers = [];
+
+        foreach ($method->arguments as $argument) {
+            foreach ($this->argumentResolvers as $resolver) {
+                if (!$resolver->support($argument, $eventClass)) {
+                    continue;
+                }
+
+                $resolvers[] = static function (Message $message) use ($resolver, $argument): mixed {
+                    return $resolver->resolve($argument, $message);
+                };
+
+                continue 2;
+            }
+
+            throw new NoSuitableResolver($this->subscriber::class, $method->name, $argument->name);
+        }
+
+        return $resolvers;
     }
 }

--- a/src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php
@@ -6,7 +6,13 @@ namespace Patchlevel\EventSourcing\Subscription\Subscriber;
 
 use Patchlevel\EventSourcing\Metadata\Subscriber\AttributeSubscriberMetadataFactory;
 use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadataFactory;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\AggregateIdArgumentResolver;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\ArgumentResolver;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\EventArgumentResolver;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\MessageArgumentResolver;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\RecordedOnArgumentResolver;
 
+use function array_merge;
 use function array_values;
 
 final class MetadataSubscriberAccessorRepository implements SubscriberAccessorRepository
@@ -14,11 +20,27 @@ final class MetadataSubscriberAccessorRepository implements SubscriberAccessorRe
     /** @var array<string, SubscriberAccessor> */
     private array $subscribersMap = [];
 
-    /** @param iterable<object> $subscribers */
+    /** @var list<ArgumentResolver> $argumentResolvers */
+    private readonly array $argumentResolvers;
+
+    /**
+     * @param iterable<object>       $subscribers
+     * @param list<ArgumentResolver> $argumentResolvers
+     */
     public function __construct(
         private readonly iterable $subscribers,
         private readonly SubscriberMetadataFactory $metadataFactory = new AttributeSubscriberMetadataFactory(),
+        array $argumentResolvers = [],
     ) {
+        $this->argumentResolvers = array_merge(
+            $argumentResolvers,
+            [
+                new MessageArgumentResolver(),
+                new EventArgumentResolver(),
+                new AggregateIdArgumentResolver(),
+                new RecordedOnArgumentResolver(),
+            ],
+        );
     }
 
     /** @return iterable<SubscriberAccessor> */
@@ -43,7 +65,11 @@ final class MetadataSubscriberAccessorRepository implements SubscriberAccessorRe
 
         foreach ($this->subscribers as $subscriber) {
             $metadata = $this->metadataFactory->metadata($subscriber::class);
-            $this->subscribersMap[$metadata->id] = new MetadataSubscriberAccessor($subscriber, $metadata);
+            $this->subscribersMap[$metadata->id] = new MetadataSubscriberAccessor(
+                $subscriber,
+                $metadata,
+                $this->argumentResolvers,
+            );
         }
 
         return $this->subscribersMap;

--- a/src/Subscription/Subscriber/NoSuitableResolver.php
+++ b/src/Subscription/Subscriber/NoSuitableResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Subscriber;
+
+use RuntimeException;
+
+use function sprintf;
+
+class NoSuitableResolver extends RuntimeException
+{
+    public function __construct(string $class, string $methodName, string $argumentName)
+    {
+        parent::__construct(
+            sprintf(
+                'No suitable resolver found for argument "%s" in method "%s" of class "%s"',
+                $argumentName,
+                $methodName,
+                $class,
+            ),
+        );
+    }
+}

--- a/src/Subscription/Subscriber/NoSuitableResolver.php
+++ b/src/Subscription/Subscriber/NoSuitableResolver.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 use function sprintf;
 
-class NoSuitableResolver extends RuntimeException
+final class NoSuitableResolver extends RuntimeException
 {
     public function __construct(string $class, string $methodName, string $argumentName)
     {

--- a/tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
+++ b/tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
@@ -5,17 +5,13 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Projection;
 
 use Doctrine\DBAL\Connection;
-use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
 use Patchlevel\EventSourcing\Attribute\Projector;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Teardown;
-use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberUtil;
 use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\NameChanged;
 use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\ProfileCreated;
-
-use function assert;
 
 #[Projector('profile')]
 final class ProfileProjector
@@ -40,12 +36,8 @@ final class ProfileProjector
     }
 
     #[Subscribe(ProfileCreated::class)]
-    public function onProfileCreated(Message $message): void
+    public function onProfileCreated(ProfileCreated $profileCreated): void
     {
-        $profileCreated = $message->event();
-
-        assert($profileCreated instanceof ProfileCreated);
-
         $this->connection->insert(
             $this->table(),
             [
@@ -56,16 +48,12 @@ final class ProfileProjector
     }
 
     #[Subscribe(NameChanged::class)]
-    public function onNameChanged(Message $message): void
+    public function onNameChanged(NameChanged $nameChanged, string $aggregateRootId): void
     {
-        $nameChanged = $message->event();
-
-        assert($nameChanged instanceof NameChanged);
-
         $this->connection->update(
             $this->table(),
             ['name' => $nameChanged->name],
-            ['id' => $message->header(AggregateHeader::class)->aggregateId],
+            ['id' => $aggregateRootId],
         );
     }
 

--- a/tests/Integration/BasicImplementation/BasicIntegrationTest.php
+++ b/tests/Integration/BasicImplementation/BasicIntegrationTest.php
@@ -19,8 +19,8 @@ use Patchlevel\EventSourcing\Subscription\Store\InMemorySubscriptionStore;
 use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorRepository;
 use Patchlevel\EventSourcing\Tests\DbalManager;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Aggregate\Profile;
+use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Listener\SendEmailListener;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\MessageDecorator\FooMessageDecorator;
-use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Processor\SendEmailProcessor;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Projection\ProfileProjector;
 use PHPUnit\Framework\TestCase;
 
@@ -59,8 +59,7 @@ final class BasicIntegrationTest extends TestCase
         );
 
         $eventBus = DefaultEventBus::create([
-            new SendEmailProcessor(),
-            $profileProjector,
+            new SendEmailListener(),
         ]);
 
         $manager = new DefaultRepositoryManager(
@@ -84,6 +83,8 @@ final class BasicIntegrationTest extends TestCase
         $profileId = ProfileId::fromString('1');
         $profile = Profile::create($profileId, 'John');
         $repository->save($profile);
+
+        $engine->run();
 
         $result = $this->connection->fetchAssociative('SELECT * FROM projection_profile WHERE id = ?', ['1']);
 
@@ -126,8 +127,7 @@ final class BasicIntegrationTest extends TestCase
         );
 
         $eventBus = DefaultEventBus::create([
-            new SendEmailProcessor(),
-            $profileProjection,
+            new SendEmailListener(),
         ]);
 
         $manager = new DefaultRepositoryManager(
@@ -151,6 +151,8 @@ final class BasicIntegrationTest extends TestCase
         $profileId = ProfileId::fromString('1');
         $profile = Profile::create($profileId, 'John');
         $repository->save($profile);
+
+        $engine->run();
 
         $result = $this->connection->fetchAssociative('SELECT * FROM projection_profile WHERE id = ?', ['1']);
 

--- a/tests/Integration/BasicImplementation/Listener/SendEmailListener.php
+++ b/tests/Integration/BasicImplementation/Listener/SendEmailListener.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Processor;
+namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Listener;
 
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\SendEmailMock;
 
-final class SendEmailProcessor
+final class SendEmailListener
 {
     #[Subscribe(ProfileCreated::class)]
     public function onProfileCreated(Message $message): void

--- a/tests/Integration/BasicImplementation/Projection/ProfileProjector.php
+++ b/tests/Integration/BasicImplementation/Projection/ProfileProjector.php
@@ -10,10 +10,7 @@ use Patchlevel\EventSourcing\Attribute\Projector;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Teardown;
-use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\ProfileCreated;
-
-use function assert;
 
 #[Projector('profile-1')]
 final class ProfileProjector
@@ -41,12 +38,8 @@ final class ProfileProjector
     }
 
     #[Subscribe(ProfileCreated::class)]
-    public function handleProfileCreated(Message $message): void
+    public function handleProfileCreated(ProfileCreated $profileCreated): void
     {
-        $profileCreated = $message->event();
-
-        assert($profileCreated instanceof ProfileCreated);
-
         $this->connection->executeStatement(
             'INSERT INTO projection_profile (id, name) VALUES(:id, :name);',
             [

--- a/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
@@ -14,6 +14,7 @@ use Patchlevel\EventSourcing\Metadata\Subscriber\AttributeSubscriberMetadataFact
 use Patchlevel\EventSourcing\Metadata\Subscriber\ClassIsNotASubscriber;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateSetupMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateTeardownMethod;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscribeMethodMetadata;
 use Patchlevel\EventSourcing\Subscription\RunMode;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
@@ -106,7 +107,11 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
         $metadata = $metadataFactory->metadata($subscriber::class);
 
         self::assertEquals(
-            [ProfileVisited::class => ['handle']],
+            [
+                ProfileVisited::class => [
+                    new SubscribeMethodMetadata('handle', []),
+                ],
+            ],
             $metadata->subscribeMethods,
         );
 
@@ -130,8 +135,8 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
 
         self::assertEquals(
             [
-                ProfileVisited::class => ['handle'],
-                ProfileCreated::class => ['handle'],
+                ProfileVisited::class => [new SubscribeMethodMetadata('handle', [])],
+                ProfileCreated::class => [new SubscribeMethodMetadata('handle', [])],
             ],
             $metadata->subscribeMethods,
         );
@@ -152,7 +157,7 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
 
         self::assertEquals(
             [
-                '*' => ['handle'],
+                '*' => [new SubscribeMethodMetadata('handle', [])],
             ],
             $metadata->subscribeMethods,
         );

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolverTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber\ArgumentResolver;
+
+use DateTimeImmutable;
+use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\AggregateIdArgumentResolver;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use PHPUnit\Framework\TestCase;
+
+/** @covers \Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\AggregateIdArgumentResolver */
+final class AggregateIdArgumentResolverTest extends TestCase
+{
+    public function testSupport(): void
+    {
+        $resolver = new AggregateIdArgumentResolver();
+
+        self::assertTrue(
+            $resolver->support(
+                new ArgumentMetadata('aggregateId', 'string'),
+                ProfileCreated::class,
+            ),
+        );
+
+        self::assertTrue(
+            $resolver->support(
+                new ArgumentMetadata('aggregateRootId', 'string'),
+                ProfileCreated::class,
+            ),
+        );
+
+        self::assertFalse(
+            $resolver->support(
+                new ArgumentMetadata('foo', 'string'),
+                ProfileCreated::class,
+            ),
+        );
+    }
+
+    public function testResolve(): void
+    {
+        $event = new ProfileVisited(ProfileId::fromString('1'));
+
+        $resolver = new AggregateIdArgumentResolver();
+        $message = (new Message($event))->withHeader(
+            new AggregateHeader('foo', 'bar', 1, new DateTimeImmutable()),
+        );
+
+        self::assertSame(
+            'bar',
+            $resolver->resolve(
+                new ArgumentMetadata('foo', 'string'),
+                $message,
+            ),
+        );
+    }
+}

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/EventArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/EventArgumentResolverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber\ArgumentResolver;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\EventArgumentResolver;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use PHPUnit\Framework\TestCase;
+
+/** @covers \Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\EventArgumentResolver */
+final class EventArgumentResolverTest extends TestCase
+{
+    public function testSupport(): void
+    {
+        $resolver = new EventArgumentResolver();
+
+        self::assertTrue(
+            $resolver->support(
+                new ArgumentMetadata('foo', ProfileCreated::class),
+                ProfileCreated::class,
+            ),
+        );
+
+        self::assertFalse(
+            $resolver->support(
+                new ArgumentMetadata('foo', ProfileVisited::class),
+                ProfileCreated::class,
+            ),
+        );
+    }
+
+    public function testResolve(): void
+    {
+        $event = new ProfileVisited(ProfileId::fromString('1'));
+
+        $resolver = new EventArgumentResolver();
+        $message = new Message($event);
+
+        self::assertSame(
+            $event,
+            $resolver->resolve(
+                new ArgumentMetadata('foo', ProfileVisited::class),
+                $message,
+            ),
+        );
+    }
+}

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/MessageArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/MessageArgumentResolverTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber\ArgumentResolver;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\MessageArgumentResolver;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @covers \Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\MessageArgumentResolver */
+final class MessageArgumentResolverTest extends TestCase
+{
+    public function testSupport(): void
+    {
+        $resolver = new MessageArgumentResolver();
+
+        self::assertTrue(
+            $resolver->support(
+                new ArgumentMetadata('foo', Message::class),
+                'qux',
+            ),
+        );
+
+        self::assertFalse(
+            $resolver->support(
+                new ArgumentMetadata('foo', 'bar'),
+                'qux',
+            ),
+        );
+    }
+
+    public function testResolve(): void
+    {
+        $resolver = new MessageArgumentResolver();
+        $message = new Message(new stdClass());
+
+        self::assertSame(
+            $message,
+            $resolver->resolve(
+                new ArgumentMetadata('foo', Message::class),
+                $message,
+            ),
+        );
+    }
+}

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/RecordedOnArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/RecordedOnArgumentResolverTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber\ArgumentResolver;
+
+use DateTimeImmutable;
+use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\RecordedOnArgumentResolver;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @covers \Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\RecordedOnArgumentResolver */
+final class RecordedOnArgumentResolverTest extends TestCase
+{
+    public function testSupport(): void
+    {
+        $resolver = new RecordedOnArgumentResolver();
+
+        self::assertTrue(
+            $resolver->support(
+                new ArgumentMetadata('foo', DateTimeImmutable::class),
+                'qux',
+            ),
+        );
+
+        self::assertFalse(
+            $resolver->support(
+                new ArgumentMetadata('foo', 'bar'),
+                'qux',
+            ),
+        );
+    }
+
+    public function testResolve(): void
+    {
+        $date = new DateTimeImmutable();
+
+        $resolver = new RecordedOnArgumentResolver();
+        $message = (new Message(new stdClass()))->withHeader(
+            new AggregateHeader(
+                'foo',
+                'bar',
+                1,
+                $date,
+            ),
+        );
+
+        self::assertSame(
+            $date,
+            $resolver->resolve(
+                new ArgumentMetadata('foo', DateTimeImmutable::class),
+                $message,
+            ),
+        );
+    }
+}

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber;
 
 use Patchlevel\EventSourcing\Attribute\Subscriber;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
 use Patchlevel\EventSourcing\Metadata\Subscriber\AttributeSubscriberMetadataFactory;
 use Patchlevel\EventSourcing\Subscription\RunMode;
 use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
@@ -32,15 +34,29 @@ final class MetadataSubscriberAccessorRepositoryTest extends TestCase
         };
         $metadataFactory = new AttributeSubscriberMetadataFactory();
 
+        $customResolver = new class implements ArgumentResolver\ArgumentResolver {
+            public function resolve(ArgumentMetadata $argument, Message $message): mixed
+            {
+                return null;
+            }
+
+            public function support(ArgumentMetadata $argument, string $eventClass): bool
+            {
+                return false;
+            }
+        };
+
         $repository = new MetadataSubscriberAccessorRepository(
             [$subscriber],
             $metadataFactory,
+            [$customResolver],
         );
 
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             $metadataFactory->metadata($subscriber::class),
             [
+                $customResolver,
                 new ArgumentResolver\MessageArgumentResolver(),
                 new ArgumentResolver\EventArgumentResolver(),
                 new ArgumentResolver\AggregateIdArgumentResolver(),

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber;
 use Patchlevel\EventSourcing\Attribute\Subscriber;
 use Patchlevel\EventSourcing\Metadata\Subscriber\AttributeSubscriberMetadataFactory;
 use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
 use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
 use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorRepository;
 use PHPUnit\Framework\TestCase;
@@ -39,6 +40,12 @@ final class MetadataSubscriberAccessorRepositoryTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             $metadataFactory->metadata($subscriber::class),
+            [
+                new ArgumentResolver\MessageArgumentResolver(),
+                new ArgumentResolver\EventArgumentResolver(),
+                new ArgumentResolver\AggregateIdArgumentResolver(),
+                new ArgumentResolver\RecordedOnArgumentResolver(),
+            ],
         );
 
         self::assertEquals([$accessor], $repository->all());

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
@@ -11,9 +11,13 @@ use Patchlevel\EventSourcing\Attribute\Teardown;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\Subscriber\AttributeSubscriberMetadataFactory;
 use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\EventArgumentResolver;
 use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\MessageArgumentResolver;
 use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
+use Patchlevel\EventSourcing\Subscription\Subscriber\NoSuitableResolver;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
 use PHPUnit\Framework\TestCase;
 
 /** @covers \Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor */
@@ -68,9 +72,12 @@ final class MetadataSubscriberAccessorTest extends TestCase
     {
         $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
         class {
-            #[Subscribe(ProfileCreated::class)]
-            public function onProfileCreated(Message $message): void
+            public Message|null $message = null;
+
+            #[Subscribe(ProfileVisited::class)]
+            public function onProfileVisited(Message $message): void
             {
+                $this->message = $message;
             }
         };
 
@@ -82,11 +89,15 @@ final class MetadataSubscriberAccessorTest extends TestCase
             ],
         );
 
-        $result = $accessor->subscribeMethods(ProfileCreated::class);
+        $result = $accessor->subscribeMethods(ProfileVisited::class);
 
-        self::assertEquals([
-            $subscriber->onProfileCreated(...),
-        ], $result);
+        self::assertArrayHasKey(0, $result);
+
+        $message = new Message(new ProfileVisited(ProfileId::fromString('1')));
+
+        $result[0]($message);
+
+        self::assertSame($message, $subscriber->message);
     }
 
     public function testMultipleSubscribeMethod(): void
@@ -114,6 +125,8 @@ final class MetadataSubscriberAccessorTest extends TestCase
 
         $result = $accessor->subscribeMethods(ProfileCreated::class);
 
+        self::assertCount(2, $result);
+
         self::assertEquals([
             $subscriber->onProfileCreated(...),
             $subscriber->onFoo(...),
@@ -124,9 +137,12 @@ final class MetadataSubscriberAccessorTest extends TestCase
     {
         $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
         class {
+            public Message|null $message = null;
+
             #[Subscribe('*')]
-            public function onProfileCreated(Message $message): void
+            public function on(Message $message): void
             {
+                $this->message = $message;
             }
         };
 
@@ -138,11 +154,69 @@ final class MetadataSubscriberAccessorTest extends TestCase
             ],
         );
 
-        $result = $accessor->subscribeMethods(ProfileCreated::class);
+        $result = $accessor->subscribeMethods(ProfileVisited::class);
 
-        self::assertEquals([
-            $subscriber->onProfileCreated(...),
-        ], $result);
+        self::assertArrayHasKey(0, $result);
+
+        $message = new Message(new ProfileVisited(ProfileId::fromString('1')));
+
+        $result[0]($message);
+
+        self::assertSame($message, $subscriber->message);
+    }
+
+    public function testNoResolver(): void
+    {
+        $this->expectException(NoSuitableResolver::class);
+
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+            #[Subscribe(ProfileVisited::class)]
+            public function on(Message $message): void
+            {
+            }
+        };
+
+        $accessor = new MetadataSubscriberAccessor(
+            $subscriber,
+            (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [],
+        );
+
+        $accessor->subscribeMethods(ProfileVisited::class);
+    }
+
+    public function testMultipleResolver(): void
+    {
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+            public Message|null $message = null;
+
+            #[Subscribe(ProfileVisited::class)]
+            public function on(Message $message): void
+            {
+                $this->message = $message;
+            }
+        };
+
+        $accessor = new MetadataSubscriberAccessor(
+            $subscriber,
+            (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [
+                new EventArgumentResolver(),
+                new MessageArgumentResolver(),
+            ],
+        );
+
+        $result = $accessor->subscribeMethods(ProfileVisited::class);
+
+        self::assertArrayHasKey(0, $result);
+
+        $message = new Message(new ProfileVisited(ProfileId::fromString('1')));
+
+        $result[0]($message);
+
+        self::assertSame($message, $subscriber->message);
     }
 
     public function testSetupMethod(): void

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
@@ -11,6 +11,7 @@ use Patchlevel\EventSourcing\Attribute\Teardown;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\Subscriber\AttributeSubscriberMetadataFactory;
 use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\MessageArgumentResolver;
 use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use PHPUnit\Framework\TestCase;
@@ -27,6 +28,7 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [],
         );
 
         self::assertEquals('profile', $accessor->id());
@@ -41,6 +43,7 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [],
         );
 
         self::assertEquals('default', $accessor->group());
@@ -55,6 +58,7 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [],
         );
 
         self::assertEquals(RunMode::FromBeginning, $accessor->runMode());
@@ -73,6 +77,9 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [
+                new MessageArgumentResolver(),
+            ],
         );
 
         $result = $accessor->subscribeMethods(ProfileCreated::class);
@@ -100,6 +107,9 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [
+                new MessageArgumentResolver(),
+            ],
         );
 
         $result = $accessor->subscribeMethods(ProfileCreated::class);
@@ -123,6 +133,9 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [
+                new MessageArgumentResolver(),
+            ],
         );
 
         $result = $accessor->subscribeMethods(ProfileCreated::class);
@@ -145,6 +158,7 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [],
         );
 
         $result = $accessor->setupMethod();
@@ -161,6 +175,7 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [],
         );
 
         $result = $accessor->setupMethod();
@@ -181,6 +196,7 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [],
         );
 
         $result = $accessor->teardownMethod();
@@ -197,6 +213,7 @@ final class MetadataSubscriberAccessorTest extends TestCase
         $accessor = new MetadataSubscriberAccessor(
             $subscriber,
             (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
+            [],
         );
 
         $result = $accessor->teardownMethod();


### PR DESCRIPTION
Introduce an argument resolver in subscriber to improve DX.

It simplifies getting aggregateId, you don't have to know where you get it from.

Type analysis is supported. We have currently only solved this problem with a psalm plugin. But that doesn't help with phpstan and phpstorm. This solves this problem globally.

Before:

```php
    #[Subscribe(NameChanged::class)]
    public function onNameChanged(Message $message): void
    {
        $nameChanged = $message->event();

        assert($nameChanged instanceof NameChanged);

        $this->connection->update(
            $this->table(),
            ['name' => $nameChanged->name],
            ['id' => $message->header(AggregateHeader::class)->aggregateId],
        );
    }
```

After:

```php
    #[Subscribe(NameChanged::class)]
    public function onNameChanged(NameChanged $nameChanged, string $aggregateRootId): void
    {
        $this->connection->update(
            $this->table(),
            ['name' => $nameChanged->name],
            ['id' => $aggregateRootId],
        );
    }
```