### PR TITLE
Add support for iterators when configuring ArgumentResolvers

### DIFF
--- a/src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php
@@ -26,7 +26,7 @@ final class MetadataSubscriberAccessorRepository implements SubscriberAccessorRe
 
     /**
      * @param iterable<object>       $subscribers
-     * @param list<ArgumentResolver> $argumentResolvers
+     * @param iterable<ArgumentResolver>|list<ArgumentResolver> $argumentResolvers
      */
     public function __construct(
         private readonly iterable $subscribers,
@@ -35,7 +35,7 @@ final class MetadataSubscriberAccessorRepository implements SubscriberAccessorRe
     ) {
         $this->argumentResolvers = array_merge(
         // the check for array is required before PHP 8.2
-            is_array($argumentResolvers) ? $argumentResolvers : iterator_to_array($argumentResolvers),
+            array_values(is_array($argumentResolvers) ? $argumentResolvers : iterator_to_array($argumentResolvers)),
             [
                 new MessageArgumentResolver(),
                 new EventArgumentResolver(),

--- a/src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php
@@ -15,6 +15,8 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\RecordedOn
 use function array_key_exists;
 use function array_merge;
 use function array_values;
+use function is_array;
+use function iterator_to_array;
 
 final class MetadataSubscriberAccessorRepository implements SubscriberAccessorRepository
 {
@@ -25,7 +27,7 @@ final class MetadataSubscriberAccessorRepository implements SubscriberAccessorRe
     private readonly array $argumentResolvers;
 
     /**
-     * @param iterable<object>       $subscribers
+     * @param iterable<object>                                  $subscribers
      * @param iterable<ArgumentResolver>|list<ArgumentResolver> $argumentResolvers
      */
     public function __construct(

--- a/src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php
@@ -31,10 +31,11 @@ final class MetadataSubscriberAccessorRepository implements SubscriberAccessorRe
     public function __construct(
         private readonly iterable $subscribers,
         private readonly SubscriberMetadataFactory $metadataFactory = new AttributeSubscriberMetadataFactory(),
-        array $argumentResolvers = [],
+        iterable $argumentResolvers = [],
     ) {
         $this->argumentResolvers = array_merge(
-            $argumentResolvers,
+        // the check for array is required before PHP 8.2
+            is_array($argumentResolvers) ? $argumentResolvers : iterator_to_array($argumentResolvers),
             [
                 new MessageArgumentResolver(),
                 new EventArgumentResolver(),

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php
@@ -69,6 +69,35 @@ final class MetadataSubscriberAccessorRepositoryTest extends TestCase
         self::assertEquals($accessor, $repository->get('foo'));
     }
 
+    public function testArgumentResolversCanBeArraysAndIterators(): void
+    {
+        $customResolver = new class implements ArgumentResolver\ArgumentResolver {
+            public function resolve(ArgumentMetadata $argument, Message $message): mixed
+            {
+                return null;
+            }
+
+            public function support(ArgumentMetadata $argument, string $eventClass): bool
+            {
+                return false;
+            }
+        };
+
+        $repository = new MetadataSubscriberAccessorRepository(
+            [],
+            new AttributeSubscriberMetadataFactory(),
+            [$customResolver],
+        );
+
+        $repository2 = new MetadataSubscriberAccessorRepository(
+            [],
+            new AttributeSubscriberMetadataFactory(),
+            new \ArrayIterator([$customResolver]),
+        );
+
+        self::assertEquals($repository, $repository2);
+    }
+
     public function testDuplicateSubscriberId(): void
     {
         $this->expectException(DuplicateSubscriberId::class);

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber;
 
+use ArrayIterator;
 use Patchlevel\EventSourcing\Attribute\Subscriber;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
@@ -92,7 +93,7 @@ final class MetadataSubscriberAccessorRepositoryTest extends TestCase
         $repository2 = new MetadataSubscriberAccessorRepository(
             [],
             new AttributeSubscriberMetadataFactory(),
-            new \ArrayIterator([$customResolver]),
+            new ArrayIterator([$customResolver]),
         );
 
         self::assertEquals($repository, $repository2);


### PR DESCRIPTION
This is required for the bundle to be able to use tagged_iterator for auto configuring ArgumentResolvers
