### PR TITLE
[Experimental] Stream Store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,16 @@ test: phpunit                                                                   
 benchmark: vendor                                                               ## run benchmarks
 	DB_URL=sqlite3:///:memory: vendor/bin/phpbench run tests/Benchmark --report=default
 
-.PHONY: benchmark-diff-test
-benchmark-diff-test: vendor                                                   	## run benchmarks
+.PHONY: benchmark-base
+benchmark-base: vendor                                                   	## run benchmarks
 	DB_URL=sqlite3:///:memory: vendor/bin/phpbench run tests/Benchmark --revs=1 --report=default --progress=none --tag=base
+
+.PHONY: benchmark-diff
+benchmark-diff: vendor                                                   	## run benchmarks
 	DB_URL=sqlite3:///:memory: vendor/bin/phpbench run tests/Benchmark --revs=1 --report=diff --progress=none --ref=base
+
+.PHONY: benchmark-diff-test
+benchmark-diff-test: benchmark-base benchmark-diff                                                	## run benchmarks
 
 .PHONY: dev
 dev: static test                                                                ## run dev tools

--- a/baseline.xml
+++ b/baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="src/Aggregate/AggregateRootBehaviour.php">
     <UnsafeInstantiation>
       <code><![CDATA[new static()]]></code>
@@ -86,6 +86,11 @@
       <code><![CDATA[$dateTimeType->convertToPHPValue($data['recorded_on'], $platform)]]></code>
     </MixedArgument>
   </file>
+  <file src="src/Store/StreamDoctrineDbalStoreStream.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$data['playhead'] === null ? null : (int)$data['playhead']]]></code>
+    </ArgumentTypeCoercion>
+  </file>
   <file src="src/Subscription/Store/DoctrineSubscriptionStore.php">
     <MixedArgument>
       <code><![CDATA[$context]]></code>
@@ -124,6 +129,14 @@
     </MissingConstructor>
   </file>
   <file src="tests/Benchmark/SimpleSetupBench.php">
+    <MissingConstructor>
+      <code><![CDATA[$multipleEventsId]]></code>
+      <code><![CDATA[$repository]]></code>
+      <code><![CDATA[$singleEventId]]></code>
+      <code><![CDATA[$store]]></code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Benchmark/SimpleSetupStreamStoreBench.php">
     <MissingConstructor>
       <code><![CDATA[$multipleEventsId]]></code>
       <code><![CDATA[$repository]]></code>

--- a/baseline.xml
+++ b/baseline.xml
@@ -378,6 +378,16 @@
             'FOR UPDATE',
             'SKIP LOCKED',
         )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
     </InternalMethod>
   </file>
   <file src="tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php">

--- a/baseline.xml
+++ b/baseline.xml
@@ -333,6 +333,53 @@
         )]]></code>
     </InternalMethod>
   </file>
+  <file src="tests/Unit/Store/StreamDoctrineDbalStoreTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[addMethods]]></code>
+    </DeprecatedMethod>
+    <InternalMethod>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+      <code><![CDATA[new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        )]]></code>
+    </InternalMethod>
+  </file>
   <file src="tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php">
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$update1]]></code>

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -92,6 +92,10 @@ deptrac:
       collectors:
         - type: directory
           value: src/Subscription/.*
+    - name: Test
+      collectors:
+        - type: directory
+          value: src/Test/.*
 
   ruleset:
     Aggregate:
@@ -175,6 +179,7 @@ deptrac:
     Store:
       - Aggregate
       - Attribute
+      - Clock
       - Message
       - Metadata
       - Schema

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -184,3 +184,4 @@ deptrac:
       - Metadata
       - Schema
       - Serializer
+    Test:

--- a/phpbench.json
+++ b/phpbench.json
@@ -43,7 +43,7 @@
                   "partition": "subject_name",
                   "cols":
                   {
-                    "time-diff": "percent_diff(partition['result_time_avg'][1], partition['result_time_avg'][0])"
+                    "time-diff": "percent_diff(coalesce(partition['result_time_avg']?[1], 0), coalesce(partition['result_time_avg']?[0], 0))"
                   }
                 },
                 "memory":
@@ -61,7 +61,7 @@
                   "partition": "subject_name",
                   "cols":
                   {
-                    "memory-diff": "percent_diff(partition['result_mem_peak'][1], partition['result_mem_peak'][0])"
+                    "memory-diff": "percent_diff(coalesce(partition['result_mem_peak']?[1], 0), coalesce(partition['result_mem_peak']?[0], 0))"
                   }
                 }
               }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,6 +51,16 @@ parameters:
 			path: src/Store/DoctrineDbalStoreStream.php
 
 		-
+			message: "#^Parameter \\#2 \\$playhead of class Patchlevel\\\\EventSourcing\\\\Store\\\\StreamHeader constructor expects int\\<1, max\\>\\|null, int\\|null given\\.$#"
+			count: 1
+			path: src/Store/StreamDoctrineDbalStoreStream.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: src/Store/StreamDoctrineDbalStoreStream.php
+
+		-
 			message: "#^Parameter \\#3 \\$errorContext of class Patchlevel\\\\EventSourcing\\\\Subscription\\\\SubscriptionError constructor expects array\\<int, array\\{class\\: class\\-string, message\\: string, code\\: int\\|string, file\\: string, line\\: int, trace\\: array\\<int, array\\{file\\?\\: string, line\\?\\: int, function\\?\\: string, class\\?\\: string, type\\?\\: string, args\\?\\: array\\}\\>\\}\\>\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Subscription/Store/DoctrineSubscriptionStore.php

--- a/src/Aggregate/AggregateHeader.php
+++ b/src/Aggregate/AggregateHeader.php
@@ -19,4 +19,9 @@ final class AggregateHeader
         public readonly DateTimeImmutable $recordedOn,
     ) {
     }
+
+    public function streamName(): string
+    {
+        return StreamNameTranslator::streamName($this->aggregateName, $this->aggregateId);
+    }
 }

--- a/src/Aggregate/InvalidAggregateStreamName.php
+++ b/src/Aggregate/InvalidAggregateStreamName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Aggregate;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class InvalidAggregateStreamName extends RuntimeException
+{
+    public function __construct(string $stream)
+    {
+        parent::__construct(sprintf('Invalid aggregate stream name "%s". Expected format is "[aggregateName]-[aggregateId]".', $stream));
+    }
+}

--- a/src/Aggregate/InvalidAggregateStreamName.php
+++ b/src/Aggregate/InvalidAggregateStreamName.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 use function sprintf;
 
