### PR TITLE
fix: remove queue in command bus

### DIFF
--- a/docs/pages/command_bus.md
+++ b/docs/pages/command_bus.md
@@ -231,11 +231,7 @@ $commandBus = new SyncCommandBus($handlerProvider);
 $commandBus->dispatch(new CreateProfile($profileId, 'name'));
 $commandBus->dispatch(new ChangeProfileName($profileId, 'new name'));
 ```
-!!! note
 
-    The `SyncCommandBus` is a synchronous command bus. 
-    But it ensures that a command has been completely handled before the next handler is executed.
-    
 ## Provider
 
 There are different types of providers that you can use to register handlers.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -159,5 +159,5 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 1
+			count: 3
 			path: src/Subscription/ThrowableToErrorContextTransformer.php

--- a/src/CommandBus/SyncCommandBus.php
+++ b/src/CommandBus/SyncCommandBus.php
@@ -9,19 +9,13 @@ use Patchlevel\EventSourcing\Repository\RepositoryManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
-use function array_shift;
 use function count;
 use function is_array;
 use function iterator_to_array;
-use function sprintf;
 
 final class SyncCommandBus implements CommandBus
 {
     private readonly HandlerProvider $handlerProvider;
-
-    /** @var array<object> */
-    private array $queue;
-    private bool $processing;
 
     /** @param iterable<HandlerProvider>|HandlerProvider $handlerProviders */
     public function __construct(
@@ -33,56 +27,30 @@ final class SyncCommandBus implements CommandBus
         } else {
             $this->handlerProvider = $handlerProviders;
         }
-
-        $this->queue = [];
-        $this->processing = false;
     }
 
     /** @throws HandlerNotFound */
     public function dispatch(object $command): void
     {
-        $this->logger?->debug(sprintf(
-            'CommandBus: Add message "%s" to queue.',
-            $command::class,
-        ));
+        $this->logger?->debug('CommandBus: dispatch command', ['command' => $command::class]);
 
-        $this->queue[] = $command;
+        $handlers = $this->handlerProvider->handlerForCommand($command::class);
 
-        if ($this->processing) {
-            $this->logger?->debug('CommandBus: Is already processing, dont start new processing.');
-
-            return;
+        if (!is_array($handlers)) {
+            $handlers = iterator_to_array($handlers);
         }
 
-        try {
-            $this->processing = true;
+        $count = count($handlers);
 
-            $this->logger?->debug('CommandBus: Start processing queue.');
-
-            while ($command = array_shift($this->queue)) {
-                $handlers = $this->handlerProvider->handlerForCommand($command::class);
-
-                if (!is_array($handlers)) {
-                    $handlers = iterator_to_array($handlers);
-                }
-
-                $count = count($handlers);
-
-                if ($count === 0) {
-                    throw new HandlerNotFound($command::class);
-                }
-
-                if ($count > 1) {
-                    throw new MultipleHandlersFound($command::class);
-                }
-
-                ($handlers[0]->callable())($command);
-            }
-        } finally {
-            $this->processing = false;
-
-            $this->logger?->debug('CommandBus: Finished processing queue.');
+        if ($count === 0) {
+            throw new HandlerNotFound($command::class);
         }
+
+        if ($count > 1) {
+            throw new MultipleHandlersFound($command::class);
+        }
+
+        ($handlers[0]->callable())($command);
     }
 
     public static function createForAggregateHandlers(

--- a/src/Subscription/ThrowableToErrorContextTransformer.php
+++ b/src/Subscription/ThrowableToErrorContextTransformer.php
@@ -19,6 +19,8 @@ use function is_float;
 use function is_int;
 use function is_object;
 use function is_resource;
+use function mb_strlen;
+use function mb_substr;
 
 /**
  * @psalm-import-type Context from SubscriptionError


### PR DESCRIPTION
We have adopted logic from the Event Bus into the Command Bus that does not work. Namely, that the commands are processed one after the other and only when the previous command has been completely processed.

That sounded like a good idea in the Command Bus without even thinking about it. It turns out that this behavior is wrong.

There are several problems, here are a few examples:

* If you dispatch a command, you cannot assume that you can access the result immediately afterwards.
* The handler is executed in a different context, so that it can break out of the subscription try-catch.

Furthermore, we do not know of any use case where this behavior is desired, unlike with the Event Bus.

This bug fix removes this logic so that the Command Bus really runs "synchronously".