### PR TITLE
use transaction id to not lose events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ phpstan.neon
 infection.log
 .phpbench/
 infection.html
-*.sqlite3
+*.sqlite*
 .deptrac.cache
 docs_php/

--- a/src/Store/Criteria/FromIndexWithTransactionIdCriterion.php
+++ b/src/Store/Criteria/FromIndexWithTransactionIdCriterion.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store\Criteria;
+
+final class FromIndexWithTransactionIdCriterion
+{
+    public function __construct(
+        public readonly int $fromIndex,
+        public readonly int $transactionId,
+    ) {
+    }
+}

--- a/src/Store/DoctrineDbalStoreStream.php
+++ b/src/Store/DoctrineDbalStoreStream.php
@@ -140,6 +140,10 @@ final class DoctrineDbalStoreStream implements Stream, IteratorAggregate
                 $message = $message->withHeader(new StreamStartHeader());
             }
 
+            if (isset($data['transaction_id'])) {
+                $message = $message->withHeader(new TransactionIdHeader((int)$data['transaction_id']));
+            }
+
             $customHeaders = $headersSerializer->deserialize($data['custom_headers']);
 
             yield $message->withHeaders($customHeaders);

--- a/src/Store/PostgresXid8Type.php
+++ b/src/Store/PostgresXid8Type.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+final class PostgresXid8Type extends Type
+{
+    /** @param array<string, mixed> $column */
+    public function getSQLDeclaration(array $column, AbstractPlatform $platform): string
+    {
+        return 'xid8';
+    }
+}

--- a/src/Store/TransactionIdHeader.php
+++ b/src/Store/TransactionIdHeader.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+/** @psalm-immutable */
+final class TransactionIdHeader
+{
+    public function __construct(
+        public readonly int $transactionId,
+    ) {
+    }
+}

--- a/src/Subscription/Subscription.php
+++ b/src/Subscription/Subscription.php
@@ -20,6 +20,7 @@ final class Subscription
         private SubscriptionError|null $error = null,
         private int $retryAttempt = 0,
         private DateTimeImmutable|null $lastSavedAt = null,
+        private int|null $transactionId = null,
     ) {
     }
 
@@ -48,6 +49,11 @@ final class Subscription
         return $this->position;
     }
 
+    public function transactionId(): int|null
+    {
+        return $this->transactionId;
+    }
+
     public function subscriptionError(): SubscriptionError|null
     {
         return $this->error;
@@ -56,6 +62,11 @@ final class Subscription
     public function changePosition(int $position): void
     {
         $this->position = $position;
+    }
+
+    public function changeTransactionId(int $transactionId): void
+    {
+        $this->transactionId = $transactionId;
     }
 
     public function new(): void

--- a/tests/DbalManager.php
+++ b/tests/DbalManager.php
@@ -19,7 +19,7 @@ final class DbalManager
 {
     public const DEFAULT_DB_NAME = 'eventstore';
 
-    public static function createConnection(string $dbName = self::DEFAULT_DB_NAME): Connection
+    public static function createConnection(string $dbName = self::DEFAULT_DB_NAME, bool $reset = true): Connection
     {
         $dbUrl = getenv('DB_URL');
 
@@ -36,6 +36,10 @@ final class DbalManager
         $connection = DriverManager::getConnection($connectionParams);
 
         if ($connection->getDriver() instanceof AbstractSQLiteDriver) {
+            return $connection;
+        }
+
+        if (!$reset) {
             return $connection;
         }
 


### PR DESCRIPTION
try to fix https://github.com/patchlevel/event-sourcing/issues/615

Implementation of:

* https://event-driven.io/en/ordering_in_postgres_outbox/
* https://github.com/eugene-khyst/postgresql-event-sourcing