+/** @experimental */
 final class InvalidAggregateStreamName extends RuntimeException
 {
     public function __construct(string $stream)

--- a/src/Aggregate/StreamNameTranslator.php
+++ b/src/Aggregate/StreamNameTranslator.php
@@ -14,6 +14,7 @@ final class StreamNameTranslator
     {
     }
 
+    /** @pure */
     public static function streamName(string $aggregate, string $aggregateId): string
     {
         return $aggregate . '-' . $aggregateId;

--- a/src/Aggregate/StreamNameTranslator.php
+++ b/src/Aggregate/StreamNameTranslator.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\Aggregate;
 use function strpos;
 use function substr;
 
+/** @experimental */
 final class StreamNameTranslator
 {
     private function __construct()

--- a/src/Aggregate/StreamNameTranslator.php
+++ b/src/Aggregate/StreamNameTranslator.php
@@ -20,11 +20,23 @@ final class StreamNameTranslator
 
     public static function aggregateName(string $stream): string
     {
-        return substr($stream, 0, strpos($stream, '-'));
+        $pos = strpos($stream, '-');
+
+        if ($pos === false) {
+            throw new InvalidAggregateStreamName($stream);
+        }
+
+        return substr($stream, 0, $pos);
     }
 
     public static function aggregateId(string $stream): string
     {
-        return substr($stream, strpos($stream, '-') + 1);
+        $pos = strpos($stream, '-');
+
+        if ($pos === false) {
+            throw new InvalidAggregateStreamName($stream);
+        }
+
+        return substr($stream, $pos + 1);
     }
 }

--- a/src/Aggregate/StreamNameTranslator.php
+++ b/src/Aggregate/StreamNameTranslator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Aggregate;
+
+use function strpos;
+use function substr;
+
+final class StreamNameTranslator
+{
+    private function __construct()
+    {
+    }
+
+    public static function streamName(string $aggregate, string $aggregateId): string
+    {
+        return $aggregate . '-' . $aggregateId;
+    }
+
+    public static function aggregateName(string $stream): string
+    {
+        return substr($stream, 0, strpos($stream, '-'));
+    }
+
+    public static function aggregateId(string $stream): string
+    {
+        return substr($stream, strpos($stream, '-') + 1);
+    }
+}

--- a/src/Console/Command/ShowAggregateCommand.php
+++ b/src/Console/Command/ShowAggregateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Console\Command;
 
+use Patchlevel\EventSourcing\Aggregate\StreamNameTranslator;
 use Patchlevel\EventSourcing\Console\InputHelper;
 use Patchlevel\EventSourcing\Console\OutputStyle;
 use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
@@ -78,7 +79,9 @@ final class ShowAggregateCommand extends Command
         if ($this->store instanceof StreamStore) {
             $stream = $this->store->load(
                 new Criteria(
-                    new StreamCriterion(sprintf('%s-%s', $aggregate, $id)),
+                    new StreamCriterion(
+                        StreamNameTranslator::streamName($aggregate, $id),
+                    ),
                 ),
             );
         } else {

--- a/src/Console/Command/ShowAggregateCommand.php
+++ b/src/Console/Command/ShowAggregateCommand.php
@@ -12,7 +12,9 @@ use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Store\Criteria\AggregateIdCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\AggregateNameCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\Criteria;
+use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
 use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Store\StreamStore;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -73,12 +75,20 @@ final class ShowAggregateCommand extends Command
             return 1;
         }
 
-        $stream = $this->store->load(
-            new Criteria(
-                new AggregateNameCriterion($aggregate),
-                new AggregateIdCriterion($id),
-            ),
-        );
+        if ($this->store instanceof StreamStore) {
+            $stream = $this->store->load(
+                new Criteria(
+                    new StreamCriterion(sprintf('%s-%s', $aggregate, $id)),
+                ),
+            );
+        } else {
+            $stream = $this->store->load(
+                new Criteria(
+                    new AggregateNameCriterion($aggregate),
+                    new AggregateIdCriterion($id),
+                ),
+            );
+        }
 
         $hasMessage = false;
         foreach ($stream as $message) {

--- a/src/Console/Command/WatchCommand.php
+++ b/src/Console/Command/WatchCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Console\Command;
 
+use Patchlevel\EventSourcing\Aggregate\StreamNameTranslator;
 use Patchlevel\EventSourcing\Console\InputHelper;
 use Patchlevel\EventSourcing\Console\OutputStyle;
 use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
@@ -19,8 +20,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-
-use function sprintf;
 
 #[AsCommand(
     'event-sourcing:watch',
@@ -76,7 +75,7 @@ final class WatchCommand extends Command
 
         if ($this->store instanceof StreamStore) {
             $criteria = (new CriteriaBuilder())
-                ->streamName(sprintf('%s-%s', $aggregate, $aggregateId))
+                ->streamName(StreamNameTranslator::streamName($aggregate, $aggregateId))
                 ->build();
         } else {
             $criteria = (new CriteriaBuilder())

--- a/src/Console/Command/WatchCommand.php
+++ b/src/Console/Command/WatchCommand.php
@@ -73,16 +73,24 @@ final class WatchCommand extends Command
             $this->store->setupSubscription();
         }
 
+        $criteriaBuilder = new CriteriaBuilder();
+
         if ($this->store instanceof StreamStore) {
-            $criteria = (new CriteriaBuilder())
-                ->streamName(StreamNameTranslator::streamName($aggregate, $aggregateId))
-                ->build();
+            if ($aggregate !== null || $aggregateId !== null) {
+                if ($aggregate === null || $aggregateId === null) {
+                    $console->error('You must provide both aggregate and aggregate-id or none of them');
+
+                    return 1;
+                }
+
+                $criteriaBuilder->streamName(StreamNameTranslator::streamName($aggregate, $aggregateId));
+            }
         } else {
-            $criteria = (new CriteriaBuilder())
-                ->aggregateName($aggregate)
-                ->aggregateId($aggregateId)
-                ->build();
+            $criteriaBuilder->aggregateName($aggregate);
+            $criteriaBuilder->aggregateId($aggregateId);
         }
+
+        $criteria = $criteriaBuilder->build();
 
         $worker = DefaultWorker::create(
             function () use ($console, &$index, $criteria, $sleep): void {

--- a/src/Console/OutputStyle.php
+++ b/src/Console/OutputStyle.php
@@ -10,6 +10,7 @@ use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
 use Patchlevel\EventSourcing\Serializer\Encoder\Encoder;
 use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Store\ArchivedHeader;
+use Patchlevel\EventSourcing\Store\StreamHeader;
 use Patchlevel\EventSourcing\Store\StreamStartHeader;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
@@ -47,7 +48,8 @@ final class OutputStyle extends SymfonyStyle
 
         $customHeaders = array_filter(
             $message->headers(),
-            static fn ($header) => !$header instanceof AggregateHeader
+            static fn ($header) => !$header instanceof StreamHeader
+                && !$header instanceof AggregateHeader
                 && !$header instanceof ArchivedHeader
                 && !$header instanceof StreamStartHeader,
         );
@@ -59,8 +61,7 @@ final class OutputStyle extends SymfonyStyle
         $this->title($data->name);
         $this->horizontalTable(
             [
-                'aggregateName',
-                'aggregateId',
+                'stream',
                 'playhead',
                 'recordedOn',
                 'streamStart',

--- a/src/Console/OutputStyle.php
+++ b/src/Console/OutputStyle.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Console;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
-use Patchlevel\EventSourcing\Aggregate\StreamNameTranslator;
 use Patchlevel\EventSourcing\Message\HeaderNotFound;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
@@ -71,7 +70,7 @@ final class OutputStyle extends SymfonyStyle
             ],
             [
                 [
-                    $this->streamName($metaHeader),
+                    $metaHeader instanceof AggregateHeader ? $metaHeader->streamName() : $metaHeader->streamName,
                     $metaHeader->playhead,
                     $metaHeader->recordedOn?->format('Y-m-d H:i:s'),
                     $streamStart ? 'yes' : 'no',
@@ -107,14 +106,5 @@ final class OutputStyle extends SymfonyStyle
         } catch (HeaderNotFound) {
             return $message->header(StreamHeader::class);
         }
-    }
-
-    private function streamName(AggregateHeader|StreamHeader $header): string
-    {
-        if ($header instanceof AggregateHeader) {
-            return StreamNameTranslator::streamName($header->aggregateName, $header->aggregateId);
-        }
-
-        return $header->streamName;
     }
 }

--- a/src/Console/OutputStyle.php
+++ b/src/Console/OutputStyle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Console;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
+use Patchlevel\EventSourcing\Aggregate\StreamNameTranslator;
 use Patchlevel\EventSourcing\Message\HeaderNotFound;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
@@ -111,7 +112,7 @@ final class OutputStyle extends SymfonyStyle
     private function streamName(AggregateHeader|StreamHeader $header): string
     {
         if ($header instanceof AggregateHeader) {
-            return sprintf('%s-%s', $header->aggregateName, $header->aggregateId);
+            return StreamNameTranslator::streamName($header->aggregateName, $header->aggregateId);
         }
 
         return $header->streamName;

--- a/src/Message/Translator/RecalculatePlayheadTranslator.php
+++ b/src/Message/Translator/RecalculatePlayheadTranslator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Message\Translator;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
-use Patchlevel\EventSourcing\Aggregate\StreamNameTranslator;
 use Patchlevel\EventSourcing\Message\HeaderNotFound;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Store\StreamHeader;
@@ -30,11 +29,7 @@ final class RecalculatePlayheadTranslator implements Translator
             }
         }
 
-        if ($header instanceof StreamHeader) {
-            $stream = $header->streamName;
-        } else {
-            $stream = StreamNameTranslator::streamName($header->aggregateName, $header->aggregateId);
-        }
+        $stream = $header instanceof StreamHeader ? $header->streamName : $header->streamName();
 
         $playhead = $this->nextPlayhead($stream);
 

--- a/src/Message/Translator/RecalculatePlayheadTranslator.php
+++ b/src/Message/Translator/RecalculatePlayheadTranslator.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Message\Translator;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
+use Patchlevel\EventSourcing\Aggregate\StreamNameTranslator;
 use Patchlevel\EventSourcing\Message\HeaderNotFound;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Store\StreamHeader;
 
 use function array_key_exists;
-use function sprintf;
 
 final class RecalculatePlayheadTranslator implements Translator
 {
@@ -33,7 +33,7 @@ final class RecalculatePlayheadTranslator implements Translator
         if ($header instanceof StreamHeader) {
             $stream = $header->streamName;
         } else {
-            $stream = sprintf('%s-%s', $header->aggregateName, $header->aggregateId);
+            $stream = StreamNameTranslator::streamName($header->aggregateName, $header->aggregateId);
         }
 
         $playhead = $this->nextPlayhead($stream);

--- a/src/Message/Translator/RecalculatePlayheadTranslator.php
+++ b/src/Message/Translator/RecalculatePlayheadTranslator.php
@@ -14,7 +14,7 @@ use function array_key_exists;
 
 final class RecalculatePlayheadTranslator implements Translator
 {
-    /** @var array<string, array<string, positive-int>> */
+    /** @var array<string, positive-int> */
     private array $index = [];
 
     /** @return list<Message> */

--- a/src/Metadata/Message/MessageHeaderRegistry.php
+++ b/src/Metadata/Message/MessageHeaderRegistry.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\Metadata\Message;
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
 use Patchlevel\EventSourcing\Debug\Trace\TraceHeader;
 use Patchlevel\EventSourcing\Store\ArchivedHeader;
+use Patchlevel\EventSourcing\Store\StreamHeader;
 use Patchlevel\EventSourcing\Store\StreamStartHeader;
 
 use function array_flip;
@@ -73,6 +74,7 @@ final class MessageHeaderRegistry
     public static function createWithInternalHeaders(array $headerNameToClassMap = []): self
     {
         $internalHeaders = [
+            'stream' => StreamHeader::class,
             'aggregate' => AggregateHeader::class,
             'trace' => TraceHeader::class,
             'archived' => ArchivedHeader::class,

--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -18,8 +18,8 @@ use Patchlevel\EventSourcing\Snapshot\SnapshotVersionInvalid;
 use Patchlevel\EventSourcing\Store\Criteria\CriteriaBuilder;
 use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Store\Stream;
-use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
 use Patchlevel\EventSourcing\Store\StreamHeader;
+use Patchlevel\EventSourcing\Store\StreamStore;
 use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
@@ -60,7 +60,7 @@ final class DefaultRepository implements Repository
         $this->clock = $clock ?? new SystemClock();
         $this->logger = $logger ?? new NullLogger();
         $this->aggregateIsValid = new WeakMap();
-        $this->useStreamHeader = $store instanceof StreamDoctrineDbalStore;
+        $this->useStreamHeader = $store instanceof StreamStore;
     }
 
     /** @return T */

--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\Repository;
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
 use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Aggregate\StreamNameTranslator;
 use Patchlevel\EventSourcing\Clock\SystemClock;
 use Patchlevel\EventSourcing\EventBus\EventBus;
 use Patchlevel\EventSourcing\Message\Message;
@@ -110,7 +111,7 @@ final class DefaultRepository implements Repository
 
         if ($this->useStreamHeader) {
             $criteria = (new CriteriaBuilder())
-                ->streamName($this->streamName($this->metadata->name, $id->toString()))
+                ->streamName(StreamNameTranslator::streamName($this->metadata->name, $id->toString()))
                 ->archived(false)
                 ->build();
         } else {
@@ -179,7 +180,7 @@ final class DefaultRepository implements Repository
     {
         if ($this->useStreamHeader) {
             $criteria = (new CriteriaBuilder())
-                ->streamName($this->streamName($this->metadata->name, $id->toString()))
+                ->streamName(StreamNameTranslator::streamName($this->metadata->name, $id->toString()))
                 ->build();
         } else {
             $criteria = (new CriteriaBuilder())
@@ -250,7 +251,7 @@ final class DefaultRepository implements Repository
                 static function (object $event) use ($aggregateName, $aggregateId, &$playhead, $messageDecorator, $clock, $useStreamHeader) {
                     if ($useStreamHeader) {
                         $header = new StreamHeader(
-                            sprintf('%s-%s', $aggregateName, $aggregateId),
+                            StreamNameTranslator::streamName($aggregateName, $aggregateId),
                             ++$playhead,
                             $clock->now(),
                         );
@@ -331,7 +332,7 @@ final class DefaultRepository implements Repository
 
         if ($this->useStreamHeader) {
             $criteria = (new CriteriaBuilder())
-                ->streamName($this->streamName($this->metadata->name, $id->toString()))
+                ->streamName(StreamNameTranslator::streamName($this->metadata->name, $id->toString()))
                 ->fromPlayhead($aggregate->playhead())
                 ->build();
         } else {
@@ -413,10 +414,5 @@ final class DefaultRepository implements Repository
         foreach ($stream as $message) {
             yield $message->event();
         }
-    }
-
-    private function streamName(string $aggregateName, string $aggregateId): string
-    {
-        return sprintf('%s-%s', $aggregateName, $aggregateId);
     }
 }

--- a/src/Store/Criteria/CriteriaBuilder.php
+++ b/src/Store/Criteria/CriteriaBuilder.php
@@ -13,6 +13,7 @@ final class CriteriaBuilder
     private int|null $fromPlayhead = null;
     private bool|null $archived = null;
 
+    /** @experimental */
     public function streamName(string|null $streamName): self
     {
         $this->streamName = $streamName;

--- a/src/Store/Criteria/CriteriaBuilder.php
+++ b/src/Store/Criteria/CriteriaBuilder.php
@@ -6,11 +6,19 @@ namespace Patchlevel\EventSourcing\Store\Criteria;
 
 final class CriteriaBuilder
 {
+    private string|null $streamName = null;
     private string|null $aggregateName = null;
     private string|null $aggregateId = null;
     private int|null $fromIndex = null;
     private int|null $fromPlayhead = null;
     private bool|null $archived = null;
+
+    public function streamName(string|null $streamName): self
+    {
+        $this->streamName = $streamName;
+
+        return $this;
+    }
 
     public function aggregateName(string|null $aggregateName): self
     {
@@ -50,6 +58,10 @@ final class CriteriaBuilder
     public function build(): Criteria
     {
         $criteria = [];
+
+        if ($this->streamName !== null) {
+            $criteria[] = new StreamCriterion($this->streamName);
+        }
 
         if ($this->aggregateName !== null) {
             $criteria[] = new AggregateNameCriterion($this->aggregateName);

--- a/src/Store/Criteria/StreamCriterion.php
+++ b/src/Store/Criteria/StreamCriterion.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store\Criteria;
+
+final class StreamCriterion
+{
+    public function __construct(
+        public readonly string $streamName,
+    ) {
+    }
+}

--- a/src/Store/Criteria/StreamCriterion.php
+++ b/src/Store/Criteria/StreamCriterion.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Store\Criteria;
 
+/** @experimental */
 final class StreamCriterion
 {
     public function __construct(

--- a/src/Store/Criteria/StreamCriterion.php
+++ b/src/Store/Criteria/StreamCriterion.php
@@ -10,4 +10,9 @@ final class StreamCriterion
         public readonly string $streamName,
     ) {
     }
+
+    public static function startWith(string $streamName): self
+    {
+        return new self($streamName . '*');
+    }
 }

--- a/src/Store/InvalidStreamName.php
+++ b/src/Store/InvalidStreamName.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+use function sprintf;
+
+class InvalidStreamName extends StoreException
+{
+    public function __construct(string $streamName)
+    {
+        parent::__construct(sprintf('Invalid stream name "%s"', $streamName));
+    }
+}

--- a/src/Store/InvalidStreamName.php
+++ b/src/Store/InvalidStreamName.php
@@ -6,6 +6,7 @@ namespace Patchlevel\EventSourcing\Store;
 
 use function sprintf;
 
+/** @experimental */
 final class InvalidStreamName extends StoreException
 {
     public function __construct(string $streamName)

--- a/src/Store/InvalidStreamName.php
+++ b/src/Store/InvalidStreamName.php
@@ -6,7 +6,7 @@ namespace Patchlevel\EventSourcing\Store;
 
 use function sprintf;
 
-class InvalidStreamName extends StoreException
+final class InvalidStreamName extends StoreException
 {
     public function __construct(string $streamName)
     {

--- a/src/Store/StreamDoctrineDbalStore.php
+++ b/src/Store/StreamDoctrineDbalStore.php
@@ -47,6 +47,7 @@ use function sprintf;
 use function str_contains;
 use function str_ends_with;
 
+/** @experimental */
 final class StreamDoctrineDbalStore implements StreamStore, SubscriptionStore, DoctrineSchemaConfigurator
 {
     /**

--- a/src/Store/StreamDoctrineDbalStore.php
+++ b/src/Store/StreamDoctrineDbalStore.php
@@ -321,7 +321,10 @@ final class StreamDoctrineDbalStore implements StreamStore, SubscriptionStore, D
             ->from($this->config['table_name'])
             ->orderBy('stream');
 
-        return $builder->fetchFirstColumn();
+        /** @var list<string> $streams */
+        $streams = $builder->fetchFirstColumn();
+
+        return $streams;
     }
 
     public function remove(string $streamName): void

--- a/src/Store/StreamDoctrineDbalStore.php
+++ b/src/Store/StreamDoctrineDbalStore.php
@@ -1,0 +1,500 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+use Closure;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Patchlevel\EventSourcing\Clock\SystemClock;
+use Patchlevel\EventSourcing\Message\HeaderNotFound;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
+use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
+use Patchlevel\EventSourcing\Schema\DoctrineSchemaConfigurator;
+use Patchlevel\EventSourcing\Serializer\EventSerializer;
+use Patchlevel\EventSourcing\Store\Criteria\ArchivedCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\Criteria;
+use Patchlevel\EventSourcing\Store\Criteria\FromIndexCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\FromPlayheadCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
+use PDO;
+use Psr\Clock\ClockInterface;
+
+use function array_fill;
+use function array_filter;
+use function array_merge;
+use function array_values;
+use function class_exists;
+use function count;
+use function explode;
+use function floor;
+use function implode;
+use function in_array;
+use function is_int;
+use function is_string;
+use function sprintf;
+
+final class StreamDoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchemaConfigurator
+{
+    /**
+     * PostgreSQL has a limit of 65535 parameters in a single query.
+     */
+    private const MAX_UNSIGNED_SMALL_INT = 65_535;
+
+    /**
+     * Default lock id for advisory lock.
+     */
+    private const DEFAULT_LOCK_ID = 133742;
+
+    private readonly HeadersSerializer $headersSerializer;
+
+    private readonly ClockInterface $clock;
+
+    /** @var array{table_name: string, locking: bool, lock_id: int, lock_timeout: int} */
+    private readonly array $config;
+
+    private bool $hasLock = false;
+
+    /** @param array{table_name?: string, locking?: bool, lock_id?: int, lock_timeout?: int} $config */
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly EventSerializer $eventSerializer,
+        HeadersSerializer|null $headersSerializer = null,
+        ClockInterface|null $clock = null,
+        array $config = [],
+    ) {
+        $this->headersSerializer = $headersSerializer ?? DefaultHeadersSerializer::createDefault();
+        $this->clock = $clock ?? new SystemClock();
+
+        $this->config = array_merge([
+            'table_name' => 'event_store',
+            'locking' => true,
+            'lock_id' => self::DEFAULT_LOCK_ID,
+            'lock_timeout' => -1,
+        ], $config);
+    }
+
+    public function load(
+        Criteria|null $criteria = null,
+        int|null $limit = null,
+        int|null $offset = null,
+        bool $backwards = false,
+    ): StreamDoctrineDbalStoreStream {
+        $builder = $this->connection->createQueryBuilder()
+            ->select('*')
+            ->from($this->config['table_name'])
+            ->orderBy('id', $backwards ? 'DESC' : 'ASC');
+
+        $this->applyCriteria($builder, $criteria ?? new Criteria());
+
+        $builder->setMaxResults($limit);
+        $builder->setFirstResult($offset ?? 0);
+
+        return new StreamDoctrineDbalStoreStream(
+            $this->connection->executeQuery(
+                $builder->getSQL(),
+                $builder->getParameters(),
+                $builder->getParameterTypes(),
+            ),
+            $this->eventSerializer,
+            $this->headersSerializer,
+            $this->connection->getDatabasePlatform(),
+        );
+    }
+
+    public function count(Criteria|null $criteria = null): int
+    {
+        $builder = $this->connection->createQueryBuilder()
+            ->select('COUNT(*)')
+            ->from($this->config['table_name']);
+
+        $this->applyCriteria($builder, $criteria ?? new Criteria());
+
+        $result = $this->connection->fetchOne(
+            $builder->getSQL(),
+            $builder->getParameters(),
+            $builder->getParameterTypes(),
+        );
+
+        if (!is_int($result) && !is_string($result)) {
+            throw new WrongQueryResult();
+        }
+
+        return (int)$result;
+    }
+
+    private function applyCriteria(QueryBuilder $builder, Criteria $criteria): void
+    {
+        $criteriaList = $criteria->all();
+
+        foreach ($criteriaList as $criterion) {
+            switch ($criterion::class) {
+                case StreamCriterion::class:
+                    $builder->andWhere('stream = :stream');
+                    $builder->setParameter('stream', $criterion->streamName);
+                    break;
+                case FromPlayheadCriterion::class:
+                    $builder->andWhere('playhead > :playhead');
+                    $builder->setParameter('playhead', $criterion->fromPlayhead, Types::INTEGER);
+                    break;
+                case ArchivedCriterion::class:
+                    $builder->andWhere('archived = :archived');
+                    $builder->setParameter('archived', $criterion->archived, Types::BOOLEAN);
+                    break;
+                case FromIndexCriterion::class:
+                    $builder->andWhere('id > :index');
+                    $builder->setParameter('index', $criterion->fromIndex, Types::INTEGER);
+                    break;
+                default:
+                    throw new UnsupportedCriterion($criterion::class);
+            }
+        }
+    }
+
+    public function save(Message ...$messages): void
+    {
+        if ($messages === []) {
+            return;
+        }
+
+        $this->transactional(
+            function () use ($messages): void {
+                /** @var array<string, int> $achievedUntilPlayhead */
+                $achievedUntilPlayhead = [];
+
+                $booleanType = Type::getType(Types::BOOLEAN);
+                $dateTimeType = Type::getType(Types::DATETIMETZ_IMMUTABLE);
+
+                $columns = [
+                    'stream',
+                    'playhead',
+                    'event',
+                    'payload',
+                    'recorded_on',
+                    'new_stream_start',
+                    'archived',
+                    'custom_headers',
+                ];
+
+                $columnsLength = count($columns);
+                $batchSize = (int)floor(self::MAX_UNSIGNED_SMALL_INT / $columnsLength);
+                $placeholder = implode(', ', array_fill(0, $columnsLength, '?'));
+
+                $parameters = [];
+                $placeholders = [];
+                /** @var array<int<0, max>, Type> $types */
+                $types = [];
+                $position = 0;
+                foreach ($messages as $message) {
+                    /** @var int<0, max> $offset */
+                    $offset = $position * $columnsLength;
+                    $placeholders[] = $placeholder;
+
+                    $data = $this->eventSerializer->serialize($message->event());
+
+                    try {
+                        $streamHeader = $message->header(StreamHeader::class);
+                    } catch (HeaderNotFound $e) {
+                        throw new MissingDataForStorage($e->name, $e);
+                    }
+
+                    $parameters[] = $streamHeader->streamName;
+                    $parameters[] = $streamHeader->playhead;
+                    $parameters[] = $data->name;
+                    $parameters[] = $data->payload;
+
+                    $parameters[] = $streamHeader->recordedOn ?: $this->clock->now();
+                    $types[$offset + 4] = $dateTimeType;
+
+                    $streamStart = $message->hasHeader(StreamStartHeader::class);
+
+                    if ($streamStart) {
+                        $achievedUntilPlayhead[$streamHeader->streamName] = $streamHeader->playhead;
+                    }
+
+                    $parameters[] = $streamStart;
+                    $types[$offset + 5] = $booleanType;
+
+                    $parameters[] = $message->hasHeader(ArchivedHeader::class);
+                    $types[$offset + 6] = $booleanType;
+
+                    $parameters[] = $this->headersSerializer->serialize($this->getCustomHeaders($message));
+
+                    $position++;
+
+                    if ($position !== $batchSize) {
+                        continue;
+                    }
+
+                    $this->executeSave($columns, $placeholders, $parameters, $types, $this->connection);
+
+                    $parameters = [];
+                    $placeholders = [];
+                    $types = [];
+
+                    $position = 0;
+                }
+
+                if ($position !== 0) {
+                    $this->executeSave($columns, $placeholders, $parameters, $types, $this->connection);
+                }
+
+                foreach ($achievedUntilPlayhead as $stream => $playhead) {
+                    $this->connection->executeStatement(
+                        sprintf(
+                            <<<'SQL'
+                            UPDATE %s
+                            SET archived = true
+                            WHERE stream = :stream
+                            AND playhead < :playhead
+                            AND archived = false
+                            SQL,
+                            $this->config['table_name'],
+                        ),
+                        [
+                            'stream' => $stream,
+                            'playhead' => $playhead,
+                        ],
+                    );
+                }
+            },
+        );
+    }
+
+    /**
+     * @param Closure():ClosureReturn $function
+     *
+     * @template ClosureReturn
+     */
+    public function transactional(Closure $function): void
+    {
+        if ($this->hasLock || !$this->config['locking']) {
+            $this->connection->transactional($function);
+        } else {
+            $this->connection->transactional(function () use ($function): void {
+                $this->lock();
+                try {
+                    $function();
+                } finally {
+                    $this->unlock();
+                }
+            });
+        }
+    }
+
+    public function configureSchema(Schema $schema, Connection $connection): void
+    {
+        if ($this->connection !== $connection) {
+            return;
+        }
+
+        $table = $schema->createTable($this->config['table_name']);
+
+        $table->addColumn('id', Types::BIGINT)
+            ->setAutoincrement(true);
+        $table->addColumn('stream', Types::STRING)
+            ->setLength(255)
+            ->setNotnull(true);
+        $table->addColumn('playhead', Types::INTEGER)
+            ->setNotnull(false);
+        $table->addColumn('event', Types::STRING)
+            ->setLength(255)
+            ->setNotnull(true);
+        $table->addColumn('payload', Types::JSON)
+            ->setNotnull(true);
+        $table->addColumn('recorded_on', Types::DATETIMETZ_IMMUTABLE)
+            ->setNotnull(true);
+        $table->addColumn('new_stream_start', Types::BOOLEAN)
+            ->setNotnull(true)
+            ->setDefault(false);
+        $table->addColumn('archived', Types::BOOLEAN)
+            ->setNotnull(true)
+            ->setDefault(false);
+        $table->addColumn('custom_headers', Types::JSON)
+            ->setNotnull(true);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['stream', 'playhead']);
+        $table->addIndex(['stream', 'playhead', 'archived']);
+    }
+
+    /** @return list<object> */
+    private function getCustomHeaders(Message $message): array
+    {
+        $filteredHeaders = [
+            StreamHeader::class,
+            StreamStartHeader::class,
+            ArchivedHeader::class,
+        ];
+
+        return array_values(
+            array_filter(
+                $message->headers(),
+                static fn (object $header) => !in_array($header::class, $filteredHeaders, true),
+            ),
+        );
+    }
+
+    public function supportSubscription(): bool
+    {
+        return $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform && class_exists(PDO::class);
+    }
+
+    public function wait(int $timeoutMilliseconds): void
+    {
+        if (!$this->supportSubscription()) {
+            return;
+        }
+
+        $this->connection->executeStatement(sprintf('LISTEN "%s"', $this->config['table_name']));
+
+        /** @var PDO $nativeConnection */
+        $nativeConnection = $this->connection->getNativeConnection();
+
+        $nativeConnection->pgsqlGetNotify(PDO::FETCH_ASSOC, $timeoutMilliseconds);
+    }
+
+    public function setupSubscription(): void
+    {
+        if (!$this->supportSubscription()) {
+            return;
+        }
+
+        $functionName = $this->createTriggerFunctionName();
+
+        $this->connection->executeStatement(sprintf(
+            <<<'SQL'
+                CREATE OR REPLACE FUNCTION %1$s() RETURNS TRIGGER AS $$
+                    BEGIN
+                        PERFORM pg_notify('%2$s', 'update');
+                        RETURN NEW;
+                    END;
+                $$ LANGUAGE plpgsql;
+                SQL,
+            $functionName,
+            $this->config['table_name'],
+        ));
+
+        $this->connection->executeStatement(sprintf(
+            'DROP TRIGGER IF EXISTS notify_trigger ON %s;',
+            $this->config['table_name'],
+        ));
+        $this->connection->executeStatement(sprintf(
+            'CREATE TRIGGER notify_trigger AFTER INSERT OR UPDATE ON %1$s FOR EACH ROW EXECUTE PROCEDURE %2$s();',
+            $this->config['table_name'],
+            $functionName,
+        ));
+    }
+
+    private function createTriggerFunctionName(): string
+    {
+        $tableConfig = explode('.', $this->config['table_name']);
+
+        if (count($tableConfig) === 1) {
+            return sprintf('notify_%1$s', $tableConfig[0]);
+        }
+
+        return sprintf('%1$s.notify_%2$s', $tableConfig[0], $tableConfig[1]);
+    }
+
+    /**
+     * @param array<string>               $columns
+     * @param array<string>               $placeholders
+     * @param list<mixed>                 $parameters
+     * @param array<0|positive-int, Type> $types
+     */
+    private function executeSave(
+        array $columns,
+        array $placeholders,
+        array $parameters,
+        array $types,
+        Connection $connection,
+    ): void {
+        $query = sprintf(
+            "INSERT INTO %s (%s) VALUES\n(%s)",
+            $this->config['table_name'],
+            implode(', ', $columns),
+            implode("),\n(", $placeholders),
+        );
+
+        try {
+            $connection->executeStatement($query, $parameters, $types);
+        } catch (UniqueConstraintViolationException $e) {
+            throw new UniqueConstraintViolation($e);
+        }
+    }
+
+    private function lock(): void
+    {
+        $this->hasLock = true;
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            $this->connection->executeStatement(
+                sprintf(
+                    'SELECT pg_advisory_xact_lock(%s)',
+                    $this->config['lock_id'],
+                ),
+            );
+
+            return;
+        }
+
+        if ($platform instanceof MariaDBPlatform || $platform instanceof MySQLPlatform) {
+            $this->connection->fetchAllAssociative(
+                sprintf(
+                    'SELECT GET_LOCK("%s", %d)',
+                    $this->config['lock_id'],
+                    $this->config['lock_timeout'],
+                ),
+            );
+
+            return;
+        }
+
+        if ($platform instanceof SQLitePlatform) {
+            return; // sql locking is not needed because of file locking
+        }
+
+        throw new LockingNotImplemented($platform::class);
+    }
+
+    private function unlock(): void
+    {
+        $this->hasLock = false;
+
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            return; // lock is released automatically after transaction
+        }
+
+        if ($platform instanceof MariaDBPlatform || $platform instanceof MySQLPlatform) {
+            $this->connection->fetchAllAssociative(
+                sprintf(
+                    'SELECT RELEASE_LOCK("%s")',
+                    $this->config['lock_id'],
+                ),
+            );
+
+            return;
+        }
+
+        if ($platform instanceof SQLitePlatform) {
+            return; // sql locking is not needed because of file locking
+        }
+
+        throw new LockingNotImplemented($platform::class);
+    }
+}

--- a/src/Store/StreamDoctrineDbalStore.php
+++ b/src/Store/StreamDoctrineDbalStore.php
@@ -44,7 +44,7 @@ use function is_int;
 use function is_string;
 use function sprintf;
 
-final class StreamDoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchemaConfigurator
+final class StreamDoctrineDbalStore implements StreamStore, SubscriptionStore, DoctrineSchemaConfigurator
 {
     /**
      * PostgreSQL has a limit of 65535 parameters in a single query.
@@ -290,6 +290,28 @@ final class StreamDoctrineDbalStore implements Store, SubscriptionStore, Doctrin
                 }
             });
         }
+    }
+
+    /** @return list<string> */
+    public function streams(): array
+    {
+        $builder = $this->connection->createQueryBuilder()
+            ->select('stream')
+            ->distinct()
+            ->from($this->config['table_name'])
+            ->orderBy('stream');
+
+        return $builder->fetchFirstColumn();
+    }
+
+    public function remove(string $streamName): void
+    {
+        $builder = $this->connection->createQueryBuilder()
+            ->delete($this->config['table_name'])
+            ->andWhere('stream = :stream')
+            ->setParameter('stream', $streamName);
+
+        $builder->executeStatement();
     }
 
     public function configureSchema(Schema $schema, Connection $connection): void

--- a/src/Store/StreamDoctrineDbalStoreStream.php
+++ b/src/Store/StreamDoctrineDbalStoreStream.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Generator;
+use IteratorAggregate;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
+use Patchlevel\EventSourcing\Serializer\EventSerializer;
+use Patchlevel\EventSourcing\Serializer\SerializedEvent;
+use Traversable;
+
+/** @implements IteratorAggregate<Message> */
+final class StreamDoctrineDbalStoreStream implements Stream, IteratorAggregate
+{
+    private Result|null $result;
+
+    /** @var Generator<Message> */
+    private Generator|null $generator;
+
+    /** @var positive-int|0|null */
+    private int|null $position;
+
+    /** @var positive-int|null */
+    private int|null $index;
+
+    public function __construct(
+        Result $result,
+        EventSerializer $eventSerializer,
+        HeadersSerializer $headersSerializer,
+        AbstractPlatform $platform,
+    ) {
+        $this->result = $result;
+        $this->generator = $this->buildGenerator($result, $eventSerializer, $headersSerializer, $platform);
+        $this->position = null;
+        $this->index = null;
+    }
+
+    public function close(): void
+    {
+        $this->result?->free();
+
+        $this->result = null;
+        $this->generator = null;
+    }
+
+    public function next(): void
+    {
+        $this->assertNotClosed();
+
+        $this->generator->next();
+    }
+
+    public function end(): bool
+    {
+        $this->assertNotClosed();
+
+        return !$this->generator->valid();
+    }
+
+    public function current(): Message|null
+    {
+        $this->assertNotClosed();
+
+        return $this->generator->current() ?: null;
+    }
+
+    /** @return positive-int|0|null */
+    public function position(): int|null
+    {
+        $this->assertNotClosed();
+
+        if ($this->position === null) {
+            $this->generator->key();
+        }
+
+        return $this->position;
+    }
+
+    /** @return positive-int|null */
+    public function index(): int|null
+    {
+        $this->assertNotClosed();
+
+        if ($this->index === null) {
+            $this->generator->key();
+        }
+
+        return $this->index;
+    }
+
+    /** @return Traversable<Message> */
+    public function getIterator(): Traversable
+    {
+        $this->assertNotClosed();
+
+        return $this->generator;
+    }
+
+    /** @return Generator<Message> */
+    private function buildGenerator(
+        Result $result,
+        EventSerializer $eventSerializer,
+        HeadersSerializer $headersSerializer,
+        AbstractPlatform $platform,
+    ): Generator {
+        $dateTimeType = Type::getType(Types::DATETIMETZ_IMMUTABLE);
+
+        /** @var array{id: positive-int, stream: string, playhead: int|string|null, event: string, payload: string, recorded_on: string, archived: int|string, new_stream_start: int|string, custom_headers: string} $data */
+        foreach ($result->iterateAssociative() as $data) {
+            if ($this->position === null) {
+                $this->position = 0;
+            } else {
+                ++$this->position;
+            }
+
+            $this->index = $data['id'];
+            $event = $eventSerializer->deserialize(new SerializedEvent($data['event'], $data['payload']));
+
+            $message = Message::create($event)
+                ->withHeader(new StreamHeader(
+                    $data['stream'],
+                    $data['playhead'] === null ? null : (int)$data['playhead'],
+                    $dateTimeType->convertToPHPValue($data['recorded_on'], $platform),
+                ));
+
+            if ($data['archived']) {
+                $message = $message->withHeader(new ArchivedHeader());
+            }
+
+            if ($data['new_stream_start']) {
+                $message = $message->withHeader(new StreamStartHeader());
+            }
+
+            $customHeaders = $headersSerializer->deserialize($data['custom_headers']);
+
+            yield $message->withHeaders($customHeaders);
+        }
+    }
+
+    /**
+     * @psalm-assert !null $this->result
+     * @psalm-assert !null $this->generator
+     */
+    private function assertNotClosed(): void
+    {
+        if ($this->result === null || $this->generator === null) {
+            throw new StreamClosed();
+        }
+    }
+}

--- a/src/Store/StreamDoctrineDbalStoreStream.php
+++ b/src/Store/StreamDoctrineDbalStoreStream.php
@@ -17,7 +17,10 @@ use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Serializer\SerializedEvent;
 use Traversable;
 
-/** @implements IteratorAggregate<Message> */
+/**
+ * @implements IteratorAggregate<Message>
+ * @experimental
+ */
 final class StreamDoctrineDbalStoreStream implements Stream, IteratorAggregate
 {
     private Result|null $result;

--- a/src/Store/StreamDoctrineDbalStoreStream.php
+++ b/src/Store/StreamDoctrineDbalStoreStream.php
@@ -6,6 +6,7 @@ namespace Patchlevel\EventSourcing\Store;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Types\DateTimeTzImmutableType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Generator;
@@ -110,6 +111,7 @@ final class StreamDoctrineDbalStoreStream implements Stream, IteratorAggregate
         HeadersSerializer $headersSerializer,
         AbstractPlatform $platform,
     ): Generator {
+        /** @var DateTimeTzImmutableType $dateTimeType */
         $dateTimeType = Type::getType(Types::DATETIMETZ_IMMUTABLE);
 
         /** @var array{id: positive-int, stream: string, playhead: int|string|null, event: string, payload: string, recorded_on: string, archived: int|string, new_stream_start: int|string, custom_headers: string} $data */

--- a/src/Store/StreamHeader.php
+++ b/src/Store/StreamHeader.php
@@ -6,7 +6,10 @@ namespace Patchlevel\EventSourcing\Store;
 
 use DateTimeImmutable;
 
-/** @psalm-immutable */
+/**
+ * @psalm-immutable
+ * @experimental
+ */
 final class StreamHeader
 {
     /** @param positive-int|null $playhead */

--- a/src/Store/StreamHeader.php
+++ b/src/Store/StreamHeader.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+use DateTimeImmutable;
+
+/** @psalm-immutable */
+final class StreamHeader
+{
+    /** @param positive-int|null $playhead */
+    public function __construct(
+        public readonly string $streamName,
+        public readonly int|null $playhead = null,
+        public readonly DateTimeImmutable|null $recordedOn = null,
+    ) {
+    }
+}

--- a/src/Store/StreamStore.php
+++ b/src/Store/StreamStore.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Store;
 
+/** @experimental */
 interface StreamStore extends Store
 {
     /** @return list<string> */

--- a/src/Store/StreamStore.php
+++ b/src/Store/StreamStore.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Store;
+
+interface StreamStore extends Store
+{
+    /** @return list<string> */
+    public function streams(): array;
+
+    public function remove(string $streamName): void;
+}

--- a/src/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolver.php
+++ b/src/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolver.php
@@ -6,13 +6,13 @@ namespace Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver;
 
 use Patchlevel\EventSourcing\Aggregate\AggregateHeader;
 use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Aggregate\StreamNameTranslator;
 use Patchlevel\EventSourcing\Message\HeaderNotFound;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
 use Patchlevel\EventSourcing\Store\StreamHeader;
 
 use function class_exists;
-use function explode;
 use function is_a;
 
 final class AggregateIdArgumentResolver implements ArgumentResolver
@@ -31,9 +31,9 @@ final class AggregateIdArgumentResolver implements ArgumentResolver
         }
 
         $stream = $message->header(StreamHeader::class)->streamName;
-        $parts = explode('-', $stream, 2);
+        $aggregateId = StreamNameTranslator::aggregateId($stream);
 
-        return $class::fromString($parts[1]);
+        return $class::fromString($aggregateId);
     }
 
     public function support(ArgumentMetadata $argument, string $eventClass): bool

--- a/tests/Benchmark/SimpleSetupStreamStoreBench.php
+++ b/tests/Benchmark/SimpleSetupStreamStoreBench.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Benchmark;
+
+use Patchlevel\EventSourcing\Aggregate\AggregateRootId;
+use Patchlevel\EventSourcing\Repository\DefaultRepository;
+use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
+use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
+use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Profile;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
+use Patchlevel\EventSourcing\Tests\DbalManager;
+use PhpBench\Attributes as Bench;
+
+#[Bench\BeforeMethods('setUp')]
+final class SimpleSetupStreamStoreBench
+{
+    private Store $store;
+    private Repository $repository;
+
+    private AggregateRootId $singleEventId;
+    private AggregateRootId $multipleEventsId;
+
+    public function setUp(): void
+    {
+        $connection = DbalManager::createConnection();
+
+        $this->store = new StreamDoctrineDbalStore(
+            $connection,
+            DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
+        );
+
+        $this->repository = new DefaultRepository($this->store, Profile::metadata());
+
+        $schemaDirector = new DoctrineSchemaDirector(
+            $connection,
+            $this->store,
+        );
+
+        $schemaDirector->create();
+
+        $this->singleEventId = ProfileId::generate();
+        $profile = Profile::create($this->singleEventId, 'Peter');
+        $this->repository->save($profile);
+
+        $this->multipleEventsId = ProfileId::generate();
+        $profile = Profile::create($this->multipleEventsId, 'Peter');
+
+        for ($i = 0; $i < 10_000; $i++) {
+            $profile->changeName('Peter');
+        }
+
+        $this->repository->save($profile);
+    }
+
+    #[Bench\Revs(10)]
+    public function benchLoad1Event(): void
+    {
+        $this->repository->load($this->singleEventId);
+    }
+
+    #[Bench\Revs(10)]
+    public function benchLoad10000Events(): void
+    {
+        $this->repository->load($this->multipleEventsId);
+    }
+
+    #[Bench\Revs(10)]
+    public function benchSave1Event(): void
+    {
+        $profile = Profile::create(ProfileId::generate(), 'Peter');
+        $this->repository->save($profile);
+    }
+
+    #[Bench\Revs(10)]
+    public function benchSave10000Events(): void
+    {
+        $profile = Profile::create(ProfileId::generate(), 'Peter');
+
+        for ($i = 1; $i < 10_000; $i++) {
+            $profile->changeName('Peter');
+        }
+
+        $this->repository->save($profile);
+    }
+
+    #[Bench\Revs(1)]
+    public function benchSave10000Aggregates(): void
+    {
+        for ($i = 1; $i < 10_000; $i++) {
+            $profile = Profile::create(ProfileId::generate(), 'Peter');
+            $this->repository->save($profile);
+        }
+    }
+
+    #[Bench\Revs(10)]
+    public function benchSave10000AggregatesTransaction(): void
+    {
+        $this->store->transactional(function (): void {
+            for ($i = 1; $i < 10_000; $i++) {
+                $profile = Profile::create(ProfileId::generate(), 'Peter');
+                $this->repository->save($profile);
+            }
+        });
+    }
+}

--- a/tests/Integration/Store/DoctrineDbalStoreTest.php
+++ b/tests/Integration/Store/DoctrineDbalStoreTest.php
@@ -12,6 +12,7 @@ use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\DoctrineDbalStore;
 use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
 use Patchlevel\EventSourcing\Tests\DbalManager;
 use Patchlevel\EventSourcing\Tests\Integration\Store\Events\ProfileCreated;
 use PHPUnit\Framework\TestCase;
@@ -19,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 use function json_decode;
 
 /** @coversNothing */
-final class StoreTest extends TestCase
+final class DoctrineDbalStoreTest extends TestCase
 {
     private Connection $connection;
     private Store $store;
@@ -140,6 +141,32 @@ final class StoreTest extends TestCase
         self::assertStringContainsString('2020-01-02 00:00:00', $result2['recorded_on']);
         self::assertEquals('profile.created', $result2['event']);
         self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+    }
+
+    public function testUniqueConstraint(): void
+    {
+        $this->expectException(UniqueConstraintViolation::class);
+
+        $profileId = ProfileId::generate();
+
+        $messages = [
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new AggregateHeader(
+                    'profile',
+                    $profileId->toString(),
+                    1,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new AggregateHeader(
+                    'profile',
+                    $profileId->toString(),
+                    1,
+                    new DateTimeImmutable('2020-01-02 00:00:00'),
+                )),
+        ];
+
+        $this->store->save(...$messages);
     }
 
     public function testSave10000Messages(): void

--- a/tests/Integration/Store/DoctrineDbalStoreTest.php
+++ b/tests/Integration/Store/DoctrineDbalStoreTest.php
@@ -91,7 +91,7 @@ final class DoctrineDbalStoreTest extends TestCase
         self::assertEquals('2', $result2['playhead']);
         self::assertStringContainsString('2020-01-02 00:00:00', $result2['recorded_on']);
         self::assertEquals('profile.created', $result2['event']);
-        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result2['payload'], true));
     }
 
     public function testSaveWithTransactional(): void
@@ -140,7 +140,7 @@ final class DoctrineDbalStoreTest extends TestCase
         self::assertEquals('2', $result2['playhead']);
         self::assertStringContainsString('2020-01-02 00:00:00', $result2['recorded_on']);
         self::assertEquals('profile.created', $result2['event']);
-        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result2['payload'], true));
     }
 
     public function testUniqueConstraint(): void

--- a/tests/Integration/Store/Events/ExternEvent.php
+++ b/tests/Integration/Store/Events/ExternEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\Store\Events;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+
+#[Event('extern')]
+final class ExternEvent
+{
+    public function __construct(
+        public string $message,
+    ) {
+    }
+}

--- a/tests/Integration/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Integration/Store/StreamDoctrineDbalStoreTest.php
@@ -255,4 +255,76 @@ final class StreamDoctrineDbalStoreTest extends TestCase
             $stream?->close();
         }
     }
+
+    public function testStreams(): void
+    {
+        $profileId = ProfileId::fromString('0190e47e-77e9-7b90-bf62-08bbf0ab9b4b');
+
+        $messages = [
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    1,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    2,
+                    new DateTimeImmutable('2020-01-02 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('foo'),
+                )),
+        ];
+
+        $this->store->save(...$messages);
+
+        $streams = $this->store->streams();
+
+        self::assertEquals([
+            'foo',
+            'profile-0190e47e-77e9-7b90-bf62-08bbf0ab9b4b',
+        ], $streams);
+    }
+
+    public function testRemote(): void
+    {
+        $profileId = ProfileId::fromString('0190e47e-77e9-7b90-bf62-08bbf0ab9b4b');
+
+        $messages = [
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    1,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    2,
+                    new DateTimeImmutable('2020-01-02 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('foo'),
+                )),
+        ];
+
+        $this->store->save(...$messages);
+
+        $streams = $this->store->streams();
+
+        self::assertEquals([
+            'foo',
+            'profile-0190e47e-77e9-7b90-bf62-08bbf0ab9b4b',
+        ], $streams);
+
+        $this->store->remove('profile-0190e47e-77e9-7b90-bf62-08bbf0ab9b4b');
+
+        $streams = $this->store->streams();
+
+        self::assertEquals(['foo'], $streams);
+    }
 }

--- a/tests/Integration/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Integration/Store/StreamDoctrineDbalStoreTest.php
@@ -10,14 +10,18 @@ use Patchlevel\EventSourcing\Clock\FrozenClock;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
+use Patchlevel\EventSourcing\Store\Criteria\Criteria;
+use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
 use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
 use Patchlevel\EventSourcing\Store\StreamHeader;
 use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
 use Patchlevel\EventSourcing\Tests\DbalManager;
+use Patchlevel\EventSourcing\Tests\Integration\Store\Events\ExternEvent;
 use Patchlevel\EventSourcing\Tests\Integration\Store\Events\ProfileCreated;
 use PHPUnit\Framework\TestCase;
 
+use function iterator_to_array;
 use function json_decode;
 use function sprintf;
 
@@ -84,7 +88,10 @@ final class StreamDoctrineDbalStoreTest extends TestCase
         self::assertEquals('1', $result1['playhead']);
         self::assertStringContainsString('2020-01-01 00:00:00', $result1['recorded_on']);
         self::assertEquals('profile.created', $result1['event']);
-        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals(
+            ['profileId' => $profileId->toString(), 'name' => 'test'],
+            json_decode($result1['payload'], true),
+        );
 
         $result2 = $result[1];
 
@@ -92,17 +99,18 @@ final class StreamDoctrineDbalStoreTest extends TestCase
         self::assertEquals('2', $result2['playhead']);
         self::assertStringContainsString('2020-01-02 00:00:00', $result2['recorded_on']);
         self::assertEquals('profile.created', $result2['event']);
-        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals(
+            ['profileId' => $profileId->toString(), 'name' => 'test'],
+            json_decode($result2['payload'], true),
+        );
     }
 
     public function testSaveWithNullableValues(): void
     {
-        $profileId = ProfileId::generate();
-
         $messages = [
-            Message::create(new ProfileCreated($profileId, 'test'))
+            Message::create(new ExternEvent('test 1'))
                 ->withHeader(new StreamHeader('extern')),
-            Message::create(new ProfileCreated($profileId, 'test'))
+            Message::create(new ExternEvent('test 2'))
                 ->withHeader(new StreamHeader('extern')),
         ];
 
@@ -118,16 +126,22 @@ final class StreamDoctrineDbalStoreTest extends TestCase
         self::assertEquals('extern', $result1['stream']);
         self::assertEquals(null, $result1['playhead']);
         self::assertStringContainsString('2020-01-01 00:00:00', $result1['recorded_on']);
-        self::assertEquals('profile.created', $result1['event']);
-        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals('extern', $result1['event']);
+        self::assertEquals(
+            ['message' => 'test 1'],
+            json_decode($result1['payload'], true),
+        );
 
         $result2 = $result[1];
 
         self::assertEquals('extern', $result2['stream']);
         self::assertEquals(null, $result2['playhead']);
         self::assertStringContainsString('2020-01-01 00:00:00', $result2['recorded_on']);
-        self::assertEquals('profile.created', $result2['event']);
-        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals('extern', $result2['event']);
+        self::assertEquals(
+            ['message' => 'test 2'],
+            json_decode($result2['payload'], true),
+        );
     }
 
     public function testSaveWithTransactional(): void
@@ -164,7 +178,10 @@ final class StreamDoctrineDbalStoreTest extends TestCase
         self::assertEquals('1', $result1['playhead']);
         self::assertStringContainsString('2020-01-01 00:00:00', $result1['recorded_on']);
         self::assertEquals('profile.created', $result1['event']);
-        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals(
+            ['profileId' => $profileId->toString(), 'name' => 'test'],
+            json_decode($result1['payload'], true),
+        );
 
         $result2 = $result[1];
 
@@ -172,7 +189,10 @@ final class StreamDoctrineDbalStoreTest extends TestCase
         self::assertEquals('2', $result2['playhead']);
         self::assertStringContainsString('2020-01-02 00:00:00', $result2['recorded_on']);
         self::assertEquals('profile.created', $result2['event']);
-        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+        self::assertEquals(
+            ['profileId' => $profileId->toString(), 'name' => 'test'],
+            json_decode($result2['payload'], true),
+        );
     }
 
     public function testUniqueConstraint(): void
@@ -248,9 +268,57 @@ final class StreamDoctrineDbalStoreTest extends TestCase
             self::assertInstanceOf(Message::class, $loadedMessage);
             self::assertNotSame($message, $loadedMessage);
             self::assertEquals($message->event(), $loadedMessage->event());
-            self::assertEquals($message->header(StreamHeader::class)->streamName, $loadedMessage->header(StreamHeader::class)->streamName);
-            self::assertEquals($message->header(StreamHeader::class)->playhead, $loadedMessage->header(StreamHeader::class)->playhead);
-            self::assertEquals($message->header(StreamHeader::class)->recordedOn, $loadedMessage->header(StreamHeader::class)->recordedOn);
+            self::assertEquals(
+                $message->header(StreamHeader::class)->streamName,
+                $loadedMessage->header(StreamHeader::class)->streamName,
+            );
+            self::assertEquals(
+                $message->header(StreamHeader::class)->playhead,
+                $loadedMessage->header(StreamHeader::class)->playhead,
+            );
+            self::assertEquals(
+                $message->header(StreamHeader::class)->recordedOn,
+                $loadedMessage->header(StreamHeader::class)->recordedOn,
+            );
+        } finally {
+            $stream?->close();
+        }
+    }
+
+    public function testLoadWithWildcard(): void
+    {
+        $profileId1 = ProfileId::generate();
+        $profileId2 = ProfileId::generate();
+
+        $messages = [
+            Message::create(new ProfileCreated($profileId1, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId1->toString()),
+                    1,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId2, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId2->toString()),
+                    1,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                )),
+            Message::create(new ExternEvent('test message'))
+                ->withHeader(new StreamHeader(
+                    'foo',
+                )),
+        ];
+
+        $this->store->save(...$messages);
+
+        $stream = null;
+
+        try {
+            $stream = $this->store->load(new Criteria(new StreamCriterion('profile-*')));
+
+            $messages = iterator_to_array($stream);
+
+            self::assertCount(2, $messages);
         } finally {
             $stream?->close();
         }
@@ -273,7 +341,7 @@ final class StreamDoctrineDbalStoreTest extends TestCase
                     2,
                     new DateTimeImmutable('2020-01-02 00:00:00'),
                 )),
