### PR TITLE
improve aggregate id argument resolver

### DIFF
--- a/docs/pages/subscription.md
+++ b/docs/pages/subscription.md
@@ -165,6 +165,97 @@ final class DoStuffSubscriber
     If you are using psalm then you can install the event sourcing [plugin](https://github.com/patchlevel/event-sourcing-psalm-plugin) 
     to make the event method return the correct type.
     
+#### Argument Resolver
+
+The library analyses the method signature and tries to resolve the arguments.
+The order of the arguments doesn't matter, you can use multiple arguments and mix them.
+
+##### Message Resolver
+
+The message resolver resolves the `Message` object.
+It looks for a parameter with the type `Message`.
+
+```php
+use Patchlevel\EventSourcing\Attribute\Subscribe;
+use Patchlevel\EventSourcing\Attribute\Subscriber;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+
+#[Subscriber('do_stuff', RunMode::Once)]
+final class DoStuffSubscriber
+{
+    #[Subscribe(ProfileCreated::class)]
+    public function onProfileCreated(Message $message): void
+    {
+        // do something
+    }
+}
+```
+##### Event Resolver
+
+The event resolver resolves the event object.
+It looks for a parameter with the type of the event.
+
+```php
+use Patchlevel\EventSourcing\Attribute\Subscribe;
+use Patchlevel\EventSourcing\Attribute\Subscriber;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+
+#[Subscriber('do_stuff', RunMode::Once)]
+final class DoStuffSubscriber
+{
+    #[Subscribe(ProfileCreated::class)]
+    public function onProfileCreated(ProfileCreated $profileCreated): void
+    {
+        // do something
+    }
+}
+```
+##### Aggregate Id Resolver
+
+The aggregate id resolver resolves the aggregate id.
+It looks for a parameter with the instance of the `AggregateRootId`.
+
+```php
+use Patchlevel\EventSourcing\Attribute\Subscribe;
+use Patchlevel\EventSourcing\Attribute\Subscriber;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+
+#[Subscriber('do_stuff', RunMode::Once)]
+final class DoStuffSubscriber
+{
+    #[Subscribe(ProfileCreated::class)]
+    public function onProfileCreated(ProfileId $profileId): void
+    {
+        // do something
+    }
+}
+```
+!!! warning
+
+    The resolver argument doesn't know if you're using the correct aggregate id class and doesn't check it. 
+    It gets the Aggregate ID as a string, takes the class and instantiates it with the method `fromString`.
+    
+##### Recorded On Resolver
+
+The recorded on resolver resolves the recorded on date.
+It looks for a parameter with the instance of the `DateTimeImmutable`.
+
+```php
+use Patchlevel\EventSourcing\Attribute\Subscribe;
+use Patchlevel\EventSourcing\Attribute\Subscriber;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+
+#[Subscriber('do_stuff', RunMode::Once)]
+final class DoStuffSubscriber
+{
+    #[Subscribe(ProfileCreated::class)]
+    public function onProfileCreated(DateTimeImmutable $recordedOn): void
+    {
+        // do something
+    }
+}
+```
 ### Setup and Teardown
 
 Subscribers can have one `setup` and `teardown` method that is executed when the subscription is created or deleted.

--- a/src/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolver.php
+++ b/src/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolver.php
@@ -5,20 +5,27 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
+use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
 
-use function in_array;
+use function class_exists;
+use function is_a;
 
 final class AggregateIdArgumentResolver implements ArgumentResolver
 {
-    public function resolve(ArgumentMetadata $argument, Message $message): string
+    public function resolve(ArgumentMetadata $argument, Message $message): AggregateRootId
     {
-        return $message->header(AggregateHeader::class)->aggregateId;
+        /** @var class-string<AggregateRootId> $class */
+        $class = $argument->type;
+
+        $id = $message->header(AggregateHeader::class)->aggregateId;
+
+        return $class::fromString($id);
     }
 
     public function support(ArgumentMetadata $argument, string $eventClass): bool
     {
-        return $argument->type === 'string' && in_array($argument->name, ['aggregateId', 'aggregateRootId']);
+        return class_exists($argument->type) && is_a($argument->type, AggregateRootId::class, true);
     }
 }

--- a/tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
+++ b/tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
@@ -12,6 +12,7 @@ use Patchlevel\EventSourcing\Attribute\Teardown;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberUtil;
 use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\NameChanged;
 use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
 
 #[Projector('profile')]
 final class ProfileProjector
@@ -48,12 +49,12 @@ final class ProfileProjector
     }
 
     #[Subscribe(NameChanged::class)]
-    public function onNameChanged(NameChanged $nameChanged, string $aggregateRootId): void
+    public function onNameChanged(NameChanged $nameChanged, ProfileId $profileId): void
     {
         $this->connection->update(
             $this->table(),
             ['name' => $nameChanged->name],
-            ['id' => $aggregateRootId],
+            ['id' => $profileId->toString()],
         );
     }
 

--- a/tests/Integration/Subscription/Subscriber/ErrorProducerSubscriber.php
+++ b/tests/Integration/Subscription/Subscriber/ErrorProducerSubscriber.php
@@ -8,7 +8,6 @@ use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Subscriber;
 use Patchlevel\EventSourcing\Attribute\Teardown;
-use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Subscription\RunMode;
 use RuntimeException;
 
