### PR TITLE
dont teardown new subscriptions

### DIFF
--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -575,6 +575,19 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
                 $errors = [];
 
                 foreach ($subscriptions as $subscription) {
+                    if ($subscription->isNew()) {
+                        $this->subscriptionManager->remove($subscription);
+
+                        $this->logger?->info(
+                            sprintf(
+                                'Subscription Engine: Subscription "%s" removed.',
+                                $subscription->id(),
+                            ),
+                        );
+
+                        continue;
+                    }
+
                     $subscriber = $this->subscriber($subscription->id());
 
                     if (!$subscriber) {


### PR DESCRIPTION
Do not try to teardown new subscriptions because they have not been set up. This way there is nothing to teardown and the subscription can simply be deleted from the DB. Otherwise you always get an error message.