-            Message::create(new ProfileCreated($profileId, 'test'))
+            Message::create(new ExternEvent('foo bar'))
                 ->withHeader(new StreamHeader(
                     sprintf('foo'),
                 )),
@@ -306,7 +374,7 @@ final class StreamDoctrineDbalStoreTest extends TestCase
                     2,
                     new DateTimeImmutable('2020-01-02 00:00:00'),
                 )),
-            Message::create(new ProfileCreated($profileId, 'test'))
+            Message::create(new ExternEvent('foo bar'))
                 ->withHeader(new StreamHeader(
                     sprintf('foo'),
                 )),

--- a/tests/Integration/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Integration/Store/StreamDoctrineDbalStoreTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\Store;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Patchlevel\EventSourcing\Clock\FrozenClock;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
+use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
+use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
+use Patchlevel\EventSourcing\Store\StreamHeader;
+use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
+use Patchlevel\EventSourcing\Tests\DbalManager;
+use Patchlevel\EventSourcing\Tests\Integration\Store\Events\ProfileCreated;
+use PHPUnit\Framework\TestCase;
+
+use function json_decode;
+use function sprintf;
+
+/** @coversNothing */
+final class StreamDoctrineDbalStoreTest extends TestCase
+{
+    private Connection $connection;
+    private Store $store;
+
+    public function setUp(): void
+    {
+        $this->connection = DbalManager::createConnection();
+
+        $clock = new FrozenClock(new DateTimeImmutable('2020-01-01 00:00:00'));
+
+        $this->store = new StreamDoctrineDbalStore(
+            $this->connection,
+            DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
+            clock: $clock,
+        );
+
+        $schemaDirector = new DoctrineSchemaDirector(
+            $this->connection,
+            $this->store,
+        );
+
+        $schemaDirector->create();
+    }
+
+    public function tearDown(): void
+    {
+        $this->connection->close();
+    }
+
+    public function testSave(): void
+    {
+        $profileId = ProfileId::generate();
+
+        $messages = [
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    1,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    2,
+                    new DateTimeImmutable('2020-01-02 00:00:00'),
+                )),
+        ];
+
+        $this->store->save(...$messages);
+
+        /** @var list<array<string, string>> $result */
+        $result = $this->connection->fetchAllAssociative('SELECT * FROM event_store');
+
+        self::assertCount(2, $result);
+
+        $result1 = $result[0];
+
+        self::assertEquals(sprintf('profile-%s', $profileId->toString()), $result1['stream']);
+        self::assertEquals('1', $result1['playhead']);
+        self::assertStringContainsString('2020-01-01 00:00:00', $result1['recorded_on']);
+        self::assertEquals('profile.created', $result1['event']);
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+
+        $result2 = $result[1];
+
+        self::assertEquals(sprintf('profile-%s', $profileId->toString()), $result2['stream']);
+        self::assertEquals('2', $result2['playhead']);
+        self::assertStringContainsString('2020-01-02 00:00:00', $result2['recorded_on']);
+        self::assertEquals('profile.created', $result2['event']);
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+    }
+
+    public function testSaveWithNullableValues(): void
+    {
+        $profileId = ProfileId::generate();
+
+        $messages = [
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader('extern')),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader('extern')),
+        ];
+
+        $this->store->save(...$messages);
+
+        /** @var list<array<string, string>> $result */
+        $result = $this->connection->fetchAllAssociative('SELECT * FROM event_store');
+
+        self::assertCount(2, $result);
+
+        $result1 = $result[0];
+
+        self::assertEquals('extern', $result1['stream']);
+        self::assertEquals(null, $result1['playhead']);
+        self::assertStringContainsString('2020-01-01 00:00:00', $result1['recorded_on']);
+        self::assertEquals('profile.created', $result1['event']);
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+
+        $result2 = $result[1];
+
+        self::assertEquals('extern', $result2['stream']);
+        self::assertEquals(null, $result2['playhead']);
+        self::assertStringContainsString('2020-01-01 00:00:00', $result2['recorded_on']);
+        self::assertEquals('profile.created', $result2['event']);
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+    }
+
+    public function testSaveWithTransactional(): void
+    {
+        $profileId = ProfileId::generate();
+
+        $messages = [
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    1,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    2,
+                    new DateTimeImmutable('2020-01-02 00:00:00'),
+                )),
+        ];
+
+        $this->store->transactional(function () use ($messages): void {
+            $this->store->save(...$messages);
+        });
+
+        /** @var list<array<string, string>> $result */
+        $result = $this->connection->fetchAllAssociative('SELECT * FROM event_store');
+
+        self::assertCount(2, $result);
+
+        $result1 = $result[0];
+
+        self::assertEquals(sprintf('profile-%s', $profileId->toString()), $result1['stream']);
+        self::assertEquals('1', $result1['playhead']);
+        self::assertStringContainsString('2020-01-01 00:00:00', $result1['recorded_on']);
+        self::assertEquals('profile.created', $result1['event']);
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+
+        $result2 = $result[1];
+
+        self::assertEquals(sprintf('profile-%s', $profileId->toString()), $result2['stream']);
+        self::assertEquals('2', $result2['playhead']);
+        self::assertStringContainsString('2020-01-02 00:00:00', $result2['recorded_on']);
+        self::assertEquals('profile.created', $result2['event']);
+        self::assertEquals(['profileId' => $profileId->toString(), 'name' => 'test'], json_decode($result1['payload'], true));
+    }
+
+    public function testUniqueConstraint(): void
+    {
+        $this->expectException(UniqueConstraintViolation::class);
+
+        $profileId = ProfileId::generate();
+
+        $messages = [
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    1,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                )),
+            Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    1,
+                    new DateTimeImmutable('2020-01-02 00:00:00'),
+                )),
+        ];
+
+        $this->store->save(...$messages);
+    }
+
+    public function testSave10000Messages(): void
+    {
+        $profileId = ProfileId::generate();
+
+        $messages = [];
+
+        for ($i = 1; $i <= 10000; $i++) {
+            $messages[] = Message::create(new ProfileCreated($profileId, 'test'))
+                ->withHeader(new StreamHeader(
+                    sprintf('profile-%s', $profileId->toString()),
+                    $i,
+                    new DateTimeImmutable('2020-01-01 00:00:00'),
+                ));
+        }
+
+        $this->store->save(...$messages);
+
+        /** @var int $result */
+        $result = $this->connection->fetchFirstColumn('SELECT COUNT(*) FROM event_store')[0];
+
+        self::assertEquals(10000, $result);
+    }
+
+    public function testLoad(): void
+    {
+        $profileId = ProfileId::generate();
+
+        $message = Message::create(new ProfileCreated($profileId, 'test'))
+            ->withHeader(new StreamHeader(
+                sprintf('profile-%s', $profileId->toString()),
+                1,
+                new DateTimeImmutable('2020-01-01 00:00:00'),
+            ));
+
+        $this->store->save($message);
+
+        $stream = null;
+
+        try {
+            $stream = $this->store->load();
+
+            self::assertSame(1, $stream->index());
+            self::assertSame(0, $stream->position());
+
+            $loadedMessage = $stream->current();
+
+            self::assertInstanceOf(Message::class, $loadedMessage);
+            self::assertNotSame($message, $loadedMessage);
+            self::assertEquals($message->event(), $loadedMessage->event());
+            self::assertEquals($message->header(StreamHeader::class)->streamName, $loadedMessage->header(StreamHeader::class)->streamName);
+            self::assertEquals($message->header(StreamHeader::class)->playhead, $loadedMessage->header(StreamHeader::class)->playhead);
+            self::assertEquals($message->header(StreamHeader::class)->recordedOn, $loadedMessage->header(StreamHeader::class)->recordedOn);
+        } finally {
+            $stream?->close();
+        }
+    }
+}

