### PR TITLE
deprecate aggregate id argument resolver

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -198,6 +198,11 @@
       <code><![CDATA[Closure(Message, Throwable):void|null]]></code>
     </MixedReturnTypeCoercion>
   </file>
+  <file src="src/Subscription/Subscriber/MetadataSubscriberAccessorRepository.php">
+    <DeprecatedClass>
+      <code><![CDATA[new AggregateIdArgumentResolver()]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Subscription/Subscriber/SubscriberAccessorRepository.php">
     <DeprecatedInterface>
       <code><![CDATA[SubscriberAccessor|null]]></code>
@@ -514,6 +519,17 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$maxAttempts]]></code>
     </ArgumentTypeCoercion>
+  </file>
+  <file src="tests/Unit/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolverTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new AggregateIdArgumentResolver()]]></code>
+      <code><![CDATA[new AggregateIdArgumentResolver()]]></code>
+    </DeprecatedClass>
+  </file>
+  <file src="tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorRepositoryTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[new ArgumentResolver\AggregateIdArgumentResolver()]]></code>
+    </DeprecatedClass>
   </file>
   <file src="tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php">
     <DeprecatedMethod>

--- a/docs/pages/subscription.md
+++ b/docs/pages/subscription.md
@@ -273,32 +273,7 @@ final class PublicProfileProjection
 !!! note
 
     More about reducers you can find [here](./message.md#reducer)
-    
-##### Aggregate Id Resolver
 
-The aggregate id resolver resolves the aggregate id.
-It looks for a parameter with the instance of the `AggregateRootId`.
-
-```php
-use Patchlevel\EventSourcing\Attribute\Subscribe;
-use Patchlevel\EventSourcing\Attribute\Subscriber;
-use Patchlevel\EventSourcing\Subscription\RunMode;
-
-#[Subscriber('do_stuff', RunMode::Once)]
-final class DoStuffSubscriber
-{
-    #[Subscribe(ProfileCreated::class)]
-    public function onProfileCreated(ProfileId $profileId): void
-    {
-        // do something
-    }
-}
-```
-!!! warning
-
-    The resolver argument doesn't know if you're using the correct aggregate id class and doesn't check it. 
-    It gets the Aggregate ID as a string, takes the class and instantiates it with the method `fromString`.
-    
 ##### Recorded On Resolver
 
 The recorded on resolver resolves the recorded on date.

--- a/src/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolver.php
+++ b/src/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolver.php
@@ -12,6 +12,7 @@ use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
 use function class_exists;
 use function is_a;
 
+/** @deprecated add aggregate id in your events, automatically resolving in stream store is not possible. */
 final class AggregateIdArgumentResolver implements ArgumentResolver
 {
     public function resolve(ArgumentMetadata $argument, Message $message): AggregateRootId


### PR DESCRIPTION
The Aggregate ID Resolver is deprecated. Aggregate IDs should always be part of the event if they are relevant. In addition, the AggregateID can no longer be determined from a stream name (with the new store).