@@ -36,7 +35,7 @@ final class ErrorProducerSubscriber
     }
 
     #[Subscribe('*')]
-    public function subscribe(Message $message): void
+    public function subscribe(): void
     {
         if ($this->subscribeError) {
             throw new RuntimeException('subscribe error');

--- a/tests/Integration/Subscription/Subscriber/ProfileNewProjection.php
+++ b/tests/Integration/Subscription/Subscriber/ProfileNewProjection.php
@@ -10,11 +10,8 @@ use Patchlevel\EventSourcing\Attribute\Projector;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Teardown;
-use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberUtil;
 use Patchlevel\EventSourcing\Tests\Integration\Subscription\Events\ProfileCreated;
-
-use function assert;
 
 #[Projector('profile_2')]
 final class ProfileNewProjection
@@ -44,12 +41,8 @@ final class ProfileNewProjection
     }
 
     #[Subscribe(ProfileCreated::class)]
-    public function handleProfileCreated(Message $message): void
+    public function handleProfileCreated(ProfileCreated $profileCreated): void
     {
-        $profileCreated = $message->event();
-
-        assert($profileCreated instanceof ProfileCreated);
-
         $this->connection->executeStatement(
             'INSERT INTO ' . $this->tableName() . ' (id, firstname) VALUES(:id, :firstname);',
             [

--- a/tests/Integration/Subscription/Subscriber/ProfileProcessor.php
+++ b/tests/Integration/Subscription/Subscriber/ProfileProcessor.php
@@ -6,12 +6,9 @@ namespace Patchlevel\EventSourcing\Tests\Integration\Subscription\Subscriber;
 
 use Patchlevel\EventSourcing\Attribute\Processor;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
-use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Repository\RepositoryManager;
 use Patchlevel\EventSourcing\Tests\Integration\Subscription\Aggregate\Profile;
 use Patchlevel\EventSourcing\Tests\Integration\Subscription\Events\ProfileCreated;
-
-use function assert;
 
 #[Processor('profile')]
 final class ProfileProcessor
@@ -22,12 +19,8 @@ final class ProfileProcessor
     }
 
     #[Subscribe(ProfileCreated::class)]
-    public function handleProfileCreated(Message $message): void
+    public function handleProfileCreated(ProfileCreated $profileCreated): void
     {
-        $profileCreated = $message->event();
-
-        assert($profileCreated instanceof ProfileCreated);
-
         $repository = $this->repositoryManager->get(Profile::class);
 
         $profile = $repository->load($profileCreated->profileId);

--- a/tests/Integration/Subscription/Subscriber/ProfileProjection.php
+++ b/tests/Integration/Subscription/Subscriber/ProfileProjection.php
@@ -10,11 +10,8 @@ use Patchlevel\EventSourcing\Attribute\Projector;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Teardown;
-use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberUtil;
 use Patchlevel\EventSourcing\Tests\Integration\Subscription\Events\ProfileCreated;
-
-use function assert;
 
 #[Projector('profile_1')]
 final class ProfileProjection
@@ -44,12 +41,8 @@ final class ProfileProjection
     }
 
     #[Subscribe(ProfileCreated::class)]
-    public function handleProfileCreated(Message $message): void
+    public function handleProfileCreated(ProfileCreated $profileCreated): void
     {
-        $profileCreated = $message->event();
-
-        assert($profileCreated instanceof ProfileCreated);
-
         $this->connection->executeStatement(
             'INSERT INTO ' . $this->tableName() . ' (id, name) VALUES(:id, :name);',
             [

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolverTest.php
@@ -6,6 +6,8 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber\ArgumentRe
 
 use DateTimeImmutable;
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
+use Patchlevel\EventSourcing\Aggregate\CustomId;
+use Patchlevel\EventSourcing\Aggregate\Uuid;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
 use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\AggregateIdArgumentResolver;
@@ -23,21 +25,21 @@ final class AggregateIdArgumentResolverTest extends TestCase
 
         self::assertTrue(
             $resolver->support(
-                new ArgumentMetadata('aggregateId', 'string'),
+                new ArgumentMetadata('aggregateId', Uuid::class),
                 ProfileCreated::class,
             ),
         );
 
         self::assertTrue(
             $resolver->support(
-                new ArgumentMetadata('aggregateRootId', 'string'),
+                new ArgumentMetadata('aggregateRootId', ProfileId::class),
                 ProfileCreated::class,
             ),
         );
 
         self::assertFalse(
             $resolver->support(
-                new ArgumentMetadata('foo', 'string'),
+                new ArgumentMetadata('foo', ProfileCreated::class),
                 ProfileCreated::class,
             ),
         );
@@ -52,10 +54,10 @@ final class AggregateIdArgumentResolverTest extends TestCase
             new AggregateHeader('foo', 'bar', 1, new DateTimeImmutable()),
         );
 
-        self::assertSame(
-            'bar',
+        self::assertEquals(
+            new CustomId('bar'),
             $resolver->resolve(
-                new ArgumentMetadata('foo', 'string'),
+                new ArgumentMetadata('foo', CustomId::class),
                 $message,
             ),
         );


### PR DESCRIPTION
Aggregate ID resolver has been changed. Instead of a string you now get an AggregateID instance.
I also adapted the docs.