--- a/tests/Integration/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Integration/Store/StreamDoctrineDbalStoreTest.php
@@ -12,9 +12,9 @@ use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\Criteria\Criteria;
 use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
-use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
 use Patchlevel\EventSourcing\Store\StreamHeader;
+use Patchlevel\EventSourcing\Store\StreamStore;
 use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
 use Patchlevel\EventSourcing\Tests\DbalManager;
 use Patchlevel\EventSourcing\Tests\Integration\Store\Events\ExternEvent;
@@ -29,7 +29,7 @@ use function sprintf;
 final class StreamDoctrineDbalStoreTest extends TestCase
 {
     private Connection $connection;
-    private Store $store;
+    private StreamStore $store;
 
     public function setUp(): void
     {
@@ -342,9 +342,7 @@ final class StreamDoctrineDbalStoreTest extends TestCase
                     new DateTimeImmutable('2020-01-02 00:00:00'),
                 )),
             Message::create(new ExternEvent('foo bar'))
-                ->withHeader(new StreamHeader(
-                    sprintf('foo'),
-                )),
+                ->withHeader(new StreamHeader('foo')),
         ];
 
         $this->store->save(...$messages);
@@ -375,9 +373,7 @@ final class StreamDoctrineDbalStoreTest extends TestCase
                     new DateTimeImmutable('2020-01-02 00:00:00'),
                 )),
             Message::create(new ExternEvent('foo bar'))
