### PR TITLE
direct activate "from now" subscriptions without "setup" method

### DIFF
--- a/tests/Integration/Subscription/SubscriptionTest.php
+++ b/tests/Integration/Subscription/SubscriptionTest.php
@@ -408,21 +408,6 @@ final class SubscriptionTest extends TestCase
                     'profile',
                     'processor',
                     RunMode::FromNow,
-                    lastSavedAt: new DateTimeImmutable('2021-01-01T00:00:00'),
-                ),
-            ],
-            $engine->subscriptions(),
-        );
-
-        $engine->setup();
-        $engine->boot();
-
-        self::assertEquals(
-            [
-                new Subscription(
-                    'profile',
-                    'processor',
-                    RunMode::FromNow,
                     Status::Active,
                     lastSavedAt: new DateTimeImmutable('2021-01-01T00:00:00'),
                 ),


### PR DESCRIPTION
When you create processors, thus "from now" subscriptions, you don't understand that you also have to run `$engine->setup()` for these subscriptions. Especially if the subscriber doesn't have a setup method.

Since nothing has to be set up nor the entire stream has to be processed from the beginning, you can set this subscription directly to active without having a negative impact.