### PR TITLE
Use jsonb when using postgresql

### DIFF
--- a/src/Store/DoctrineDbalStore.php
+++ b/src/Store/DoctrineDbalStore.php
@@ -337,6 +337,7 @@ final class DoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchem
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('payload', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
         $table->addColumn('recorded_on', Types::DATETIMETZ_IMMUTABLE)
             ->setNotnull(true);
@@ -347,6 +348,7 @@ final class DoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchem
             ->setNotnull(true)
             ->setDefault(false);
         $table->addColumn('custom_headers', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
 
         $table->setPrimaryKey(['id']);

--- a/src/Store/StreamDoctrineDbalStore.php
+++ b/src/Store/StreamDoctrineDbalStore.php
@@ -416,6 +416,7 @@ final class StreamDoctrineDbalStore implements StreamStore, SubscriptionStore, D
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('event_payload', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
         $table->addColumn('recorded_on', Types::DATETIMETZ_IMMUTABLE)
             ->setNotnull(true);
@@ -423,6 +424,7 @@ final class StreamDoctrineDbalStore implements StreamStore, SubscriptionStore, D
             ->setNotnull(true)
             ->setDefault(false);
         $table->addColumn('custom_headers', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
 
         $table->setPrimaryKey(['id']);

--- a/src/Subscription/Store/DoctrineSubscriptionStore.php
+++ b/src/Subscription/Store/DoctrineSubscriptionStore.php
@@ -230,6 +230,7 @@ final class DoctrineSubscriptionStore implements LockableSubscriptionStore, Doct
             ->setLength(32)
             ->setNotnull(false);
         $table->addColumn('error_context', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(false);
         $table->addColumn('retry_attempt', Types::INTEGER)
             ->setNotnull(true);

--- a/src/Subscription/ThrowableToErrorContextTransformer.php
+++ b/src/Subscription/ThrowableToErrorContextTransformer.php
@@ -70,6 +70,10 @@ final class ThrowableToErrorContextTransformer
      */
     private static function transformTrace(array $trace): array
     {
+        if (array_key_exists('class', $trace) && is_string($trace['class'])) {
+            $trace['class'] = str_replace("\x00", '', $trace['class']);
+        }
+
         if (!array_key_exists('args', $trace)) {
             return $trace;
         }

--- a/src/Subscription/ThrowableToErrorContextTransformer.php
+++ b/src/Subscription/ThrowableToErrorContextTransformer.php
@@ -21,6 +21,7 @@ use function is_object;
 use function is_resource;
 use function mb_strlen;
 use function mb_substr;
+use function str_replace;
 
 /**
  * @psalm-import-type Context from SubscriptionError
@@ -70,7 +71,7 @@ final class ThrowableToErrorContextTransformer
      */
     private static function transformTrace(array $trace): array
     {
-        if (array_key_exists('class', $trace) && is_string($trace['class'])) {
+        if (array_key_exists('class', $trace)) {
             $trace['class'] = str_replace("\x00", '', $trace['class']);
         }
 

--- a/tests/Unit/Store/DoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/DoctrineDbalStoreTest.php
@@ -1310,6 +1310,7 @@ final class DoctrineDbalStoreTest extends TestCase
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('payload', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
         $table->addColumn('recorded_on', Types::DATETIMETZ_IMMUTABLE)
             ->setNotnull(true);
@@ -1320,6 +1321,7 @@ final class DoctrineDbalStoreTest extends TestCase
             ->setNotnull(true)
             ->setDefault(false);
         $table->addColumn('custom_headers', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
 
         $table->setPrimaryKey(['id']);
@@ -1362,6 +1364,7 @@ final class DoctrineDbalStoreTest extends TestCase
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('payload', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
         $table->addColumn('recorded_on', Types::DATETIMETZ_IMMUTABLE)
             ->setNotnull(true);
@@ -1372,6 +1375,7 @@ final class DoctrineDbalStoreTest extends TestCase
             ->setNotnull(true)
             ->setDefault(false);
         $table->addColumn('custom_headers', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
 
         $table->setPrimaryKey(['id']);

--- a/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
@@ -1416,6 +1416,7 @@ final class StreamDoctrineDbalStoreTest extends TestCase
             ->setLength(255)
             ->setNotnull(true);
         $table->addColumn('event_payload', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
         $table->addColumn('recorded_on', Types::DATETIMETZ_IMMUTABLE)
             ->setNotnull(true);
@@ -1423,6 +1424,7 @@ final class StreamDoctrineDbalStoreTest extends TestCase
             ->setNotnull(true)
             ->setDefault(false);
         $table->addColumn('custom_headers', Types::JSON)
+            ->setPlatformOption('jsonb', true)
             ->setNotnull(true);
 
         $table->setPrimaryKey(['id']);


### PR DESCRIPTION
We should use `jsonb` when the user is using postgresql. This give the user better query capabilities on the json fields in the store.

When this PR is released https://github.com/doctrine/dbal/pull/6693 the migration tooling should pick this change up. So the user does not need to update the table themselfes besides of the normal call to `bin/console do:mi:di` & `bin/console do:mi:mi`.