### PR TITLE
only retry relevant subscriptions

### DIFF
--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -21,7 +21,6 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 use function count;
-use function in_array;
 use function sprintf;
 
 final class DefaultSubscriptionEngine implements SubscriptionEngine
@@ -60,7 +59,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
         );
 
         $this->discoverNewSubscriptions();
-        $this->retrySubscriptions($criteria);
+        $this->retrySubscriptions($criteria, Status::New);
 
         return $this->subscriptionManager->findForUpdate(
             new SubscriptionCriteria(
@@ -169,7 +168,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
             );
 
             $this->discoverNewSubscriptions();
-            $this->retrySubscriptions($criteria);
+            $this->retrySubscriptions($criteria, Status::Booting);
 
             return $this->subscriptionManager->findForUpdate(
                 new SubscriptionCriteria(
@@ -340,7 +339,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
 
             $this->discoverNewSubscriptions();
             $this->markDetachedSubscriptions($criteria);
-            $this->retrySubscriptions($criteria);
+            $this->retrySubscriptions($criteria, Status::Active);
 
             return $this->subscriptionManager->findForUpdate(
                 new SubscriptionCriteria(
@@ -901,7 +900,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
         );
     }
 
-    private function retrySubscriptions(SubscriptionEngineCriteria $criteria): void
+    private function retrySubscriptions(SubscriptionEngineCriteria $criteria, Status $previousStatus): void
     {
         $this->subscriptionManager->findForUpdate(
             new SubscriptionCriteria(
@@ -909,7 +908,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
                 groups: $criteria->groups,
                 status: [Status::Error],
             ),
-            function (SubscriptionCollection $subscriptions): void {
+            function (SubscriptionCollection $subscriptions) use ($previousStatus): void {
                 /** @var Subscription $subscription */
                 foreach ($subscriptions as $subscription) {
                     $error = $subscription->subscriptionError();
@@ -918,13 +917,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
                         continue;
                     }
 
-                    $retryable = in_array(
-                        $error->previousStatus,
-                        [Status::New, Status::Booting, Status::Active],
-                        true,
-                    );
-
-                    if (!$retryable) {
+                    if ($error->previousStatus !== $previousStatus) {
                         continue;
                     }
 

--- a/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
@@ -3050,6 +3050,58 @@ final class DefaultSubscriptionEngineTest extends TestCase
         self::assertEquals(1, $update2->retryAttempt());
     }
 
+    #[DataProvider('statusProvider')]
+    public function testShouldNotRetryOtherStatus(string $method, string $status): void
+    {
+        $subscriptionId = 'test';
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class {
+        };
+
+        $streamableStore = $this->prophesize(Store::class);
+
+        $subscription = new Subscription(
+            $subscriptionId,
+            Subscription::DEFAULT_GROUP,
+            RunMode::FromBeginning,
+            Status::Error,
+            0,
+            new SubscriptionError('ERROR', Status::from($status)),
+        );
+
+        $subscriptionStore = new DummySubscriptionStore([$subscription]);
+
+        $retryStrategy = $this->prophesize(RetryStrategy::class);
+        $retryStrategy->shouldRetry($subscription)->shouldNotBeCalled();
+
+        $engine = new DefaultSubscriptionEngine(
+            $streamableStore->reveal(),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            $retryStrategy->reveal(),
+            new NullLogger(),
+        );
+
+        $result = match ($method) {
+            'setup' => $engine->setup(),
+            'boot' => $engine->boot(),
+            'run' => $engine->run(),
+        };
+
+        self::assertCount(0, $result->errors);
+        self::assertEquals([], $subscriptionStore->updatedSubscriptions);
+    }
+
+    public static function statusProvider(): Generator
+    {
+        yield 'setup_booting' => ['setup', 'booting'];
+        yield 'setup_active' => ['setup', 'active'];
+        yield 'boot_new' => ['boot', 'new'];
+        yield 'boot_active' => ['boot', 'active'];
+        yield 'run_new' => ['run', 'new'];
+        yield 'run_booting' => ['run', 'booting'];
+    }
+
     public function testShouldNotRetry(): void
     {
         $subscriptionId = 'test';


### PR DESCRIPTION
Previously, the following actions "setup", "boot" and "run" set all subscriptions that were in error and that the retry strategy had instructed to do so to the previous state.

If, for example, a subscription received an error when booting, it is set to the error status with an error message. If a subscription engine run is now carried out, it could happen that this subscription is set back to booting because it is supposed to be retried.

The problem here is that there may not be a boot process running, so the subscription remains in booting and you no longer have an error message because it was reset by the retry system. This is very confusing for the developer because he does not know why the status is in booting.

The logic has been adjusted so that with the actions "setup", "boot" and "run" only the subscription is retried if it previously failed in the same action.

In principle, the behavior remains the same, only the error is not deleted earlier than necessary.