### PR TITLE
make aggregate id type configurable between uuid and string

### DIFF
--- a/docs/pages/aggregate_id.md
+++ b/docs/pages/aggregate_id.md
@@ -7,6 +7,12 @@ since only an aggregate-wide unique string is expected in the store.
 
 This library provides you with a few options for generating the id.
 
+!!! warning
+
+    Performance reasons, the default configuration of the store require an uuid string for `aggregate id`.
+    But technically, for the library, it can be any string.
+    If you want to use a custom id, you have to change the `aggregate_id_type` in the [store](store.md) configuration.
+    
 ## Uuid
 
 The easiest way is to use an `uuid` as an aggregate ID.
@@ -68,6 +74,12 @@ final class Profile extends BasicAggregateRoot
     private CustomId $id;
 }
 ```
+!!! warning
+
+    If you want to use a custom id that is not an uuid, 
+    you need to change the `aggregate_id_type` to `string` in the store configuration.
+    More information can be found [here](store.md).
+    
 !!! note
 
     If you want to use snapshots, then you have to make sure that the aggregate id are normalized. 

--- a/docs/pages/message_decorator.md
+++ b/docs/pages/message_decorator.md
@@ -99,7 +99,7 @@ final class OnSystemRecordedDecorator implements MessageDecorator
 ```
 !!! note
 
-    The Message is immutable, for more information look up [here](event_bus.md#message).
+    The Message is immutable, for more information look up [here](message.md).
     
 !!! tip
 

--- a/docs/pages/store.md
+++ b/docs/pages/store.md
@@ -5,7 +5,7 @@ Each message contains an event and the associated headers.
 
 !!! note
 
-    More information about the message can be found [here](event_bus.md).
+    More information about the message can be found [here](message.md).
     
 The store is optimized to efficiently store and load events for aggregates.
 We currently only offer one [doctrine dbal](https://www.doctrine-project.org/projects/dbal.html) store.
@@ -39,28 +39,33 @@ $store = new DoctrineDbalStore(
     $connection,
     DefaultEventSerializer::createFromPaths(['src/Event']),
     null,
-    'eventstore',
+    ['table_name' => 'eventstore'],
 );
 ```
 ## Schema
 
 The table structure of the `DoctrineDbalStore` looks like this:
 
-| Column           | Type     | Description                                      |
-|------------------|----------|--------------------------------------------------|
-| id               | bigint   | The index of the whole stream (autoincrement)    |
-| aggregate        | string   | The name of the aggregate                        |
-| aggregate_id     | string   | The id of the aggregate                          |
-| playhead         | int      | The current playhead of the aggregate            |
-| event            | string   | The name of the event                            |
-| payload          | json     | The payload of the event                         |
-| recorded_on      | datetime | The date when the event was recorded             |
-| new_stream_start | bool     | If the event is the first event of the aggregate |
-| archived         | bool     | If the event is archived                         |
-| custom_headers   | json     | Custom headers for the event                     |
+| Column           | Type        | Description                                      |
+|------------------|-------------|--------------------------------------------------|
+| id               | bigint      | The index of the whole stream (autoincrement)    |
+| aggregate        | string      | The name of the aggregate                        |
+| aggregate_id     | uuid/string | The id of the aggregate                          |
+| playhead         | int         | The current playhead of the aggregate            |
+| event            | string      | The name of the event                            |
+| payload          | json        | The payload of the event                         |
+| recorded_on      | datetime    | The date when the event was recorded             |
+| new_stream_start | bool        | If the event is the first event of the aggregate |
+| archived         | bool        | If the event is archived                         |
+| custom_headers   | json        | Custom headers for the event                     |
 
 With the help of the `SchemaDirector`, the database structure can be created, updated and deleted.
 
+!!! note
+
+    The default type of the `aggregate_id` column is `uuid` if the database supports it and `string` if not.
+    You can change the type with the `aggregate_id_type` to `string` if you want use custom id.
+    
 !!! tip
 
     You can also use doctrine [migration](migration.md) to create and keep your schema in sync.
@@ -280,7 +285,7 @@ foreach ($stream as $message) {
 ```
 !!! note
 
-    You can find more information about the `Message` object [here](event_bus.md).
+    You can find more information about the `Message` object [here](message.md).
     
 !!! warning
 

--- a/docs/pages/subscription.md
+++ b/docs/pages/subscription.md
@@ -125,10 +125,6 @@ final class WelcomeEmailProcessor
     }
 }
 ```
-!!! note
-
-    More about the processor can be found [here](processor.md).
-    
 ### Subscribe
 
 A subscriber (projector/processor) can subscribe any number of events.
@@ -155,16 +151,28 @@ final class DoStuffSubscriber
     }
 }
 ```