-                ->withHeader(new StreamHeader(
-                    sprintf('foo'),
-                )),
+                ->withHeader(new StreamHeader('foo')),
         ];
 
         $this->store->save(...$messages);

--- a/tests/Unit/Console/OutputStyleTest.php
+++ b/tests/Unit/Console/OutputStyleTest.php
@@ -62,7 +62,7 @@ final class OutputStyleTest extends TestCase
         self::assertStringContainsString('profile.created', $content);
         self::assertStringContainsString('profile', $content);
         self::assertStringContainsString('{"id":"1","email":"foo@bar.com"}', $content);
-        self::assertStringContainsString('aggregate', $content);
+        self::assertStringContainsString('stream', $content);
         self::assertStringContainsString('profile', $content);
     }
 
@@ -106,7 +106,7 @@ final class OutputStyleTest extends TestCase
         self::assertStringContainsString('profile.created', $content);
         self::assertStringContainsString('profile', $content);
         self::assertStringContainsString('{"id":"1","email":"foo@bar.com"}', $content);
-        self::assertStringContainsString('aggregate', $content);
+        self::assertStringContainsString('stream', $content);
         self::assertStringContainsString('profile', $content);
     }
 }

--- a/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
@@ -1,0 +1,1503 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use ArrayIterator;
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\SQL\Builder\DefaultSelectSQLBuilder;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use EmptyIterator;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
+use Patchlevel\EventSourcing\Serializer\EventSerializer;
+use Patchlevel\EventSourcing\Serializer\SerializedEvent;
+use Patchlevel\EventSourcing\Store\Criteria\CriteriaBuilder;
+use Patchlevel\EventSourcing\Store\MissingDataForStorage;
+use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
+use Patchlevel\EventSourcing\Store\StreamHeader;
+use Patchlevel\EventSourcing\Store\StreamStartHeader;
+use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
+use Patchlevel\EventSourcing\Store\WrongQueryResult;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Header\BazHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Header\FooHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileEmailChanged;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PDO;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Clock\ClockInterface;
+use RuntimeException;
+
+use function iterator_to_array;
+use function method_exists;
+
+/** @covers \Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore */
+final class StreamDoctrineDbalStoreTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testLoadWithNoEvents(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->willReturn(new EmptyIterator());
+
+        $connection->executeQuery(
+            'SELECT * FROM event_store WHERE (stream = :stream) AND (playhead > :playhead) AND (archived = :archived) ORDER BY id ASC',
+            [
+                'stream' => 'profile-1',
+                'playhead' => 0,
+                'archived' => false,
+            ],
+            Argument::type('array'),
+        )->willReturn($result->reveal());
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+        $abstractPlatform->createSelectSQLBuilder()->shouldBeCalledOnce()->willReturn(new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        ));
+
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+        $queryBuilder = new QueryBuilder($connection->reveal());
+        $connection->createQueryBuilder()->willReturn($queryBuilder);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $stream = $doctrineDbalStore->load(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->fromPlayhead(0)
+                ->archived(false)
+                ->build(),
+        );
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithLimit(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->willReturn(new EmptyIterator());
+
+        $connection->executeQuery(
+            'SELECT * FROM event_store WHERE (stream = :stream) AND (playhead > :playhead) AND (archived = :archived) ORDER BY id ASC LIMIT 10',
+            [
+                'stream' => 'profile-1',
+                'playhead' => 0,
+                'archived' => false,
+            ],
+            Argument::type('array'),
+        )->willReturn($result->reveal());
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+        $abstractPlatform->createSelectSQLBuilder()->shouldBeCalledOnce()->willReturn(new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        ));
+
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+        $queryBuilder = new QueryBuilder($connection->reveal());
+        $connection->createQueryBuilder()->willReturn($queryBuilder);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $stream = $doctrineDbalStore->load(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->fromPlayhead(0)
+                ->archived(false)
+                ->build(),
+            10,
+        );
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithOffset(): void
+    {
+        if (method_exists(AbstractPlatform::class, 'supportsLimitOffset')) {
+            $this->markTestSkipped('In older DBAL versions platforms did not need to support this');
+        }
+
+        $connection = $this->prophesize(Connection::class);
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->willReturn(new EmptyIterator());
+
+        $connection->executeQuery(
+            'SELECT * FROM event_store WHERE (stream = :stream) AND (playhead > :playhead) AND (archived = :archived) ORDER BY id ASC OFFSET 5',
+            [
+                'stream' => 'profile-1',
+                'playhead' => 0,
+                'archived' => false,
+            ],
+            Argument::type('array'),
+        )->willReturn($result->reveal());
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+        $abstractPlatform->createSelectSQLBuilder()->shouldBeCalledOnce()->willReturn(new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        ));
+
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+        $queryBuilder = new QueryBuilder($connection->reveal());
+        $connection->createQueryBuilder()->willReturn($queryBuilder);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $stream = $doctrineDbalStore->load(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->fromPlayhead(0)
+                ->archived(false)
+                ->build(),
+            offset: 5,
+        );
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithIndex(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->willReturn(new EmptyIterator());
+
+        $connection->executeQuery(
+            'SELECT * FROM event_store WHERE (stream = :stream) AND (playhead > :playhead) AND (id > :index) AND (archived = :archived) ORDER BY id ASC',
+            [
+                'stream' => 'profile-1',
+                'playhead' => 0,
+                'archived' => false,
+                'index' => 1,
+            ],
+            Argument::type('array'),
+        )->willReturn($result->reveal());
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+        $abstractPlatform->createSelectSQLBuilder()->shouldBeCalledOnce()->willReturn(new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        ));
+
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+        $queryBuilder = new QueryBuilder($connection->reveal());
+        $connection->createQueryBuilder()->willReturn($queryBuilder);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $stream = $doctrineDbalStore->load(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->fromPlayhead(0)
+                ->archived(false)
+                ->fromIndex(1)
+                ->build(),
+        );
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithOneEvent(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->willReturn(new ArrayIterator(
+            [
+                [
+                    'id' => 1,
+                    'stream' => 'profile-1',
+                    'playhead' => '1',
+                    'event' => 'profile.created',
+                    'payload' => '{"profileId": "1", "email": "s"}',
+                    'recorded_on' => '2021-02-17 10:00:00',
+                    'archived' => '0',
+                    'new_stream_start' => '0',
+                    'custom_headers' => '[]',
+                ],
+            ],
+        ));
+
+        $connection->executeQuery(
+            'SELECT * FROM event_store WHERE (stream = :stream) AND (playhead > :playhead) AND (archived = :archived) ORDER BY id ASC',
+            [
+                'stream' => 'profile-1',
+                'playhead' => 0,
+                'archived' => false,
+            ],
+            Argument::type('array'),
+        )->willReturn($result->reveal());
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+
+        $abstractPlatform->createSelectSQLBuilder()->shouldBeCalledOnce()->willReturn(new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        ));
+        $abstractPlatform->getDateTimeTzFormatString()->shouldBeCalledOnce()->willReturn('Y-m-d H:i:s');
+
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+
+        $queryBuilder = new QueryBuilder($connection->reveal());
+        $connection->createQueryBuilder()->willReturn($queryBuilder);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->deserialize(
+            new SerializedEvent('profile.created', '{"profileId": "1", "email": "s"}'),
+        )->willReturn(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->deserialize('[]')->willReturn([]);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $stream = $doctrineDbalStore->load(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->fromPlayhead(0)
+                ->archived(false)
+                ->build(),
+        );
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+
+        $message = $stream->current();
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+
+        self::assertInstanceOf(Message::class, $message);
+        self::assertInstanceOf(ProfileCreated::class, $message->event());
+        self::assertSame('profile-1', $message->header(StreamHeader::class)->streamName);
+        self::assertSame(1, $message->header(StreamHeader::class)->playhead);
+        self::assertEquals(
+            new DateTimeImmutable('2021-02-17 10:00:00'),
+            $message->header(StreamHeader::class)->recordedOn,
+        );
+
+        iterator_to_array($stream);
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+    }
+
+    public function testLoadWithTwoEvents(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->willReturn(new ArrayIterator(
+            [
+                [
+                    'id' => 1,
+                    'stream' => 'profile-1',
+                    'playhead' => '1',
+                    'event' => 'profile.created',
+                    'payload' => '{"profileId": "1", "email": "s"}',
+                    'recorded_on' => '2021-02-17 10:00:00',
+                    'archived' => '0',
+                    'new_stream_start' => '0',
+                    'custom_headers' => '[]',
+                ],
+                [
+                    'id' => 2,
+                    'stream' => 'profile-1',
+                    'playhead' => '2',
+                    'event' => 'profile.email_changed',
+                    'payload' => '{"profileId": "1", "email": "d"}',
+                    'recorded_on' => '2021-02-17 11:00:00',
+                    'archived' => '0',
+                    'new_stream_start' => '0',
+                    'custom_headers' => '[]',
+                ],
+            ],
+        ));
+
+        $connection->executeQuery(
+            'SELECT * FROM event_store WHERE (stream = :stream) AND (playhead > :playhead) AND (archived = :archived) ORDER BY id ASC',
+            [
+                'stream' => 'profile-1',
+                'playhead' => 0,
+                'archived' => false,
+            ],
+            Argument::type('array'),
+        )->willReturn($result->reveal());
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+        $abstractPlatform->createSelectSQLBuilder()->shouldBeCalledOnce()->willReturn(new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        ));
+        $abstractPlatform->getDateTimeTzFormatString()->shouldBeCalledTimes(2)->willReturn('Y-m-d H:i:s');
+
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+
+        $queryBuilder = new QueryBuilder($connection->reveal());
+        $connection->createQueryBuilder()->willReturn($queryBuilder);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->deserialize(
+            new SerializedEvent('profile.created', '{"profileId": "1", "email": "s"}'),
+        )->willReturn(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')));
+        $eventSerializer->deserialize(
+            new SerializedEvent('profile.email_changed', '{"profileId": "1", "email": "d"}'),
+        )->willReturn(new ProfileEmailChanged(ProfileId::fromString('1'), Email::fromString('d')));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->deserialize('[]')->willReturn([]);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $stream = $doctrineDbalStore->load(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->fromPlayhead(0)
+                ->archived(false)
+                ->build(),
+        );
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+
+        $message = $stream->current();
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+
+        self::assertInstanceOf(Message::class, $message);
+        self::assertInstanceOf(ProfileCreated::class, $message->event());
+        self::assertSame('profile-1', $message->header(StreamHeader::class)->streamName);
+        self::assertSame(1, $message->header(StreamHeader::class)->playhead);
+        self::assertEquals(
+            new DateTimeImmutable('2021-02-17 10:00:00'),
+            $message->header(StreamHeader::class)->recordedOn,
+        );
+
+        $stream->next();
+        $message = $stream->current();
+
+        self::assertSame(2, $stream->index());
+        self::assertSame(1, $stream->position());
+
+        self::assertInstanceOf(Message::class, $message);
+        self::assertInstanceOf(ProfileEmailChanged::class, $message->event());
+        self::assertSame('profile-1', $message->header(StreamHeader::class)->streamName);
+        self::assertSame(2, $message->header(StreamHeader::class)->playhead);
+        self::assertEquals(
+            new DateTimeImmutable('2021-02-17 11:00:00'),
+            $message->header(StreamHeader::class)->recordedOn,
+        );
+    }
+
+    public function testTransactional(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $connection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        )->shouldBeCalled();
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $store->transactional($callback(...));
+
+        self::assertTrue($callback->called);
+    }
+
+    public function testTransactionalWithMySQL(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new MySQLPlatform());
+        $connection->fetchAllAssociative('SELECT GET_LOCK("133742", -1)')->shouldBeCalledOnce()->willReturn([]);
+        $connection->fetchAllAssociative('SELECT RELEASE_LOCK("133742")')->shouldBeCalledOnce()->willReturn([]);
+
+        $connection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        )->shouldBeCalled();
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $store->transactional($callback(...));
+
+        self::assertTrue($callback->called);
+    }
+
+    public function testTransactionalWithMariaDB(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new MariaDBPlatform());
+        $connection->fetchAllAssociative('SELECT GET_LOCK("133742", -1)')->shouldBeCalledOnce()->willReturn([]);
+        $connection->fetchAllAssociative('SELECT RELEASE_LOCK("133742")')->shouldBeCalledOnce()->willReturn([]);
+
+        $connection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        )->shouldBeCalled();
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $store->transactional($callback(...));
+
+        self::assertTrue($callback->called);
+    }
+
+    public function testTransactionalWithPostgreSQL(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new PostgreSQLPlatform());
+        $connection->executeStatement('SELECT pg_advisory_xact_lock(133742)')->shouldBeCalledOnce();
+
+        $connection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        )->shouldBeCalled();
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $store->transactional($callback(...));
+
+        self::assertTrue($callback->called);
+    }
+
+    public function testTransactionalNested(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new PostgreSQLPlatform());
+        $connection->executeStatement('SELECT pg_advisory_xact_lock(133742)')->shouldBeCalledOnce();
+
+        $connection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        )->shouldBeCalledTimes(2);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $store->transactional(static function () use ($store, $callback): void {
+            $store->transactional($callback(...));
+        });
+
+        self::assertTrue($callback->called);
+    }
+
+    public function testTransactionalTwice(): void
+    {
+        $callback = new class () {
+            public int $called = 0;
+
+            public function __invoke(): void
+            {
+                $this->called++;
+            }
+        };
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new PostgreSQLPlatform());
+        $connection->executeStatement('SELECT pg_advisory_xact_lock(133742)')->shouldBeCalledTimes(2);
+
+        $connection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        )->shouldBeCalled();
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $store->transactional($callback(...));
+        $store->transactional($callback(...));
+
+        self::assertEquals(2, $callback->called);
+    }
+
+    public function testTransactionalUnlockByException(): void
+    {
+        $callback = new class () {
+            public function __invoke(): void
+            {
+                throw new RuntimeException();
+            }
+        };
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getDatabasePlatform()->willReturn(new MariaDBPlatform());
+        $connection->fetchAllAssociative('SELECT GET_LOCK("133742", -1)')->shouldBeCalledOnce()->willReturn([]);
+        $connection->fetchAllAssociative('SELECT RELEASE_LOCK("133742")')->shouldBeCalledOnce()->willReturn([]);
+
+        $connection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        )->shouldBeCalled();
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $this->expectException(RuntimeException::class);
+
+        $store->transactional($callback(...));
+    }
+
+    public function testSaveWithOneEvent(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                1,
+                $recordedOn,
+            ));
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->serialize($message->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_created',
+            '',
+        ));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->serialize([])->willReturn('[]');
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $mockedConnection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        );
+
+        $mockedConnection->executeStatement(
+            "INSERT INTO event_store (stream, playhead, event, payload, recorded_on, new_stream_start, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?)",
+            ['profile-1', 1, 'profile_created', '', $recordedOn, false, false, '[]'],
+            [
+                4 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                5 => Type::getType(Types::BOOLEAN),
+                6 => Type::getType(Types::BOOLEAN),
+            ],
+        )->shouldBeCalledOnce();
+
+        $singleTableStore = new StreamDoctrineDbalStore(
+            $mockedConnection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+        $singleTableStore->save($message);
+    }
+
+    public function testSaveWithoutStreamHeader(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')));
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->serialize($message->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_created',
+            '',
+        ));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->serialize([])->willReturn('[]');
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $mockedConnection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        );
+
+        $mockedConnection->executeStatement(
+            "INSERT INTO event_store (stream, playhead, event, payload, recorded_on, new_stream_start, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?)",
+            ['profile-1', 1, 'profile_created', '', $recordedOn, false, false, []],
+            [
+                4 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                5 => Type::getType(Types::BOOLEAN),
+                6 => Type::getType(Types::BOOLEAN),
+            ],
+        )->shouldNotBeCalled();
+
+        $singleTableStore = new StreamDoctrineDbalStore(
+            $mockedConnection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $this->expectException(MissingDataForStorage::class);
+        $singleTableStore->save($message);
+    }
+
+    public function testSaveWithTwoEvents(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message1 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                1,
+                $recordedOn,
+            ));
+        $message2 = Message::create(new ProfileEmailChanged(ProfileId::fromString('1'), Email::fromString('d')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                2,
+                $recordedOn,
+            ));
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->serialize($message1->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_created',
+            '',
+        ));
+        $eventSerializer->serialize($message2->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_email_changed',
+            '',
+        ));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->serialize([])->willReturn('[]');
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $mockedConnection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        );
+
+        $mockedConnection->executeStatement(
+            "INSERT INTO event_store (stream, playhead, event, payload, recorded_on, new_stream_start, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?),\n(?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                'profile-1',
+                1,
+                'profile_created',
+                '',
+                $recordedOn,
+                false,
+                false,
+                '[]',
+                'profile-1',
+                2,
+                'profile_email_changed',
+                '',
+                $recordedOn,
+                false,
+                false,
+                '[]',
+            ],
+            [
+                4 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                5 => Type::getType(Types::BOOLEAN),
+                6 => Type::getType(Types::BOOLEAN),
+                12 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                13 => Type::getType(Types::BOOLEAN),
+                14 => Type::getType(Types::BOOLEAN),
+            ],
+        )->shouldBeCalledOnce();
+
+        $singleTableStore = new StreamDoctrineDbalStore(
+            $mockedConnection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+        $singleTableStore->save($message1, $message2);
+    }
+
+    public function testSaveWithUniqueConstraintViolation(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message1 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                1,
+                $recordedOn,
+            ));
+        $message2 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                1,
+                $recordedOn,
+            ));
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->serialize($message1->event())->shouldBeCalledTimes(2)->willReturn(new SerializedEvent(
+            'profile_created',
+            '',
+        ));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->serialize([])->willReturn('[]');
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $mockedConnection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        );
+
+        $mockedConnection->executeStatement(
+            "INSERT INTO event_store (stream, playhead, event, payload, recorded_on, new_stream_start, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?),\n(?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                'profile-1',
+                1,
+                'profile_created',
+                '',
+                $recordedOn,
+                false,
+                false,
+                '[]',
+                'profile-1',
+                1,
+                'profile_created',
+                '',
+                $recordedOn,
+                false,
+                false,
+                '[]',
+            ],
+            [
+                4 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                5 => Type::getType(Types::BOOLEAN),
+                6 => Type::getType(Types::BOOLEAN),
+                12 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                13 => Type::getType(Types::BOOLEAN),
+                14 => Type::getType(Types::BOOLEAN),
+            ],
+        )->shouldBeCalledOnce()->willThrow(UniqueConstraintViolationException::class);
+
+        $singleTableStore = new StreamDoctrineDbalStore(
+            $mockedConnection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $this->expectException(UniqueConstraintViolation::class);
+        $singleTableStore->save($message1, $message2);
+    }
+
+    public function testSaveWithThousandEvents(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+
+        $messages = [];
+        for ($i = 1; $i <= 10000; $i++) {
+            $messages[] = Message::create(new ProfileEmailChanged(ProfileId::fromString('1'), Email::fromString('s')))
+                ->withHeader(new StreamHeader(
+                    'profile-1',
+                    $i,
+                    $recordedOn,
+                ));
+        }
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->serialize($messages[0]->event())->shouldBeCalledTimes(10000)->willReturn(new SerializedEvent(
+            'profile_email_changed',
+            '',
+        ));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->serialize([])->willReturn('[]');
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $mockedConnection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        );
+
+        $mockedConnection->executeStatement(Argument::any(), Argument::any(), Argument::any())
+            ->shouldBeCalledTimes(2);
+
+        $singleTableStore = new StreamDoctrineDbalStore(
+            $mockedConnection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+        $singleTableStore->save(...$messages);
+    }
+
+    public function testSaveWithCustomHeaders(): void
+    {
+        $customHeaders = [
+            new FooHeader('foo'),
+            new BazHeader('baz'),
+        ];
+
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                1,
+                $recordedOn,
+            ))
+            ->withHeaders($customHeaders);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->serialize($message->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_created',
+            '',
+        ));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->serialize($customHeaders)->willReturn('{foo: "foo", baz: "baz"}');
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $mockedConnection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        );
+
+        $mockedConnection->executeStatement(
+            "INSERT INTO event_store (stream, playhead, event, payload, recorded_on, new_stream_start, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?)",
+            ['profile-1', 1, 'profile_created', '', $recordedOn, false, false, '{foo: "foo", baz: "baz"}'],
+            [
+                4 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                5 => Type::getType(Types::BOOLEAN),
+                6 => Type::getType(Types::BOOLEAN),
+            ],
+        )->shouldBeCalledOnce();
+
+        $singleTableStore = new StreamDoctrineDbalStore(
+            $mockedConnection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+        $singleTableStore->save($message);
+    }
+
+    public function testCount(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $connection->fetchOne(
+            'SELECT COUNT(*) FROM event_store WHERE (stream = :stream) AND (playhead > :playhead) AND (archived = :archived)',
+            [
+                'stream' => 'profile-1',
+                'playhead' => 0,
+                'archived' => false,
+            ],
+            Argument::type('array'),
+        )->willReturn('1');
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+        $abstractPlatform->createSelectSQLBuilder()->shouldBeCalledOnce()->willReturn(new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        ));
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+
+        $queryBuilder = new QueryBuilder($connection->reveal());
+        $connection->createQueryBuilder()->willReturn($queryBuilder);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $count = $doctrineDbalStore->count(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->fromPlayhead(0)
+                ->archived(false)
+                ->build(),
+        );
+
+        self::assertSame(1, $count);
+    }
+
+    public function testCountWrongResult(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $connection->fetchOne(
+            'SELECT COUNT(*) FROM event_store WHERE (stream = :stream) AND (playhead > :playhead) AND (archived = :archived)',
+            [
+                'stream' => 'profile-1',
+                'playhead' => 0,
+                'archived' => false,
+            ],
+            Argument::type('array'),
+        )->willReturn([]);
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+        $abstractPlatform->createSelectSQLBuilder()->shouldBeCalledOnce()->willReturn(new DefaultSelectSQLBuilder(
+            $abstractPlatform->reveal(),
+            'FOR UPDATE',
+            'SKIP LOCKED',
+        ));
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+
+        $queryBuilder = new QueryBuilder($connection->reveal());
+        $connection->createQueryBuilder()->willReturn($queryBuilder);
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $this->expectException(WrongQueryResult::class);
+        $doctrineDbalStore->count(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->fromPlayhead(0)
+                ->archived(false)
+                ->build(),
+        );
+    }
+
+    public function testSetupSubscription(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $connection->executeStatement(
+            <<<'SQL'
+                CREATE OR REPLACE FUNCTION notify_event_store() RETURNS TRIGGER AS $$
+                    BEGIN
+                        PERFORM pg_notify('event_store', 'update');
+                        RETURN NEW;
+                    END;
+                $$ LANGUAGE plpgsql;
+                SQL,
+        )->shouldBeCalledOnce()->willReturn(1);
+        $connection->executeStatement('DROP TRIGGER IF EXISTS notify_trigger ON event_store;')
+            ->shouldBeCalledOnce()->willReturn(1);
+        $connection->executeStatement('CREATE TRIGGER notify_trigger AFTER INSERT OR UPDATE ON event_store FOR EACH ROW EXECUTE PROCEDURE notify_event_store();')
+            ->shouldBeCalledOnce()->willReturn(1);
+
+        $abstractPlatform = $this->prophesize(PostgreSQLPlatform::class);
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+        $doctrineDbalStore->setupSubscription();
+    }
+
+    public function testSetupSubscriptionWithOtherStoreTableName(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $connection->executeStatement(
+            <<<'SQL'
+                CREATE OR REPLACE FUNCTION new.notify_event_store() RETURNS TRIGGER AS $$
+                    BEGIN
+                        PERFORM pg_notify('new.event_store', 'update');
+                        RETURN NEW;
+                    END;
+                $$ LANGUAGE plpgsql;
+                SQL,
+        )->shouldBeCalledOnce()->willReturn(1);
+        $connection->executeStatement('DROP TRIGGER IF EXISTS notify_trigger ON new.event_store;')
+            ->shouldBeCalledOnce()->willReturn(1);
+        $connection->executeStatement('CREATE TRIGGER notify_trigger AFTER INSERT OR UPDATE ON new.event_store FOR EACH ROW EXECUTE PROCEDURE new.notify_event_store();')
+            ->shouldBeCalledOnce()->willReturn(1);
+
+        $abstractPlatform = $this->prophesize(PostgreSQLPlatform::class);
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $clock = $this->prophesize(ClockInterface::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+            $clock->reveal(),
+            ['table_name' => 'new.event_store'],
+        );
+        $doctrineDbalStore->setupSubscription();
+    }
+
+    public function testSetupSubscriptionNotPostgres(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $connection->executeStatement(
+            <<<'SQL'
+                CREATE OR REPLACE FUNCTION notify_event_store() RETURNS TRIGGER AS $$
+                    BEGIN
+                        PERFORM pg_notify('event_store');
+                        RETURN NEW;
+                    END;
+                $$ LANGUAGE plpgsql;
+                SQL,
+        )->shouldNotBeCalled();
+        $connection->executeStatement('DROP TRIGGER IF EXISTS notify_trigger ON event_store;')
+            ->shouldNotBeCalled();
+        $connection->executeStatement('CREATE TRIGGER notify_trigger AFTER INSERT OR UPDATE ON event_store FOR EACH ROW EXECUTE PROCEDURE notify_event_store();')
+            ->shouldNotBeCalled();
+
+        $abstractPlatform = $this->prophesize(AbstractPlatform::class);
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+        $doctrineDbalStore->setupSubscription();
+    }
+
+    public function testWait(): void
+    {
+        $nativeConnection = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['pgsqlGetNotify'])
+            ->getMock();
+        $nativeConnection
+            ->expects($this->once())
+            ->method('pgsqlGetNotify')
+            ->with(PDO::FETCH_ASSOC, 100)
+            ->willReturn([]);
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->executeStatement('LISTEN "event_store"')
+            ->shouldBeCalledOnce()
+            ->willReturn(1);
+        $connection->getNativeConnection()
+            ->shouldBeCalledOnce()
+            ->willReturn($nativeConnection);
+
+        $abstractPlatform = $this->prophesize(PostgreSQLPlatform::class);
+        $connection->getDatabasePlatform()->willReturn($abstractPlatform->reveal());
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+        $doctrineDbalStore->wait(100);
+    }
+
+    public function testConfigureSchemaWithDifferentConnections(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+        $schema = new Schema();
+        $doctrineDbalStore->configureSchema($schema, $this->prophesize(Connection::class)->reveal());
+
+        self::assertEquals(new Schema(), $schema);
+    }
+
+    public function testConfigureSchema(): void
+    {
+        $connection = $this->prophesize(Connection::class);
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $expectedSchema = new Schema();
+        $table = $expectedSchema->createTable('event_store');
+        $table->addColumn('id', Types::BIGINT)
+            ->setAutoincrement(true)
+            ->setNotnull(true);
+        $table->addColumn('stream', Types::STRING)
+            ->setLength(255)
+            ->setNotnull(true);
+        $table->addColumn('playhead', Types::INTEGER)
+            ->setNotnull(false);
+        $table->addColumn('event', Types::STRING)
+            ->setLength(255)
+            ->setNotnull(true);
+        $table->addColumn('payload', Types::JSON)
+            ->setNotnull(true);
+        $table->addColumn('recorded_on', Types::DATETIMETZ_IMMUTABLE)
+            ->setNotnull(true);
+        $table->addColumn('new_stream_start', Types::BOOLEAN)
+            ->setNotnull(true)
+            ->setDefault(false);
+        $table->addColumn('archived', Types::BOOLEAN)
+            ->setNotnull(true)
+            ->setDefault(false);
+        $table->addColumn('custom_headers', Types::JSON)
+            ->setNotnull(true);
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['stream', 'playhead']);
+        $table->addIndex(['stream', 'playhead', 'archived']);
+
+        $schema = new Schema();
+        $doctrineDbalStore->configureSchema($schema, $connection->reveal());
+
+        self::assertEquals($expectedSchema, $schema);
+    }
+
+    #[RequiresPhp('>= 8.2')]
+    public function testArchiveMessagesDifferentAggregates(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message1 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                5,
+                $recordedOn,
+            ))
+            ->withHeader(new StreamStartHeader());
+
+        $message2 = Message::create(new ProfileEmailChanged(ProfileId::fromString('2'), Email::fromString('d')))
+            ->withHeader(new StreamHeader(
+                'profile-2',
+                42,
+                $recordedOn,
+            ))
+            ->withHeader(new StreamStartHeader());
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->serialize($message1->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_created',
+            '',
+        ));
+        $eventSerializer->serialize($message2->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_email_changed',
+            '',
+        ));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->serialize([])->willReturn('[]');
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $mockedConnection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        );
+
+        $mockedConnection->executeStatement(
+            "INSERT INTO event_store (stream, playhead, event, payload, recorded_on, new_stream_start, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?),\n(?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                'profile-1',
+                5,
+                'profile_created',
+                '',
+                $recordedOn,
+                true,
+                false,
+                '[]',
+                'profile-2',
+                42,
+                'profile_email_changed',
+                '',
+                $recordedOn,
+                true,
+                false,
+                '[]',
+            ],
+            [
+                4 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                5 => Type::getType(Types::BOOLEAN),
+                6 => Type::getType(Types::BOOLEAN),
+                12 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                13 => Type::getType(Types::BOOLEAN),
+                14 => Type::getType(Types::BOOLEAN),
+            ],
+        )->shouldBeCalledOnce();
+
+        $mockedConnection->executeStatement(
+            <<<'SQL'
+            UPDATE event_store
+            SET archived = true
+            WHERE stream = :stream
+            AND playhead < :playhead
+            AND archived = false
+            SQL,
+            [
+                'stream' => 'profile-1',
+                'playhead' => 5,
+            ],
+        )->shouldBeCalledOnce();
+
+        $mockedConnection->executeStatement(
+            <<<'SQL'
+            UPDATE event_store
+            SET archived = true
+            WHERE stream = :stream
+            AND playhead < :playhead
+            AND archived = false
+            SQL,
+            [
+                'stream' => 'profile-2',
+                'playhead' => 42,
+            ],
+        )->shouldBeCalledOnce();
+
+        $singleTableStore = new StreamDoctrineDbalStore(
+            $mockedConnection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $singleTableStore->save($message1, $message2);
+    }
+
+    #[RequiresPhp('>= 8.2')]
+    public function testArchiveMessagesSameAggregate(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message1 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                5,
+                $recordedOn,
+            ))
+            ->withHeader(new StreamStartHeader());
+
+        $message2 = Message::create(new ProfileEmailChanged(ProfileId::fromString('1'), Email::fromString('d')))
+            ->withHeader(new StreamHeader(
+                'profile-1',
+                42,
+                $recordedOn,
+            ))
+            ->withHeader(new StreamStartHeader());
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->serialize($message1->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_created',
+            '',
+        ));
+        $eventSerializer->serialize($message2->event())->shouldBeCalledOnce()->willReturn(new SerializedEvent(
+            'profile_email_changed',
+            '',
+        ));
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->serialize([])->willReturn('[]');
+
+        $mockedConnection = $this->prophesize(Connection::class);
+        $mockedConnection->getDatabasePlatform()->willReturn(new SQLitePlatform());
+        $mockedConnection->transactional(Argument::any())->will(
+        /** @param array{0: callable} $args */
+            static fn (array $args): mixed => $args[0](),
+        );
+
+        $mockedConnection->executeStatement(
+            "INSERT INTO event_store (stream, playhead, event, payload, recorded_on, new_stream_start, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?),\n(?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                'profile-1',
+                5,
+                'profile_created',
+                '',
+                $recordedOn,
+                true,
+                false,
+                '[]',
+                'profile-1',
+                42,
+                'profile_email_changed',
+                '',
+                $recordedOn,
+                true,
+                false,
+                '[]',
+            ],
+            [
+                4 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                5 => Type::getType(Types::BOOLEAN),
+                6 => Type::getType(Types::BOOLEAN),
+                12 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                13 => Type::getType(Types::BOOLEAN),
+                14 => Type::getType(Types::BOOLEAN),
+            ],
+        )->shouldBeCalledOnce();
+
+        $mockedConnection->executeStatement(
+            <<<'SQL'
+            UPDATE event_store
+            SET archived = true
+            WHERE stream = :stream
+            AND playhead < :playhead
+            AND archived = false
+            SQL,
+            [
+                'stream' => 'profile-1',
+                'playhead' => 42,
+            ],
+        )->shouldBeCalledOnce();
+
+        $singleTableStore = new StreamDoctrineDbalStore(
+            $mockedConnection->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+        );
+
+        $singleTableStore->save($message1, $message2);
+    }
+}

