### PR TITLE
Throw on duplicate name in aggregate and event registry

### DIFF
--- a/src/Metadata/AggregateRoot/AggregateRootAlreadyInRegistry.php
+++ b/src/Metadata/AggregateRoot/AggregateRootAlreadyInRegistry.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Metadata\AggregateRoot;
+
+use Patchlevel\EventSourcing\Metadata\MetadataException;
+
+use function sprintf;
+
+final class AggregateRootAlreadyInRegistry extends MetadataException
+{
+    public function __construct(string $aggregateName)
+    {
+        parent::__construct(sprintf(
+            'The aggregate name "%s" is already used in the registry. Maybe you defined 2 Aggregates with the same name.',
+            $aggregateName,
+        ));
+    }
+}

--- a/src/Metadata/AggregateRoot/AggregateRootAlreadyInRegistry.php
+++ b/src/Metadata/AggregateRoot/AggregateRootAlreadyInRegistry.php
@@ -13,7 +13,7 @@ final class AggregateRootAlreadyInRegistry extends MetadataException
     public function __construct(string $aggregateName)
     {
         parent::__construct(sprintf(
-            'The aggregate name "%s" is already used in the registry. Maybe you defined 2 Aggregates with the same name.',
+            'The aggregate name "%s" is already used in the registry. Maybe you defined 2 aggregates with the same name.',
             $aggregateName,
         ));
     }

--- a/src/Metadata/AggregateRoot/AttributeAggregateRootRegistryFactory.php
+++ b/src/Metadata/AggregateRoot/AttributeAggregateRootRegistryFactory.php
@@ -9,6 +9,7 @@ use Patchlevel\EventSourcing\Attribute\Aggregate;
 use Patchlevel\EventSourcing\Metadata\ClassFinder;
 use ReflectionClass;
 
+use function array_key_exists;
 use function count;
 use function is_subclass_of;
 
@@ -34,6 +35,10 @@ final class AttributeAggregateRootRegistryFactory implements AggregateRootRegist
             }
 
             $aggregateName = $attributes[0]->newInstance()->name;
+
+            if (array_key_exists($aggregateName, $result)) {
+                throw new AggregateRootAlreadyInRegistry($aggregateName);
+            }
 
             $result[$aggregateName] = $class;
         }

--- a/src/Metadata/Event/AttributeEventRegistryFactory.php
+++ b/src/Metadata/Event/AttributeEventRegistryFactory.php
@@ -8,6 +8,7 @@ use Patchlevel\EventSourcing\Attribute\Event;
 use Patchlevel\EventSourcing\Metadata\ClassFinder;
 use ReflectionClass;
 
+use function array_key_exists;
 use function count;
 
 final class AttributeEventRegistryFactory implements EventRegistryFactory
@@ -28,6 +29,10 @@ final class AttributeEventRegistryFactory implements EventRegistryFactory
             }
 
             $eventName = $attributes[0]->newInstance()->name;
+
+            if (array_key_exists($eventName, $result)) {
+                throw new EventAlreadyInRegistry($eventName);
+            }
 
             $result[$eventName] = $class;
         }

--- a/src/Metadata/Event/EventAlreadyInRegistry.php
+++ b/src/Metadata/Event/EventAlreadyInRegistry.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\MetadataException;
+
+use function sprintf;
+
+final class EventAlreadyInRegistry extends MetadataException
+{
+    public function __construct(string $eventName)
+    {
+        parent::__construct(sprintf(
+            'The event name "%s" is already used in the registry. Maybe you defined 2 events with the same name.',
+            $eventName,
+        ));
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AttributeAggregateRootRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/AttributeAggregateRootRegistryFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
 
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootAlreadyInRegistry;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Message;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
@@ -21,5 +22,14 @@ final class AttributeAggregateRootRegistryFactoryTest extends TestCase
         self::assertTrue($registry->hasAggregateName('profile'));
 
         self::assertFalse($registry->hasAggregateClass(Message::class));
+    }
+
+    public function testCreateRegistryWithDuplicateEventName(): void
+    {
+        $this->expectException(AggregateRootAlreadyInRegistry::class);
+        $this->expectExceptionMessage('The aggregate name "profile" is already used in the registry. Maybe you defined 2 aggregates with the same name.');
+
+        $factory = new AttributeAggregateRootRegistryFactory();
+        $factory->create([__DIR__ . '/Fixture']);
     }
 }

--- a/tests/Unit/Metadata/Aggregate/Fixture/Profile.php
+++ b/tests/Unit/Metadata/Aggregate/Fixture/Profile.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+
+#[Aggregate('profile')]
+final class Profile extends BasicAggregateRoot
+{
+}

--- a/tests/Unit/Metadata/Aggregate/Fixture/Profile2.php
+++ b/tests/Unit/Metadata/Aggregate/Fixture/Profile2.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+
+#[Aggregate('profile')]
+final class Profile2 extends BasicAggregateRoot
+{
+}

--- a/tests/Unit/Metadata/Event/AttributeEventRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Event/AttributeEventRegistryFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
 
 use Patchlevel\EventSourcing\Metadata\Event\AttributeEventRegistryFactory;
+use Patchlevel\EventSourcing\Metadata\Event\EventAlreadyInRegistry;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Message;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use PHPUnit\Framework\TestCase;
@@ -19,5 +20,14 @@ final class AttributeEventRegistryFactoryTest extends TestCase
 
         self::assertTrue($registry->hasEventClass(ProfileCreated::class));
         self::assertFalse($registry->hasEventClass(Message::class));
+    }
+
+    public function testCreateRegistryWithDuplicateEventName(): void
+    {
+        $this->expectException(EventAlreadyInRegistry::class);
+        $this->expectExceptionMessage('The event name "email_changed" is already used in the registry. Maybe you defined 2 events with the same name.');
+
+        $factory = new AttributeEventRegistryFactory();
+        $factory->create([__DIR__ . '/Fixture']);
     }
 }

--- a/tests/Unit/Metadata/Event/Fixture/EmailChanged.php
+++ b/tests/Unit/Metadata/Event/Fixture/EmailChanged.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event\Fixture;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+
+#[Event('email_changed')]
+final class EmailChanged
+{
+    public function __construct(
+        public string $id,
+        public string $email,
+    ) {
+    }
+}

--- a/tests/Unit/Metadata/Event/Fixture/EmailChanged2.php
+++ b/tests/Unit/Metadata/Event/Fixture/EmailChanged2.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event\Fixture;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+
+#[Event('email_changed')]
+final class EmailChanged2
+{
+    public function __construct(
+        public string $id,
+        public string $email,
+    ) {
+    }
+}


### PR DESCRIPTION
This will prevent configuration errors. Right now, we just take the last found Aggregate but imho we should throw since the name must be unique and this can not be the desired behaviour for our users.