-!!! note
-
-    You can subscribe to multiple events on the same method or you can use "*" to subscribe to all events.
-    More about this can be found [here](./event_bus.md#listener).
-    
 !!! tip
 
     If you are using psalm then you can install the event sourcing [plugin](https://github.com/patchlevel/event-sourcing-psalm-plugin) 
     to make the event method return the correct type.
     
+### Subscribe all events
+
+If you want to subscribe on all events, you can pass `*` or `Subscribe::ALL` instead of the event class.
+
+```php
+use Patchlevel\EventSourcing\Attribute\Subscribe;
+use Patchlevel\EventSourcing\Message\Message;
+
+final class WelcomeSubscriber
+{
+    #[Subscribe('*')]
+    public function onProfileCreated(Message $message): void
+    {
+        echo 'Welcome!';
+    }
+}
+```
 #### Argument Resolver
 
 The library analyses the method signature and tries to resolve the arguments.

--- a/tests/Benchmark/PersonalDataBench.php
+++ b/tests/Benchmark/PersonalDataBench.php
@@ -6,7 +6,6 @@ namespace Patchlevel\EventSourcing\Tests\Benchmark;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
 use Patchlevel\EventSourcing\Cryptography\DoctrineCipherKeyStore;
-use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
 use Patchlevel\EventSourcing\Schema\ChainDoctrineSchemaConfigurator;
@@ -45,11 +44,6 @@ final class PersonalDataBench
                 [__DIR__ . '/BasicImplementation/Events'],
                 cryptographer: $cryptographer,
             ),
-            DefaultHeadersSerializer::createFromPaths([
-                __DIR__ . '/../../src',
-                __DIR__ . '/BasicImplementation/Events',
-            ]),
-            'eventstore',
         );
 
         $this->repository = new DefaultRepository($this->store, Profile::metadata());

