### PR TITLE
Add RunSubscriptionEngineRepository

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -151,6 +151,7 @@ deptrac:
       - Clock
       - Message
       - MetadataSubscriber
+      - Repository
       - Schema
       - Store
     Repository:

--- a/src/Subscription/Engine/AlreadyProcessing.php
+++ b/src/Subscription/Engine/AlreadyProcessing.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Engine;
+
+use RuntimeException;
+
+final class AlreadyProcessing extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Subscription engine is already processing');
+    }
+}

--- a/src/Subscription/Engine/SubscriptionEngine.php
+++ b/src/Subscription/Engine/SubscriptionEngine.php
@@ -14,6 +14,7 @@ interface SubscriptionEngine
      * @param positive-int|null $limit
      *
      * @throws SubscriberNotFound
+     * @throws AlreadyProcessing
      */
     public function boot(
         SubscriptionEngineCriteria|null $criteria = null,
@@ -24,6 +25,7 @@ interface SubscriptionEngine
      * @param positive-int|null $limit
      *
      * @throws SubscriberNotFound
+     * @throws AlreadyProcessing
      */
     public function run(
         SubscriptionEngineCriteria|null $criteria = null,

--- a/src/Subscription/Repository/RunSubscriptionEngineRepository.php
+++ b/src/Subscription/Repository/RunSubscriptionEngineRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Repository;
+
+use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
+use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Subscription\Engine\AlreadyProcessing;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
+
+/**
+ * @template T of AggregateRoot
+ * @implements Repository<T>
+ */
+final class RunSubscriptionEngineRepository implements Repository
+{
+    /**
+     * @param Repository<T>     $repository
+     * @param list<string>|null $ids
+     * @param list<string>|null $groups
+     * @param positive-int|null $limit
+     */
+    public function __construct(
+        private readonly Repository $repository,
+        private readonly SubscriptionEngine $engine,
+        private readonly array|null $ids = null,
+        private readonly array|null $groups = null,
+        private readonly int|null $limit = null,
+    ) {
+    }
+
+    /** @return T */
+    public function load(AggregateRootId $id): AggregateRoot
+    {
+        return $this->repository->load($id);
+    }
+
+    public function has(AggregateRootId $id): bool
+    {
+        return $this->repository->has($id);
+    }
+
+    /** @param T $aggregate */
+    public function save(AggregateRoot $aggregate): void
+    {
+        $this->repository->save($aggregate);
+
+        try {
+            $this->engine->run(
+                new SubscriptionEngineCriteria(
+                    $this->ids,
+                    $this->groups,
+                ),
+                $this->limit,
+            );
+        } catch (AlreadyProcessing) {
+            // do nothing
+        }
+    }
+}

--- a/src/Subscription/Repository/RunSubscriptionEngineRepositoryManager.php
+++ b/src/Subscription/Repository/RunSubscriptionEngineRepositoryManager.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Subscription\Repository;
+
+use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
+use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\RepositoryManager;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+
+final class RunSubscriptionEngineRepositoryManager implements RepositoryManager
+{
+    /**
+     * @param list<string>|null $ids
+     * @param list<string>|null $groups
+     * @param positive-int|null $limit
+     */
+    public function __construct(
+        private readonly RepositoryManager $repositoryManager,
+        private readonly SubscriptionEngine $engine,
+        private readonly array|null $ids = null,
+        private readonly array|null $groups = null,
+        private readonly int|null $limit = null,
+    ) {
+    }
+
+    /**
+     * @param class-string<T> $aggregateClass
+     *
+     * @return Repository<T>
+     *
+     * @template T of AggregateRoot
+     */
+    public function get(string $aggregateClass): Repository
+    {
+        return new RunSubscriptionEngineRepository(
+            $this->repositoryManager->get($aggregateClass),
+            $this->engine,
+            $this->ids,
+            $this->groups,
+            $this->limit,
+        );
+    }
+}

--- a/tests/Integration/BasicImplementation/Processor/SendEmailProcessor.php
+++ b/tests/Integration/BasicImplementation/Processor/SendEmailProcessor.php
@@ -2,14 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Listener;
+namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Processor;
 
+use Patchlevel\EventSourcing\Attribute\Processor;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\SendEmailMock;
 
-final class SendEmailListener
+#[Processor('send_email')]
+final class SendEmailProcessor
 {
     #[Subscribe(ProfileCreated::class)]
     public function onProfileCreated(Message $message): void

--- a/tests/Unit/Subscription/DummySubscriptionStore.php
+++ b/tests/Unit/Subscription/DummySubscriptionStore.php
@@ -56,4 +56,11 @@ final class DummySubscriptionStore implements SubscriptionStore
         $this->parentStore->remove($subscription);
         $this->removedSubscriptions[] = clone $subscription;
     }
+
+    public function reset(): void
+    {
+        $this->addedSubscriptions = [];
+        $this->updatedSubscriptions = [];
+        $this->removedSubscriptions = [];
+    }
 }

--- a/tests/Unit/Subscription/Repository/RunSubscriptionEngineRepositoryManagerTest.php
+++ b/tests/Unit/Subscription/Repository/RunSubscriptionEngineRepositoryManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Repository;
+
+use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\RepositoryManager;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use Patchlevel\EventSourcing\Subscription\Repository\RunSubscriptionEngineRepositoryManager;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/** @covers \Patchlevel\EventSourcing\Subscription\Repository\RunSubscriptionEngineRepositoryManager */
+final class RunSubscriptionEngineRepositoryManagerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testGet(): void
+    {
+        $defaultRepository = $this->prophesize(Repository::class)->reveal();
+
+        $defaultRepositoryManager = $this->prophesize(RepositoryManager::class);
+        $defaultRepositoryManager->get(Profile::class)->willReturn($defaultRepository)->shouldBeCalledOnce();
+
+        $engine = $this->prophesize(SubscriptionEngine::class);
+
+        $repository = new RunSubscriptionEngineRepositoryManager(
+            $defaultRepositoryManager->reveal(),
+            $engine->reveal(),
+            ['id1', 'id2'],
+            ['group1', 'group2'],
+            42,
+        );
+
+        $repository->get(Profile::class);
+    }
+}

