### PR TITLE
fix finish flag in subscription engine

### DIFF
--- a/src/Console/Command/SubscriptionBootCommand.php
+++ b/src/Console/Command/SubscriptionBootCommand.php
@@ -86,7 +86,7 @@ final class SubscriptionBootCommand extends SubscriptionCommand
             function (Closure $stop) use ($criteria, $messageLimit, &$finished): void {
                 $result = $this->engine->boot($criteria, $messageLimit);
 
-                if (!$result->streamFinished) {
+                if (!$result->finished) {
                     return;
                 }
 

--- a/src/Subscription/Engine/CatchUpSubscriptionEngine.php
+++ b/src/Subscription/Engine/CatchUpSubscriptionEngine.php
@@ -89,18 +89,18 @@ final class CatchUpSubscriptionEngine implements SubscriptionEngine
     private function mergeResult(ProcessedResult ...$results): ProcessedResult
     {
         $processedMessages = 0;
-        $streamFinished = false;
+        $finished = false;
         $errors = [];
 
         foreach ($results as $result) {
             $processedMessages += $result->processedMessages;
-            $streamFinished = $result->streamFinished;
+            $finished = $result->finished;
             $errors[] = $result->errors;
         }
 
         return new ProcessedResult(
             $processedMessages,
-            $streamFinished,
+            $finished,
             array_merge(...$errors),
         );
     }

--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -168,7 +168,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
                     if (count($subscriptions) === 0) {
                         $this->logger?->info('Subscription Engine: No subscriptions in booting status, finish booting.');
 
-                        return new ProcessedResult(0);
+                        return new ProcessedResult(0, true);
                     }
 
                     /** @var list<Error> $errors */
@@ -334,7 +334,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
                     if (count($subscriptions) === 0) {
                         $this->logger?->info('Subscription Engine: No subscriptions to process, finish processing.');
 
-                        return new ProcessedResult(0);
+                        return new ProcessedResult(0, true);
                     }
 
                     /** @var list<Error> $errors */

--- a/src/Subscription/Engine/ProcessedResult.php
+++ b/src/Subscription/Engine/ProcessedResult.php
@@ -9,7 +9,7 @@ final class ProcessedResult
     /** @param list<Error> $errors */
     public function __construct(
         public readonly int $processedMessages,
-        public readonly bool $streamFinished = false,
+        public readonly bool $finished = false,
         public readonly array $errors = [],
     ) {
     }

--- a/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
@@ -367,7 +367,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot();
 
         self::assertEquals(0, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([], $store->addedSubscriptions);
@@ -396,7 +396,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot();
 
         self::assertEquals(0, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -449,7 +449,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot();
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([], $subscriptionStore->addedSubscriptions);
@@ -515,7 +515,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot();
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertCount(1, $result->errors);
 
         $error = $result->errors[0];
@@ -581,7 +581,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot(new SubscriptionEngineCriteria(), 1);
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(false, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([], $subscriptionStore->addedSubscriptions);
@@ -656,7 +656,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot();
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -734,7 +734,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot();
 
         self::assertEquals(2, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -795,7 +795,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot();
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -900,7 +900,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot(limit: 1);
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(false, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([], $subscriptionStore->addedSubscriptions);
@@ -921,7 +921,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->boot();
 
         self::assertEquals(0, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -955,7 +955,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(0, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -1006,7 +1006,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -1064,7 +1064,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run(new SubscriptionEngineCriteria(), 1);
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(false, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -1137,7 +1137,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -1202,7 +1202,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertCount(1, $result->errors);
 
         $error = $result->errors[0];
@@ -1256,7 +1256,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(0, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -1296,7 +1296,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(0, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([], $subscriptionStore->updatedSubscriptions);
@@ -1342,7 +1342,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(2, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -1396,7 +1396,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([
@@ -1501,7 +1501,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run(limit: 1);
 
         self::assertEquals(1, $result->processedMessages);
-        self::assertEquals(false, $result->streamFinished);
+        self::assertEquals(false, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([], $subscriptionStore->addedSubscriptions);
@@ -1522,7 +1522,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
         $result = $engine->run();
 
         self::assertEquals(0, $result->processedMessages);
-        self::assertEquals(true, $result->streamFinished);
+        self::assertEquals(true, $result->finished);
         self::assertEquals([], $result->errors);
 
         self::assertEquals([], $subscriptionStore->updatedSubscriptions);


### PR DESCRIPTION
The flag is there to identify whether work still exists. "No subscriptions" was incorrectly marked as not finished because the flag was just named "streamFinished". I renamed the flag and included this case as "finished".

Otherwise you would have an endless loop in the boot because there was nothing to boot, but it wasn't set to finished either.