--- a/tests/Benchmark/blackfire.php
+++ b/tests/Benchmark/blackfire.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\DriverManager;
-use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
@@ -28,11 +27,6 @@ $connection = DriverManager::getConnection([
 $store = new DoctrineDbalStore(
     $connection,
     DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
-    DefaultHeadersSerializer::createFromPaths([
-        __DIR__ . '/../../src',
-        __DIR__ . '/BasicImplementation/Events',
-    ]),
-    'eventstore',
 );
 
 $repository = new DefaultRepository($store, Profile::metadata());

--- a/tests/Integration/BankAccountSplitStream/AccountId.php
+++ b/tests/Integration/BankAccountSplitStream/AccountId.php
@@ -5,21 +5,9 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Integration\BankAccountSplitStream;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Aggregate\RamseyUuidBehaviour;
 
 final class AccountId implements AggregateRootId
 {
-    private function __construct(
-        private string $id,
-    ) {
-    }
-
-    public static function fromString(string $id): self
-    {
-        return new self($id);
-    }
-
-    public function toString(): string
-    {
-        return $this->id;
-    }
+    use RamseyUuidBehaviour;
 }

--- a/tests/Integration/BankAccountSplitStream/IntegrationTest.php
+++ b/tests/Integration/BankAccountSplitStream/IntegrationTest.php
@@ -75,7 +75,7 @@ final class IntegrationTest extends TestCase
         $engine->setup();
         $engine->boot();
 
-        $bankAccountId = AccountId::fromString('1');
+        $bankAccountId = AccountId::v7();
         $bankAccount = BankAccount::create($bankAccountId, 'John');
         $bankAccount->addBalance(100);
         $bankAccount->addBalance(500);
@@ -83,11 +83,14 @@ final class IntegrationTest extends TestCase
 
         $engine->run();
 
-        $result = $this->connection->fetchAssociative('SELECT * FROM projection_bank_account WHERE id = ?', ['1']);
+        $result = $this->connection->fetchAssociative(
+            'SELECT * FROM projection_bank_account WHERE id = ?',
+            [$bankAccountId->toString()],
+        );
 
         self::assertIsArray($result);
         self::assertArrayHasKey('id', $result);
-        self::assertSame('1', $result['id']);
+        self::assertSame($bankAccountId->toString(), $result['id']);
         self::assertSame('John', $result['name']);
         self::assertSame(600, $result['balance_in_cents']);
 
@@ -119,11 +122,14 @@ final class IntegrationTest extends TestCase
 
         $engine->run();
 
-        $result = $this->connection->fetchAssociative('SELECT * FROM projection_bank_account WHERE id = ?', ['1']);
+        $result = $this->connection->fetchAssociative(
+            'SELECT * FROM projection_bank_account WHERE id = ?',
+            [$bankAccountId->toString()],
+        );
 
         self::assertIsArray($result);
         self::assertArrayHasKey('id', $result);
-        self::assertSame('1', $result['id']);
+        self::assertSame($bankAccountId->toString(), $result['id']);
         self::assertSame('John', $result['name']);
         self::assertSame(800, $result['balance_in_cents']);
 

--- a/tests/Integration/BasicImplementation/BasicIntegrationTest.php
+++ b/tests/Integration/BasicImplementation/BasicIntegrationTest.php
@@ -79,17 +79,20 @@ final class BasicIntegrationTest extends TestCase
         $engine->setup();
         $engine->boot();
 
-        $profileId = ProfileId::fromString('1');
+        $profileId = ProfileId::v7();
         $profile = Profile::create($profileId, 'John');
         $repository->save($profile);
 
         $engine->run();
 
-        $result = $this->connection->fetchAssociative('SELECT * FROM projection_profile WHERE id = ?', ['1']);
+        $result = $this->connection->fetchAssociative(
+            'SELECT * FROM projection_profile WHERE id = ?',
+            [$profileId->toString()],
+        );
 
         self::assertIsArray($result);
         self::assertArrayHasKey('id', $result);
-        self::assertSame('1', $result['id']);
+        self::assertSame($profileId->toString(), $result['id']);
         self::assertSame('John', $result['name']);
 
         $manager = new DefaultRepositoryManager(
@@ -147,17 +150,20 @@ final class BasicIntegrationTest extends TestCase
         $engine->setup();
         $engine->boot();
 
-        $profileId = ProfileId::fromString('1');
+        $profileId = ProfileId::v7();
         $profile = Profile::create($profileId, 'John');
         $repository->save($profile);
 
         $engine->run();
 
-        $result = $this->connection->fetchAssociative('SELECT * FROM projection_profile WHERE id = ?', ['1']);
+        $result = $this->connection->fetchAssociative(
+            'SELECT * FROM projection_profile WHERE id = ?',
+            [$profileId->toString()],
+        );
 
         self::assertIsArray($result);
         self::assertArrayHasKey('id', $result);
-        self::assertSame('1', $result['id']);
+        self::assertSame($profileId->toString(), $result['id']);
         self::assertSame('John', $result['name']);
 
         $manager = new DefaultRepositoryManager(

--- a/tests/Integration/BasicImplementation/ProfileId.php
+++ b/tests/Integration/BasicImplementation/ProfileId.php
@@ -5,21 +5,9 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Aggregate\RamseyUuidBehaviour;
 
 final class ProfileId implements AggregateRootId
 {
-    private function __construct(
-        private string $id,
-    ) {
-    }
-
-    public static function fromString(string $id): self
-    {
-        return new self($id);
-    }
-
-    public function toString(): string
-    {
-        return $this->id;
-    }
+    use RamseyUuidBehaviour;
 }

--- a/tests/Integration/PersonalData/PersonalDataTest.php
+++ b/tests/Integration/PersonalData/PersonalDataTest.php
@@ -6,7 +6,6 @@ namespace Patchlevel\EventSourcing\Tests\Integration\PersonalData;
 
 use Doctrine\DBAL\Connection;
 use Patchlevel\EventSourcing\Cryptography\DoctrineCipherKeyStore;
-use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
 use Patchlevel\EventSourcing\Schema\ChainDoctrineSchemaConfigurator;
@@ -46,11 +45,6 @@ final class PersonalDataTest extends TestCase
         $store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events'], cryptographer: $cryptographer),
-            DefaultHeadersSerializer::createFromPaths([
-                __DIR__ . '/../../../src',
-                __DIR__,
-            ]),
-            'eventstore',
         );
 
         $manager = new DefaultRepositoryManager(
@@ -70,7 +64,7 @@ final class PersonalDataTest extends TestCase
 
         $schemaDirector->create();
 
-        $profileId = ProfileId::fromString('1');
+        $profileId = ProfileId::v7();
         $profile = Profile::create($profileId, 'John');
 
         $repository->save($profile);
@@ -104,11 +98,6 @@ final class PersonalDataTest extends TestCase
         $store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events'], cryptographer: $cryptographer),
-            DefaultHeadersSerializer::createFromPaths([
-                __DIR__ . '/../../../src',
-                __DIR__,
-            ]),
-            'eventstore',
         );
 
         $manager = new DefaultRepositoryManager(
@@ -137,7 +126,7 @@ final class PersonalDataTest extends TestCase
 
         $engine->setup(skipBooting: true);
 
-        $profileId = ProfileId::fromString('1');
+        $profileId = ProfileId::v7();
         $profile = Profile::create($profileId, 'John');
 
         $repository->save($profile);
@@ -184,11 +173,6 @@ final class PersonalDataTest extends TestCase
         $store = new DoctrineDbalStore(
             $this->connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/Events'], cryptographer: $cryptographer),
-            DefaultHeadersSerializer::createFromPaths([
-                __DIR__ . '/../../../src',
-                __DIR__,
-            ]),
-            'eventstore',
         );
 
         $snapshotAdapter = new InMemorySnapshotAdapter();
@@ -224,7 +208,7 @@ final class PersonalDataTest extends TestCase
 
         $engine->setup(skipBooting: true);
 
-        $profileId = ProfileId::fromString('1');
+        $profileId = ProfileId::v7();
         $profile = Profile::create($profileId, 'John');
         $profile->changeName('John 2');
 
@@ -238,7 +222,7 @@ final class PersonalDataTest extends TestCase
         self::assertSame(2, $profile->playhead());
         self::assertSame('John 2', $profile->name());
 
-        $cipherKeyStore->remove('1');
+        $cipherKeyStore->remove($profileId->toString());
 
         $profile = $repository->load($profileId);
 

--- a/tests/Integration/PersonalData/ProfileId.php
+++ b/tests/Integration/PersonalData/ProfileId.php
@@ -5,21 +5,9 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Integration\PersonalData;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Aggregate\RamseyUuidBehaviour;
 
 final class ProfileId implements AggregateRootId
 {
-    private function __construct(
-        private string $id,
-    ) {
-    }
-
-    public static function fromString(string $id): self
-    {
-        return new self($id);
-    }
-
-    public function toString(): string
-    {
-        return $this->id;
-    }
+    use RamseyUuidBehaviour;
 }

--- a/tests/Integration/Store/ProfileId.php
+++ b/tests/Integration/Store/ProfileId.php
@@ -5,20 +5,9 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Integration\Store;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Aggregate\RamseyUuidBehaviour;
 
 final class ProfileId implements AggregateRootId
 {
-    private function __construct(private string $id)
-    {
-    }
-
-    public static function fromString(string $id): self
-    {
-        return new self($id);
-    }
-
-    public function toString(): string
-    {
-        return $this->id;
-    }
+    use RamseyUuidBehaviour;
 }

--- a/tests/Integration/Store/StoreTest.php
+++ b/tests/Integration/Store/StoreTest.php
@@ -48,18 +48,20 @@ final class StoreTest extends TestCase
 
     public function testSave(): void
     {
+        $profileId = ProfileId::v7();
+
         $messages = [
-            Message::create(new ProfileCreated(ProfileId::fromString('test'), 'test'))
+            Message::create(new ProfileCreated($profileId, 'test'))
                 ->withHeader(new AggregateHeader(
                     'profile',
-                    'test',
+                    $profileId->toString(),
                     1,
                     new DateTimeImmutable('2020-01-01 00:00:00'),
                 )),
-            Message::create(new ProfileCreated(ProfileId::fromString('test'), 'test'))
+            Message::create(new ProfileCreated($profileId, 'test'))
                 ->withHeader(new AggregateHeader(
                     'profile',
-                    'test',
+                    $profileId->toString(),
                     2,
                     new DateTimeImmutable('2020-01-02 00:00:00'),
                 )),
@@ -74,30 +76,32 @@ final class StoreTest extends TestCase
 
         $result1 = $result[0];
 
-        self::assertEquals('test', $result1['aggregate_id']);
+        self::assertEquals($profileId->toString(), $result1['aggregate_id']);
         self::assertEquals('profile', $result1['aggregate']);
         self::assertEquals('1', $result1['playhead']);
         self::assertStringContainsString('2020-01-01 00:00:00', $result1['recorded_on']);
         self::assertEquals('profile.created', $result1['event']);
-        self::assertEquals(['profileId' => 'test', 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
 
         $result2 = $result[1];
 
-        self::assertEquals('test', $result2['aggregate_id']);
+        self::assertEquals($profileId->toString(), $result2['aggregate_id']);
         self::assertEquals('profile', $result2['aggregate']);
         self::assertEquals('2', $result2['playhead']);
         self::assertStringContainsString('2020-01-02 00:00:00', $result2['recorded_on']);
         self::assertEquals('profile.created', $result2['event']);
-        self::assertEquals(['profileId' => 'test', 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
     }
 
     public function testSave10000Messages(): void
     {
+        $profileId = ProfileId::v7();
+
         $messages = [];
 
         for ($i = 1; $i <= 10000; $i++) {
-            $messages[] = Message::create(new ProfileCreated(ProfileId::fromString('test'), 'test'))
-                ->withHeader(new AggregateHeader('profile', 'test', $i, new DateTimeImmutable('2020-01-01 00:00:00')));
+            $messages[] = Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new AggregateHeader('profile', $profileId->toString(), $i, new DateTimeImmutable('2020-01-01 00:00:00')));
         }
 
         $this->store->save(...$messages);
@@ -110,10 +114,12 @@ final class StoreTest extends TestCase
 
     public function testLoad(): void
     {
-        $message = Message::create(new ProfileCreated(ProfileId::fromString('test'), 'test'))
+        $profileId = ProfileId::v7();
+
+        $message = Message::create(new ProfileCreated($profileId, 'test'))
             ->withHeader(new AggregateHeader(
                 'profile',
-                'test',
+                $profileId->toString(),
                 1,
                 new DateTimeImmutable('2020-01-01 00:00:00'),
             ));

--- a/tests/Integration/Subscription/ProfileId.php
+++ b/tests/Integration/Subscription/ProfileId.php
@@ -5,21 +5,9 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Integration\Subscription;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Aggregate\RamseyUuidBehaviour;
 
 final class ProfileId implements AggregateRootId
 {
-    private function __construct(
-        private string $id,
-    ) {
-    }
-
-    public static function fromString(string $id): self
-    {
-        return new self($id);
-    }
-
-    public function toString(): string
-    {
-        return $this->id;
-    }
+    use RamseyUuidBehaviour;
 }

--- a/tests/Integration/Subscription/SubscriptionTest.php
+++ b/tests/Integration/Subscription/SubscriptionTest.php
@@ -127,7 +127,8 @@ final class SubscriptionTest extends TestCase
             $engine->subscriptions(),
         );
 
-        $profile = Profile::create(ProfileId::fromString('1'), 'John');
+        $profileId = ProfileId::v7();
+        $profile = Profile::create($profileId, 'John');
         $repository->save($profile);
 
         $result = $engine->run();
@@ -151,12 +152,12 @@ final class SubscriptionTest extends TestCase
 
         $result = $this->projectionConnection->fetchAssociative(
             'SELECT * FROM projection_profile_1 WHERE id = ?',
-            ['1'],
+            [$profileId->toString()],
         );
 
         self::assertIsArray($result);
         self::assertArrayHasKey('id', $result);
-        self::assertSame('1', $result['id']);
+        self::assertSame($profileId->toString(), $result['id']);
         self::assertSame('John', $result['name']);
 
         $result = $engine->remove();
@@ -238,7 +239,7 @@ final class SubscriptionTest extends TestCase
 
         $repository = $manager->get(Profile::class);
 
-        $profile = Profile::create(ProfileId::fromString('1'), 'John');
+        $profile = Profile::create(ProfileId::v7(), 'John');
         $repository->save($profile);
 
         $subscriber->subscribeError = true;
@@ -429,7 +430,7 @@ final class SubscriptionTest extends TestCase
             $engine->subscriptions(),
         );
 
-        $profile = Profile::create(ProfileId::fromString('1'), 'John');
+        $profile = Profile::create(ProfileId::v7(), 'John');
         $repository->save($profile);
 
         $engine->run();
@@ -521,7 +522,7 @@ final class SubscriptionTest extends TestCase
 
         // Run first version
 
-        $profile = Profile::create(ProfileId::fromString('1'), 'John');
+        $profile = Profile::create(ProfileId::v7(), 'John');
         $repository->save($profile);
 
         $firstEngine->run();
@@ -677,7 +678,7 @@ final class SubscriptionTest extends TestCase
 
         // Run first version
 
-        $profile = Profile::create(ProfileId::fromString('1'), 'John');
+        $profile = Profile::create(ProfileId::v7(), 'John');
         $repository->save($profile);
 
         $firstEngine->run();


### PR DESCRIPTION
In some cases it can make sense and because of BC to event sourcing v2, the aggregate id type must be configurable in the store. You can choose between `string` and `uuid`. Default will now be `uuid`.