--- a/tests/Unit/Subscription/Repository/RunSubscriptionEngineRepositoryTest.php
+++ b/tests/Unit/Subscription/Repository/RunSubscriptionEngineRepositoryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Repository;
+
+use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Subscription\Engine\AlreadyProcessing;
+use Patchlevel\EventSourcing\Subscription\Engine\ProcessedResult;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
+use Patchlevel\EventSourcing\Subscription\Repository\RunSubscriptionEngineRepository;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/** @covers \Patchlevel\EventSourcing\Subscription\Repository\RunSubscriptionEngineRepository */
+final class RunSubscriptionEngineRepositoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testLoad(): void
+    {
+        $profileId = ProfileId::fromString('id1');
+
+        $aggregate = Profile::createProfile(
+            $profileId,
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $defaultRepository = $this->prophesize(Repository::class);
+        $defaultRepository->load($profileId)->willReturn($aggregate)->shouldBeCalledOnce();
+
+        $engine = $this->prophesize(SubscriptionEngine::class);
+
+        $repository = new RunSubscriptionEngineRepository(
+            $defaultRepository->reveal(),
+            $engine->reveal(),
+            ['id1', 'id2'],
+            ['group1', 'group2'],
+            42,
+        );
+
+        self::assertSame($aggregate, $repository->load($profileId));
+    }
+
+    public function testHas(): void
+    {
+        $profileId = ProfileId::fromString('id1');
+
+        $defaultRepository = $this->prophesize(Repository::class);
+        $defaultRepository->has($profileId)->willReturn(true)->shouldBeCalledOnce();
+
+        $engine = $this->prophesize(SubscriptionEngine::class);
+
+        $repository = new RunSubscriptionEngineRepository(
+            $defaultRepository->reveal(),
+            $engine->reveal(),
+            ['id1', 'id2'],
+            ['group1', 'group2'],
+            42,
+        );
+
+        self::assertSame(true, $repository->has($profileId));
+    }
+
+    public function testSave(): void
+    {
+        $criteria = new SubscriptionEngineCriteria(
+            ['id1', 'id2'],
+            ['group1', 'group2'],
+        );
+
+        $aggregate = Profile::createProfile(
+            ProfileId::fromString('id1'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $defaultRepository = $this->prophesize(Repository::class);
+        $defaultRepository->save($aggregate)->shouldBeCalledOnce();
+
+        $engine = $this->prophesize(SubscriptionEngine::class);
+        $engine->run($criteria, 42)->willReturn(new ProcessedResult(21))->shouldBeCalledOnce();
+
+        $repository = new RunSubscriptionEngineRepository(
+            $defaultRepository->reveal(),
+            $engine->reveal(),
+            ['id1', 'id2'],
+            ['group1', 'group2'],
+            42,
+        );
+
+        $repository->save($aggregate);
+    }
+
+    public function testSaveWithAlreadyProcessing(): void
+    {
+        $criteria = new SubscriptionEngineCriteria(
+            ['id1', 'id2'],
+            ['group1', 'group2'],
+        );
+
+        $aggregate = Profile::createProfile(
+            ProfileId::fromString('id1'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $defaultRepository = $this->prophesize(Repository::class);
+        $defaultRepository->save($aggregate)->shouldBeCalledOnce();
+
+        $engine = $this->prophesize(SubscriptionEngine::class);
+        $engine->run($criteria, 42)->willThrow(new AlreadyProcessing())->shouldBeCalledOnce();
+
+        $repository = new RunSubscriptionEngineRepository(
+            $defaultRepository->reveal(),
+            $engine->reveal(),
+            ['id1', 'id2'],
+            ['group1', 'group2'],
+            42,
+        );
+
+        $repository->save($aggregate);
+    }
+}


### PR DESCRIPTION
The repository decorator runs the subscription engine after an aggregate has been saved. This means that a Subscription Engine Worker does not necessarily have to be used for the projectors and processors to run. This should be used in combination with the CatchUpSubscriptionEngine decorator. And is highly recommended for development and testing.