### PR TITLE
POC: allow to buffer messages in save

### DIFF
--- a/tests/Benchmark/SimpleSetupBench.php
+++ b/tests/Benchmark/SimpleSetupBench.php
@@ -32,6 +32,8 @@ final class SimpleSetupBench
         $this->store = new DoctrineDbalStore(
             $connection,
             DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
+            null,
+            ['buffer_messages' => true],
         );
 
         $this->repository = new DefaultRepository($this->store, Profile::metadata());


### PR DESCRIPTION
Storing 10k aggregates takes 8 seconds, which is very long. 
As a proof of concept, I added a flag, which buffers messages and may solve the problem if you use transactions.