--- a/tests/Unit/Store/StreamDoctrineDbalStreamTest.php
+++ b/tests/Unit/Store/StreamDoctrineDbalStreamTest.php
@@ -1,0 +1,400 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use ArrayIterator;
+use DateTimeImmutable;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
+use Patchlevel\EventSourcing\Serializer\EventSerializer;
+use Patchlevel\EventSourcing\Serializer\SerializedEvent;
+use Patchlevel\EventSourcing\Store\StreamClosed;
+use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStoreStream;
+use Patchlevel\EventSourcing\Store\StreamHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Throwable;
+
+use function iterator_to_array;
+
+/** @covers \Patchlevel\EventSourcing\Store\StreamDoctrineDbalStoreStream */
+final class StreamDoctrineDbalStreamTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testEmpty(): void
+    {
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $platform = $this->prophesize(AbstractPlatform::class);
+
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->shouldBeCalledOnce()->willReturn(new ArrayIterator());
+
+        $stream = new StreamDoctrineDbalStoreStream(
+            $result->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+            $platform->reveal(),
+        );
+
+        self::assertSame(null, $stream->position());
+        self::assertSame(null, $stream->current());
+        self::assertSame(null, $stream->index());
+        self::assertSame(true, $stream->end());
+
+        $this->expectException(Throwable::class);
+        iterator_to_array($stream);
+    }
+
+    public function testOneMessage(): void
+    {
+        $messages = [
+            [
+                'id' => 1,
+                'event' => 'profile_created',
+                'payload' => '{}',
+                'stream' => 'profile-1',
+                'playhead' => 1,
+                'recorded_on' => '2022-10-10 10:10:10',
+                'archived' => '0',
+                'new_stream_start' => '0',
+                'custom_headers' => '{}',
+            ],
+        ];
+
+        $event = new ProfileCreated(
+            ProfileId::fromString('foo'),
+            Email::fromString('info@patchlevel.de'),
+        );
+        $message = Message::create($event)
+            ->withHeader(new StreamHeader('profile-1', 1, new DateTimeImmutable('2022-10-10 10:10:10')));
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->deserialize(new SerializedEvent('profile_created', '{}'))
+            ->shouldBeCalledOnce()
+            ->willReturn($event);
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->deserialize('{}')->shouldBeCalledOnce()->willReturn([]);
+
+        $platform = $this->prophesize(AbstractPlatform::class);
+        $platform->getDateTimeTzFormatString()->shouldBeCalledOnce()->willReturn('Y-m-d H:i:s');
+
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->shouldBeCalledOnce()->willReturn(new ArrayIterator($messages));
+
+        $stream = new StreamDoctrineDbalStoreStream(
+            $result->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+            $platform->reveal(),
+        );
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+        self::assertEquals($message, $stream->current());
+        self::assertSame(false, $stream->end());
+
+        $stream->next();
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+        self::assertSame(null, $stream->current());
+        self::assertSame(true, $stream->end());
+    }
+
+    public function testMultipleMessages(): void
+    {
+        $messagesArray = [
+            [
+                'id' => 1,
+                'event' => 'profile_created',
+                'payload' => '{}',
+                'stream' => 'profile-1',
+                'playhead' => 1,
+                'recorded_on' => '2022-10-10 10:10:10',
+                'archived' => '0',
+                'new_stream_start' => '0',
+                'custom_headers' => '{}',
+            ],
+            [
+                'id' => 2,
+                'event' => 'profile_created2',
+                'payload' => '{}',
+                'stream' => 'profile-2',
+                'playhead' => null,
+                'recorded_on' => '2022-10-10 10:10:10',
+                'archived' => '0',
+                'new_stream_start' => '0',
+                'custom_headers' => '{}',
+            ],
+            [
+                'id' => 3,
+                'event' => 'profile_created3',
+                'payload' => '{}',
+                'stream' => 'profile-3',
+                'playhead' => 1,
+                'recorded_on' => '2022-10-10 10:10:10',
+                'archived' => '0',
+                'new_stream_start' => '0',
+                'custom_headers' => '{}',
+            ],
+        ];
+
+        $event = new ProfileCreated(
+            ProfileId::fromString('foo'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $messages = [
+            Message::create($event)
+                ->withHeader(new StreamHeader('profile-1', 1, new DateTimeImmutable('2022-10-10 10:10:10'))),
+            Message::create($event)
+                ->withHeader(new StreamHeader('profile-2', null, new DateTimeImmutable('2022-10-10 10:10:10'))),
+            Message::create($event)
+                ->withHeader(new StreamHeader('profile-3', 1, new DateTimeImmutable('2022-10-10 10:10:10'))),
+        ];
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->deserialize(new SerializedEvent('profile_created', '{}'))
+            ->shouldBeCalledOnce()
+            ->willReturn($event);
+        $eventSerializer->deserialize(new SerializedEvent('profile_created2', '{}'))
+            ->shouldBeCalledOnce()
+            ->willReturn($event);
+        $eventSerializer->deserialize(new SerializedEvent('profile_created3', '{}'))
+            ->shouldBeCalledOnce()
+            ->willReturn($event);
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->deserialize('{}')->shouldBeCalledTimes(3)->willReturn([]);
+
+        $platform = $this->prophesize(AbstractPlatform::class);
+        $platform->getDateTimeTzFormatString()->shouldBeCalledTimes(3)->willReturn('Y-m-d H:i:s');
+
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->shouldBeCalledOnce()->willReturn(new ArrayIterator($messagesArray));
+
+        $stream = new StreamDoctrineDbalStoreStream(
+            $result->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+            $platform->reveal(),
+        );
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+        self::assertEquals($messages[0], $stream->current());
+        self::assertSame(false, $stream->end());
+
+        $stream->next();
+
+        self::assertSame(2, $stream->index());
+        self::assertSame(1, $stream->position());
+        self::assertEquals($messages[1], $stream->current());
+        self::assertSame(false, $stream->end());
+
+        $stream->next();
+
+        self::assertSame(3, $stream->index());
+        self::assertSame(2, $stream->position());
+        self::assertEquals($messages[2], $stream->current());
+        self::assertSame(false, $stream->end());
+
+        $stream->next();
+
+        self::assertSame(3, $stream->index());
+        self::assertSame(2, $stream->position());
+        self::assertSame(null, $stream->current());
+        self::assertSame(true, $stream->end());
+    }
+
+    public function testWithNoList(): void
+    {
+        $messages = [
+            5 => [
+                'id' => 5,
+                'event' => 'profile_created',
+                'payload' => '{}',
+                'stream' => 'profile-1',
+                'playhead' => 1,
+                'recorded_on' => '2022-10-10 10:10:10',
+                'archived' => '0',
+                'new_stream_start' => '0',
+                'custom_headers' => '{}',
+            ],
+        ];
+
+        $event = new ProfileCreated(
+            ProfileId::fromString('foo'),
+            Email::fromString('info@patchlevel.de'),
+        );
+        $message = Message::create($event)
+            ->withHeader(new StreamHeader('profile-1', 1, new DateTimeImmutable('2022-10-10 10:10:10')));
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->deserialize(new SerializedEvent('profile_created', '{}'))
+            ->shouldBeCalledOnce()
+            ->willReturn($event);
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->deserialize('{}')->shouldBeCalledOnce()->willReturn([]);
+
+        $platform = $this->prophesize(AbstractPlatform::class);
+        $platform->getDateTimeTzFormatString()->shouldBeCalledOnce()->willReturn('Y-m-d H:i:s');
+
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->shouldBeCalledOnce()->willReturn(new ArrayIterator($messages));
+
+        $stream = new StreamDoctrineDbalStoreStream(
+            $result->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+            $platform->reveal(),
+        );
+
+        self::assertSame(5, $stream->index());
+        self::assertSame(0, $stream->position());
+        self::assertEquals($message, $stream->current());
+        self::assertSame(false, $stream->end());
+
+        $stream->next();
+
+        self::assertSame(5, $stream->index());
+        self::assertSame(0, $stream->position());
+        self::assertSame(null, $stream->current());
+        self::assertSame(true, $stream->end());
+    }
+
+    public function testClose(): void
+    {
+        $messages = [
+            [
+                'id' => 1,
+                'event' => 'profile_created',
+                'payload' => '{}',
+                'stream' => 'profile-1',
+                'playhead' => 1,
+                'recorded_on' => '2022-10-10 10:10:10',
+                'archived' => '0',
+                'new_stream_start' => '0',
+                'custom_headers' => '{}',
+            ],
+        ];
+
+        $event = new ProfileCreated(
+            ProfileId::fromString('foo'),
+            Email::fromString('info@patchlevel.de'),
+        );
+        $message = Message::create($event)
+            ->withHeader(new StreamHeader('profile-1', 1, new DateTimeImmutable('2022-10-10 10:10:10')));
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->deserialize(new SerializedEvent('profile_created', '{}'))
+            ->shouldBeCalledOnce()
+            ->willReturn($event);
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->deserialize('{}')->shouldBeCalledOnce()->willReturn([]);
+
+        $platform = $this->prophesize(AbstractPlatform::class);
+        $platform->getDateTimeTzFormatString()->shouldBeCalledOnce()->willReturn('Y-m-d H:i:s');
+
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->shouldBeCalledOnce()->willReturn(new ArrayIterator($messages));
+        $result->free()->shouldBeCalledOnce();
+
+        $stream = new StreamDoctrineDbalStoreStream(
+            $result->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+            $platform->reveal(),
+        );
+
+        self::assertSame(1, $stream->index());
+        self::assertSame(0, $stream->position());
+        self::assertEquals($message, $stream->current());
+        self::assertSame(false, $stream->end());
+
+        $stream->close();
+
+        $this->expectException(StreamClosed::class);
+        $stream->index();
+    }
+
+    public function testPositionEmpty(): void
+    {
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $platform = $this->prophesize(AbstractPlatform::class);
+
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->shouldBeCalledOnce()->willReturn(new ArrayIterator());
+
+        $stream = new StreamDoctrineDbalStoreStream(
+            $result->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+            $platform->reveal(),
+        );
+
+        $position = $stream->position();
+
+        self::assertNull($position);
+    }
+
+    public function testPosition(): void
+    {
+        $messages = [
+            [
+                'id' => 1,
+                'event' => 'profile_created',
+                'payload' => '{}',
+                'stream' => 'profile-1',
+                'playhead' => 1,
+                'recorded_on' => '2022-10-10 10:10:10',
+                'archived' => '0',
+                'new_stream_start' => '0',
+                'custom_headers' => '{}',
+            ],
+        ];
+
+        $event = new ProfileCreated(
+            ProfileId::fromString('foo'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $eventSerializer = $this->prophesize(EventSerializer::class);
+        $eventSerializer->deserialize(new SerializedEvent('profile_created', '{}'))
+            ->shouldBeCalledOnce()
+            ->willReturn($event);
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+        $headersSerializer->deserialize('{}')->shouldBeCalledOnce()->willReturn([]);
+
+        $platform = $this->prophesize(AbstractPlatform::class);
+        $platform->getDateTimeTzFormatString()->shouldBeCalledOnce()->willReturn('Y-m-d H:i:s');
+
+        $result = $this->prophesize(Result::class);
+        $result->iterateAssociative()->shouldBeCalledOnce()->willReturn(new ArrayIterator($messages));
+
+        $stream = new StreamDoctrineDbalStoreStream(
+            $result->reveal(),
+            $eventSerializer->reveal(),
+            $headersSerializer->reveal(),
+            $platform->reveal(),
+        );
+
+        $position = $stream->position();
+
+        self::assertSame(0, $position);
+    }
+}


### PR DESCRIPTION
This pull request introduces an event store that is decoupled from the aggregate root. This means that the columns `aggregate` and `aggregateId` have been merged into `stream`. Playhead is also optional in this store.

fix: https://github.com/patchlevel/event-sourcing/issues/535