### PR TITLE
move event bus dispatch outside of repository transaction

### DIFF
--- a/docs/pages/repository.md
+++ b/docs/pages/repository.md
@@ -38,7 +38,7 @@ $repository = $repositoryManager->get(Profile::class);
 ### Event Bus
 
 You can pass an event bus to the `DefaultRepositoryManager` to dispatch events synchronously.
-This is useful if you want to react to events in the same transaction.
+This will be done after the events are saved in the store outside the transaction.
 
 ```php
 use Patchlevel\EventSourcing\EventBus\DefaultEventBus;

--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -266,7 +266,6 @@ final class DefaultRepository implements Repository
                 }
 
                 $this->archive(...$messages);
-                $this->eventBus?->dispatch(...$messages);
             });
 
             $this->aggregateIsValid[$aggregate] = true;
@@ -283,6 +282,8 @@ final class DefaultRepository implements Repository
 
             throw $exception;
         }
+
+        $this->eventBus?->dispatch(...$messages);
     }
 
     /**


### PR DESCRIPTION
Event Bus dispatching was in the transaction because we implemented the outbox pattern. Since we now offer the subscription engine, we have removed the outbox. Therefore, the dispatch in a transaction is no longer necessary.

On the contrary: the transaction makes implementations more difficult. If an error occurs in the listener, the transaction would take effect and rollback. This means that actions that happened on the same connection will be rollback, but other actions such as sending emails and changes in mongodb / elastic search would remain as before. The transaction also prevents us from triggering the subscription engine synchronously.