### PR TITLE
add on failed hook in subscription engine

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -152,6 +152,9 @@
     <DeprecatedInterface>
       <code><![CDATA[SubscriberAccessor|null]]></code>
     </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[realSubscriber]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="src/Subscription/Lookup/Lookup.php">
     <ArgumentTypeCoercion>
@@ -187,8 +190,13 @@
     <MixedMethodCall>
       <code><![CDATA[$method]]></code>
       <code><![CDATA[$method]]></code>
+      <code><![CDATA[$method]]></code>
       <code><![CDATA[$methodName]]></code>
     </MixedMethodCall>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->subscriber->$method(...)]]></code>
+      <code><![CDATA[Closure(Message, Throwable):void|null]]></code>
+    </MixedReturnTypeCoercion>
   </file>
   <file src="src/Subscription/Subscriber/SubscriberAccessorRepository.php">
     <DeprecatedInterface>
@@ -299,6 +307,11 @@
     <TypeDoesNotContainNull>
       <code><![CDATA[$stream]]></code>
     </TypeDoesNotContainNull>
+  </file>
+  <file src="tests/Integration/Subscription/SubscriptionTest.php">
+    <InvalidArgument>
+      <code><![CDATA[0]]></code>
+    </InvalidArgument>
   </file>
   <file src="tests/Unit/CommandBus/AggregateHandlerProviderTest.php">
     <InvalidArrayAccess>
@@ -496,6 +509,11 @@
       <code><![CDATA[$subscriptions]]></code>
       <code><![CDATA[$subscriptions]]></code>
     </InvalidArgument>
+  </file>
+  <file src="tests/Unit/Subscription/RetryStrategy/ClockBasedRetryStrategyTest.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$maxAttempts]]></code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php">
     <DeprecatedMethod>

--- a/docs/pages/subscription.md
+++ b/docs/pages/subscription.md
@@ -377,6 +377,45 @@ final class ProfileProjector
     Most databases have a limit on the length of the table/collection name.
     The limit is usually 64 characters.
     
+### On Failed
+
+The subscription engine has a [retry strategy](#retry-strategy) to retry subscriptions that have an error.
+If this does not work, the subscription changes the status to failed and will be ignored in all future runs.
+You can react to this transition and prevent it, so the subscription can skip the message and continue with the next one.
+To do this, you can add a method with the `OnFailed` attribute.
+If the method throws an exception, the subscription will be set to failed,
+otherwise the subscription will continue with the next message.
+
+```php
+use Patchlevel\EventSourcing\Attribute\OnFailed;
+use Patchlevel\EventSourcing\Attribute\Processor;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
+use Patchlevel\EventSourcing\Message\Message;
+
+#[Processor('invoice')]
+final class InvoiceProcessor
+{
+    #[Subscribe(OrderPlaced::class)]
+    public function onOrderPlaced(OrderPlaced $orderPlaced): void
+    {
+        // an error occurs
+    }
+
+    #[OnFailed]
+    public function onFailed(Message $message, Throwable $throwable): void
+    {
+        // do something (failed queue, logging, etc.), so the subscription can continue
+    }
+}
+```
+!!! warning
+
+    Currently, the `OnFailed` method is only available for non-batchable subscribers.
+    
+!!! note
+
+    The `OnFailed` method is called after the retry strategy has decided that the subscription should be set to failed.
+    
 ### Versioning
 
 As soon as the structure of a projection changes, or you need other events from the past,

--- a/src/Attribute/OnFailed.php
+++ b/src/Attribute/OnFailed.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class OnFailed
+{
+}

--- a/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
+++ b/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Metadata\Subscriber;
 
+use Patchlevel\EventSourcing\Attribute\OnFailed;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Subscriber;
@@ -42,6 +43,7 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
         $subscribeMethods = [];
         $setupMethod = null;
         $teardownMethod = null;
+        $failedMethod = null;
 
         foreach ($methods as $method) {
             $attributes = $method->getAttributes(Subscribe::class);
@@ -51,6 +53,18 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
                 $eventClass = $instance->eventClass;
 
                 $subscribeMethods[$eventClass][] = $this->subscribeMethod($method);
+            }
+
+            if ($method->getAttributes(OnFailed::class)) {
+                if ($failedMethod !== null) {
+                    throw new DuplicateFailedMethod(
+                        $subscriber,
+                        $setupMethod,
+                        $method->getName(),
+                    );
+                }
+
+                $failedMethod = $method->getName();
             }
 
             if ($method->getAttributes(Setup::class)) {
@@ -87,6 +101,7 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
             $subscribeMethods,
             $setupMethod,
             $teardownMethod,
+            $failedMethod,
         );
 
         $this->subscriberMetadata[$subscriber] = $metadata;

--- a/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
+++ b/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
@@ -59,7 +59,7 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
                 if ($failedMethod !== null) {
                     throw new DuplicateFailedMethod(
                         $subscriber,
-                        $setupMethod,
+                        $failedMethod,
                         $method->getName(),
                     );
                 }

--- a/src/Metadata/Subscriber/DuplicateFailedMethod.php
+++ b/src/Metadata/Subscriber/DuplicateFailedMethod.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\MetadataException;
+use function sprintf;
+
+final class DuplicateFailedMethod extends MetadataException
+{
+    /** @param class-string $subscriber */
+    public function __construct(string $subscriber, string $fistMethod, string $secondMethod)
+    {
+        parent::__construct(
+            sprintf(
+                'Two methods "%s" and "%s" on the subscriber "%s" have been marked as "OnFailed" methods. Only one method can be defined like this.',
+                $fistMethod,
+                $secondMethod,
+                $subscriber,
+            ),
+        );
+    }
+}

--- a/src/Metadata/Subscriber/DuplicateFailedMethod.php
+++ b/src/Metadata/Subscriber/DuplicateFailedMethod.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Metadata\Subscriber;
 
 use Patchlevel\EventSourcing\Metadata\MetadataException;
+
 use function sprintf;
 
 final class DuplicateFailedMethod extends MetadataException

--- a/src/Metadata/Subscriber/SubscriberMetadata.php
+++ b/src/Metadata/Subscriber/SubscriberMetadata.php
@@ -17,6 +17,7 @@ final class SubscriberMetadata
         public readonly array $subscribeMethods = [],
         public readonly string|null $setupMethod = null,
         public readonly string|null $teardownMethod = null,
+        public readonly string|null $failedMethod = null,
     ) {
     }
 }

--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -14,6 +14,7 @@ use Patchlevel\EventSourcing\Subscription\Status;
 use Patchlevel\EventSourcing\Subscription\Store\SubscriptionCriteria;
 use Patchlevel\EventSourcing\Subscription\Store\SubscriptionStore;
 use Patchlevel\EventSourcing\Subscription\Subscriber\BatchableSubscriber;
+use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
 use Patchlevel\EventSourcing\Subscription\Subscriber\RealSubscriberAccessor;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessor;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessorRepository;
@@ -831,7 +832,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
                 ),
             );
 
-            $this->handleError($subscription, $e);
+            $this->handleError($subscription, $e, $message);
 
             return new Error(
                 $subscription->id(),
@@ -984,9 +985,19 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
         $this->subscriptionManager->flush();
     }
 
-    private function handleError(Subscription $subscription, Throwable $throwable): void
+    private function handleError(Subscription $subscription, Throwable $throwable, Message|null $message = null): void
     {
         if ($this->retryStrategy instanceof ConditionalRetryStrategy && !$this->retryStrategy->canRetry($subscription)) {
+            $subscriber = $this->subscriber($subscription->id());
+
+            if ($subscriber instanceof MetadataSubscriberAccessor) {
+                $failedMethod = $subscriber->failedMethod();
+
+                if ($failedMethod) {
+                    $failedMethod($message);
+                }
+            }
+
             $subscription->failed($throwable);
         } else {
             $subscription->error($throwable);
@@ -994,8 +1005,20 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
 
         $this->subscriptionManager->update($subscription);
 
+        if ($this->needRollback($subscription)) {
+            $this->rollback($subscription);
+        }
+    }
+
+    private function needRollback(Subscription $subscription): bool
+    {
+        return isset($this->batching[$subscription->id()]);
+    }
+
+    private function rollback(Subscription $subscription): void
+    {
         if (!isset($this->batching[$subscription->id()])) {
-            return;
+            throw new UnexpectedError('No batch to rollback.');
         }
 
         $subscriber = $this->batching[$subscription->id()];

--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -21,6 +21,7 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessorRepositor
 use Patchlevel\EventSourcing\Subscription\Subscription;
 use Psr\Log\LoggerInterface;
 use Throwable;
+
 use function count;
 use function sprintf;
 
@@ -1018,7 +1019,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
             return;
         }
 
-        if (!$subscriber->realSubscriber() instanceof BatchableSubscriber) {
+        if ($subscriber->realSubscriber() instanceof BatchableSubscriber) {
             $subscription->failed($throwable);
             $this->subscriptionManager->update($subscription);
 
@@ -1035,7 +1036,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
         }
 
         try {
-            $failedMethod($message);
+            $failedMethod($message, $throwable);
             $subscription->changePosition($index);
             $subscription->resetRetry();
 

--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -21,7 +21,6 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessorRepositor
 use Patchlevel\EventSourcing\Subscription\Subscription;
 use Psr\Log\LoggerInterface;
 use Throwable;
-
 use function count;
 use function sprintf;
 
@@ -832,7 +831,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
                 ),
             );
 
-            $this->handleError($subscription, $e, $message);
+            $this->handleError($subscription, $e, $message, $index);
 
             return new Error(
                 $subscription->id(),
@@ -985,28 +984,71 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
         $this->subscriptionManager->flush();
     }
 
-    private function handleError(Subscription $subscription, Throwable $throwable, Message|null $message = null): void
+    private function handleError(Subscription $subscription, Throwable $throwable, Message|null $message = null, int|null $index = null): void
     {
-        if ($this->retryStrategy instanceof ConditionalRetryStrategy && !$this->retryStrategy->canRetry($subscription)) {
-            $subscriber = $this->subscriber($subscription->id());
-
-            if ($subscriber instanceof MetadataSubscriberAccessor) {
-                $failedMethod = $subscriber->failedMethod();
-
-                if ($failedMethod) {
-                    $failedMethod($message);
-                }
-            }
-
-            $subscription->failed($throwable);
-        } else {
-            $subscription->error($throwable);
-        }
-
-        $this->subscriptionManager->update($subscription);
-
         if ($this->needRollback($subscription)) {
             $this->rollback($subscription);
+        }
+
+        if (!$this->retryStrategy instanceof ConditionalRetryStrategy || $this->retryStrategy->canRetry($subscription)) {
+            $subscription->error($throwable);
+            $this->subscriptionManager->update($subscription);
+
+            return;
+        }
+
+        $this->handleFailed($subscription, $throwable, $message, $index);
+    }
+
+    private function handleFailed(Subscription $subscription, Throwable $throwable, Message|null $message = null, int|null $index = null): void
+    {
+        if (!$message || $index === null) {
+            $subscription->failed($throwable);
+            $this->subscriptionManager->update($subscription);
+
+            return;
+        }
+
+        $subscriber = $this->subscriber($subscription->id());
+
+        if (!$subscriber instanceof MetadataSubscriberAccessor) {
+            $subscription->failed($throwable);
+            $this->subscriptionManager->update($subscription);
+
+            return;
+        }
+
+        if (!$subscriber->realSubscriber() instanceof BatchableSubscriber) {
+            $subscription->failed($throwable);
+            $this->subscriptionManager->update($subscription);
+
+            return;
+        }
+
+        $failedMethod = $subscriber->failedMethod();
+
+        if (!$failedMethod) {
+            $subscription->failed($throwable);
+            $this->subscriptionManager->update($subscription);
+
+            return;
+        }
+
+        try {
+            $failedMethod($message);
+            $subscription->changePosition($index);
+            $subscription->resetRetry();
+
+            $this->subscriptionManager->update($subscription);
+        } catch (Throwable $e) {
+            $this->logger?->error(sprintf(
+                'Subscription Engine: Subscriber "%s" has an error in the failed method: %s',
+                $subscription->id(),
+                $e->getMessage(),
+            ));
+
+            $subscription->failed($throwable);
+            $this->subscriptionManager->update($subscription);
         }
     }
 

--- a/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
@@ -85,6 +85,20 @@ final class MetadataSubscriberAccessor implements SubscriberAccessor, RealSubscr
         return $this->subscriber->$method(...);
     }
 
+    /**
+     * @return Closure(Message):void|null
+     */
+    public function failedMethod(): Closure|null
+    {
+        $method = $this->metadata->failedMethod;
+
+        if ($method === null) {
+            return null;
+        }
+
+        return $this->subscriber->$method(...);
+    }
+
     /** @return list<class-string|'*'> */
     public function events(): array
     {

--- a/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
@@ -11,6 +11,7 @@ use Patchlevel\EventSourcing\Metadata\Subscriber\SubscribeMethodMetadata;
 use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadata;
 use Patchlevel\EventSourcing\Subscription\RunMode;
 use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\ArgumentResolver;
+use Throwable;
 
 use function array_key_exists;
 use function array_keys;
@@ -85,9 +86,7 @@ final class MetadataSubscriberAccessor implements SubscriberAccessor, RealSubscr
         return $this->subscriber->$method(...);
     }
 
-    /**
-     * @return Closure(Message):void|null
-     */
+    /** @return Closure(Message, Throwable):void|null */
     public function failedMethod(): Closure|null
     {
         $method = $this->metadata->failedMethod;

--- a/tests/Integration/Subscription/Subscriber/ErrorProducerWithSelfRecoverySubscriber.php
+++ b/tests/Integration/Subscription/Subscriber/ErrorProducerWithSelfRecoverySubscriber.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\Subscription\Subscriber;
+
+use Patchlevel\EventSourcing\Attribute\OnFailed;
+use Patchlevel\EventSourcing\Attribute\Setup;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
+use Patchlevel\EventSourcing\Attribute\Subscriber;
+use Patchlevel\EventSourcing\Attribute\Teardown;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+use RuntimeException;
+use Throwable;
+
+#[Subscriber('error_producer', RunMode::FromBeginning)]
+final class ErrorProducerWithSelfRecoverySubscriber
+{
+    public bool $setupError = false;
+    public bool $subscribeError = false;
+    public bool $teardownError = false;
+
+    public bool $onFailedError = false;
+
+    public Message|null $erroredMessage = null;
+
+    public Throwable|null $erroredThrowable = null;
+
+    #[Setup]
+    public function setup(): void
+    {
+        if ($this->setupError) {
+            throw new RuntimeException('setup error');
+        }
+    }
+
+    #[Teardown]
+    public function teardown(): void
+    {
+        if ($this->teardownError) {
+            throw new RuntimeException('teardown error');
+        }
+    }
+
+    #[Subscribe('*')]
+    public function subscribe(): void
+    {
+        if ($this->subscribeError) {
+            throw new RuntimeException('subscribe error');
+        }
+    }
+
+    #[OnFailed]
+    public function onFailed(Message $message, Throwable $throwable): void
+    {
+        $this->erroredMessage = $message;
+        $this->erroredThrowable = $throwable;
+
+        if ($this->onFailedError) {
+            throw new RuntimeException('on failed error');
+        }
+    }
+}

--- a/tests/Integration/Subscription/SubscriptionTest.php
+++ b/tests/Integration/Subscription/SubscriptionTest.php
@@ -35,6 +35,7 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorR
 use Patchlevel\EventSourcing\Subscription\Subscription;
 use Patchlevel\EventSourcing\Tests\DbalManager;
 use Patchlevel\EventSourcing\Tests\Integration\Subscription\Subscriber\ErrorProducerSubscriber;
+use Patchlevel\EventSourcing\Tests\Integration\Subscription\Subscriber\ErrorProducerWithSelfRecoverySubscriber;
 use Patchlevel\EventSourcing\Tests\Integration\Subscription\Subscriber\LookupSubscriber;
 use Patchlevel\EventSourcing\Tests\Integration\Subscription\Subscriber\MigrateAggregateToStreamStoreSubscriber;
 use Patchlevel\EventSourcing\Tests\Integration\Subscription\Subscriber\ProfileNewProjection;
@@ -390,6 +391,104 @@ final class SubscriptionTest extends TestCase
         self::assertEquals(Status::Active, $subscription->status());
         self::assertEquals(null, $subscription->subscriptionError());
         self::assertEquals(0, $subscription->retryAttempt());
+    }
+
+    public function testSelfRecovery(): void
+    {
+        $clock = new FrozenClock(new DateTimeImmutable('2021-01-01T00:00:00'));
+
+        $store = new DoctrineDbalStore(
+            $this->connection,
+            DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
+        );
+
+        $subscriptionStore = new DoctrineSubscriptionStore(
+            $this->connection,
+            $clock,
+        );
+
+        $schemaDirector = new DoctrineSchemaDirector(
+            $this->connection,
+            new ChainDoctrineSchemaConfigurator([
+                $store,
+                $subscriptionStore,
+            ]),
+        );
+
+        $schemaDirector->create();
+
+        $manager = new DefaultRepositoryManager(
+            new AggregateRootRegistry(['profile' => Profile::class]),
+            $store,
+        );
+
+        $subscriber = new ErrorProducerWithSelfRecoverySubscriber();
+
+        $engine = new DefaultSubscriptionEngine(
+            $store,
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            new ClockBasedRetryStrategy(
+                $clock,
+                ClockBasedRetryStrategy::DEFAULT_BASE_DELAY,
+                ClockBasedRetryStrategy::DEFAULT_DELAY_FACTOR,
+                0,
+            ),
+        );
+
+        $result = $engine->setup(skipBooting: true);
+        self::assertEquals([], $result->errors);
+
+        // add data
+
+        $repository = $manager->get(Profile::class);
+
+        $profile = Profile::create(ProfileId::generate(), 'John');
+        $repository->save($profile);
+
+        $subscriber->subscribeError = true;
+
+        // first run, failed -> self recovery
+
+        $result = $engine->run();
+
+        self::assertEquals(1, $result->processedMessages);
+        self::assertCount(1, $result->errors);
+
+        $error = $result->errors[0];
+
+        self::assertEquals('error_producer', $error->subscriptionId);
+        self::assertEquals('subscribe error', $error->message);
+
+        $subscription = self::findSubscription($engine->subscriptions(), 'error_producer');
+
+        self::assertEquals(Status::Active, $subscription->status());
+        self::assertEquals(0, $subscription->retryAttempt());
+        self::assertEquals(1, $subscription->position());
+
+        // change data
+
+        $profile->changeName('Jane');
+        $repository->save($profile);
+
+        // second run, failed -> self recovery failed
+
+        $subscriber->onFailedError = true;
+        $result = $engine->run();
+
+        self::assertEquals(1, $result->processedMessages);
+        self::assertCount(1, $result->errors);
+
+        $error = $result->errors[0];
+
+        self::assertEquals('error_producer', $error->subscriptionId);
+        self::assertEquals('subscribe error', $error->message);
+
+        $subscription = self::findSubscription($engine->subscriptions(), 'error_producer');
+
+        self::assertEquals(Status::Failed, $subscription->status());
+        self::assertEquals(0, $subscription->retryAttempt());
+        self::assertEquals(1, $subscription->position());
     }
 
     public function testLargeErrorMessage(): void

--- a/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
@@ -6,6 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
 
 use Closure;
 use Generator;
+use Patchlevel\EventSourcing\Attribute\OnFailed;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Subscriber;
@@ -26,6 +27,7 @@ use Patchlevel\EventSourcing\Subscription\Status;
 use Patchlevel\EventSourcing\Subscription\Store\LockableSubscriptionStore;
 use Patchlevel\EventSourcing\Subscription\Store\SubscriptionCriteria;
 use Patchlevel\EventSourcing\Subscription\Store\SubscriptionStore;
+use Patchlevel\EventSourcing\Subscription\Subscriber\BatchableSubscriber;
 use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorRepository;
 use Patchlevel\EventSourcing\Subscription\Subscription;
 use Patchlevel\EventSourcing\Subscription\SubscriptionError;
@@ -236,6 +238,71 @@ final class DefaultSubscriptionEngineTest extends TestCase
             public function create(): void
             {
                 throw $this->exception;
+            }
+        };
+
+        $subscriptionStore = new DummySubscriptionStore([
+            new Subscription($subscriptionId),
+        ]);
+
+        $message1 = new Message(new ProfileVisited(ProfileId::fromString('test')));
+
+        $streamableStore = $this->prophesize(Store::class);
+        $streamableStore->load(null, 1, null, true)->willReturn(new ArrayStream([$message1]))->shouldBeCalledOnce();
+
+        $engine = new DefaultSubscriptionEngine(
+            $streamableStore->reveal(),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            new NoRetryStrategy(),
+            logger: new NullLogger(),
+        );
+
+        $result = $engine->setup();
+
+        self::assertCount(1, $result->errors);
+
+        $error = $result->errors[0];
+
+        self::assertEquals($subscriptionId, $error->subscriptionId);
+        self::assertEquals('ERROR', $error->message);
+        self::assertInstanceOf(RuntimeException::class, $error->throwable);
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Failed,
+                0,
+                new SubscriptionError(
+                    'ERROR',
+                    Status::New,
+                    ThrowableToErrorContextTransformer::transform($subscriber->exception),
+                ),
+            ),
+        );
+    }
+
+    public function testSetupWithCreateErrorRecoveryNotPossible(): void
+    {
+        $subscriptionId = 'test';
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class {
+            public function __construct(
+                public readonly RuntimeException $exception = new RuntimeException('ERROR'),
+            ) {
+            }
+
+            #[Setup]
+            public function create(): void
+            {
+                throw $this->exception;
+            }
+
+            #[OnFailed]
+            public function onFailed(): void
+            {
             }
         };
 
@@ -604,6 +671,238 @@ final class DefaultSubscriptionEngineTest extends TestCase
             public function handle(Message $message): void
             {
                 throw $this->exception;
+            }
+        };
+
+        $subscriptionStore = new DummySubscriptionStore([
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Booting,
+            ),
+        ]);
+
+        $message = new Message(new ProfileVisited(ProfileId::fromString('test')));
+
+        $streamableStore = $this->prophesize(Store::class);
+        $streamableStore->load($this->criteria())->willReturn(new ArrayStream([$message]))->shouldBeCalledOnce();
+
+        $engine = new DefaultSubscriptionEngine(
+            $streamableStore->reveal(),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            new NoRetryStrategy(),
+            logger: new NullLogger(),
+        );
+
+        $result = $engine->boot();
+
+        self::assertEquals(1, $result->processedMessages);
+        self::assertEquals(true, $result->finished);
+        self::assertCount(1, $result->errors);
+
+        $error = $result->errors[0];
+
+        self::assertEquals($subscriptionId, $error->subscriptionId);
+        self::assertEquals('ERROR', $error->message);
+        self::assertInstanceOf(RuntimeException::class, $error->throwable);
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Failed,
+                0,
+                new SubscriptionError(
+                    'ERROR',
+                    Status::Booting,
+                    ThrowableToErrorContextTransformer::transform($subscriber->exception),
+                ),
+            ),
+        );
+    }
+
+    public function testBootWithErrorAndRecovery(): void
+    {
+        $subscriptionId = 'test';
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class {
+            public function __construct(
+                public readonly RuntimeException $exception = new RuntimeException('ERROR'),
+            ) {
+            }
+
+            #[Subscribe(ProfileVisited::class)]
+            public function handle(Message $message): void
+            {
+                throw $this->exception;
+            }
+
+            #[OnFailed]
+            public function onFailed(): void
+            {
+            }
+        };
+
+        $subscriptionStore = new DummySubscriptionStore([
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Booting,
+            ),
+        ]);
+
+        $message = new Message(new ProfileVisited(ProfileId::fromString('test')));
+
+        $streamableStore = $this->prophesize(Store::class);
+        $streamableStore->load($this->criteria())->willReturn(new ArrayStream([$message]))->shouldBeCalledOnce();
+
+        $engine = new DefaultSubscriptionEngine(
+            $streamableStore->reveal(),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            new NoRetryStrategy(),
+            logger: new NullLogger(),
+        );
+
+        $result = $engine->boot();
+
+        self::assertEquals(1, $result->processedMessages);
+        self::assertEquals(true, $result->finished);
+        self::assertCount(1, $result->errors);
+
+        $error = $result->errors[0];
+
+        self::assertEquals($subscriptionId, $error->subscriptionId);
+        self::assertEquals('ERROR', $error->message);
+        self::assertInstanceOf(RuntimeException::class, $error->throwable);
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Booting,
+                1,
+            ),
+        );
+    }
+
+    public function testBootWithErrorAndRecoveryFailed(): void
+    {
+        $subscriptionId = 'test';
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class {
+            public function __construct(
+                public readonly RuntimeException $exception = new RuntimeException('ERROR'),
+            ) {
+            }
+
+            #[Subscribe(ProfileVisited::class)]
+            public function handle(Message $message): void
+            {
+                throw $this->exception;
+            }
+
+            #[OnFailed]
+            public function onFailed(): void
+            {
+                throw new RuntimeException('RECOVERY ERROR');
+            }
+        };
+
+        $subscriptionStore = new DummySubscriptionStore([
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Booting,
+            ),
+        ]);
+
+        $message = new Message(new ProfileVisited(ProfileId::fromString('test')));
+
+        $streamableStore = $this->prophesize(Store::class);
+        $streamableStore->load($this->criteria())->willReturn(new ArrayStream([$message]))->shouldBeCalledOnce();
+
+        $engine = new DefaultSubscriptionEngine(
+            $streamableStore->reveal(),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            new NoRetryStrategy(),
+            logger: new NullLogger(),
+        );
+
+        $result = $engine->boot();
+
+        self::assertEquals(1, $result->processedMessages);
+        self::assertEquals(true, $result->finished);
+        self::assertCount(1, $result->errors);
+
+        $error = $result->errors[0];
+
+        self::assertEquals($subscriptionId, $error->subscriptionId);
+        self::assertEquals('ERROR', $error->message);
+        self::assertInstanceOf(RuntimeException::class, $error->throwable);
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Failed,
+                0,
+                new SubscriptionError(
+                    'ERROR',
+                    Status::Booting,
+                    ThrowableToErrorContextTransformer::transform($subscriber->exception),
+                ),
+            ),
+        );
+    }
+
+    public function testBootWithErrorAndRecoveryFailedBecauseBatching(): void
+    {
+        $subscriptionId = 'test';
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class implements BatchableSubscriber {
+            public function __construct(
+                public readonly RuntimeException $exception = new RuntimeException('ERROR'),
+            ) {
+            }
+
+            #[Subscribe(ProfileVisited::class)]
+            public function handle(Message $message): void
+            {
+                throw $this->exception;
+            }
+
+            #[OnFailed]
+            public function onFailed(): void
+            {
+            }
+
+            public function beginBatch(): void
+            {
+                // TODO: Implement beginBatch() method.
+            }
+
+            public function commitBatch(): void
+            {
+                // TODO: Implement commitBatch() method.
+            }
+
+            public function rollbackBatch(): void
+            {
+                // TODO: Implement rollbackBatch() method.
+            }
+
+            public function forceCommit(): bool
+            {
+                return false;
             }
         };
 
@@ -1671,6 +1970,146 @@ final class DefaultSubscriptionEngineTest extends TestCase
             public function handle(Message $message): void
             {
                 throw $this->exception;
+            }
+        };
+
+        $subscriptionStore = new DummySubscriptionStore([
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Active,
+            ),
+        ]);
+
+        $message = new Message(new ProfileVisited(ProfileId::fromString('test')));
+
+        $streamableStore = $this->prophesize(Store::class);
+        $streamableStore->load($this->criteria())->willReturn(new ArrayStream([$message]))->shouldBeCalledOnce();
+
+        $engine = new DefaultSubscriptionEngine(
+            $streamableStore->reveal(),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            new NoRetryStrategy(),
+            logger: new NullLogger(),
+        );
+
+        $result = $engine->run();
+
+        self::assertEquals(1, $result->processedMessages);
+        self::assertEquals(true, $result->finished);
+        self::assertCount(1, $result->errors);
+
+        $error = $result->errors[0];
+
+        self::assertEquals($subscriptionId, $error->subscriptionId);
+        self::assertEquals('ERROR', $error->message);
+        self::assertInstanceOf(RuntimeException::class, $error->throwable);
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Failed,
+                0,
+                new SubscriptionError(
+                    'ERROR',
+                    Status::Active,
+                    ThrowableToErrorContextTransformer::transform($subscriber->exception),
+                ),
+            ),
+        );
+    }
+
+    public function testRunningWithErrorAndRecovery(): void
+    {
+        $subscriptionId = 'test';
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class {
+            public function __construct(
+                public readonly RuntimeException $exception = new RuntimeException('ERROR'),
+            ) {
+            }
+
+            #[Subscribe(ProfileVisited::class)]
+            public function handle(Message $message): void
+            {
+                throw $this->exception;
+            }
+
+            #[OnFailed]
+            public function onFailed(): void
+            {
+            }
+        };
+
+        $subscriptionStore = new DummySubscriptionStore([
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Active,
+            ),
+        ]);
+
+        $message = new Message(new ProfileVisited(ProfileId::fromString('test')));
+
+        $streamableStore = $this->prophesize(Store::class);
+        $streamableStore->load($this->criteria())->willReturn(new ArrayStream([$message]))->shouldBeCalledOnce();
+
+        $engine = new DefaultSubscriptionEngine(
+            $streamableStore->reveal(),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            new NoRetryStrategy(),
+            logger: new NullLogger(),
+        );
+
+        $result = $engine->run();
+
+        self::assertEquals(1, $result->processedMessages);
+        self::assertEquals(true, $result->finished);
+        self::assertCount(1, $result->errors);
+
+        $error = $result->errors[0];
+
+        self::assertEquals($subscriptionId, $error->subscriptionId);
+        self::assertEquals('ERROR', $error->message);
+        self::assertInstanceOf(RuntimeException::class, $error->throwable);
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                $subscriptionId,
+                Subscription::DEFAULT_GROUP,
+                RunMode::FromBeginning,
+                Status::Active,
+                1,
+            ),
+        );
+    }
+
+    public function testRunningWithErrorAndRecoveryFailed(): void
+    {
+        $subscriptionId = 'test';
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class {
+            public function __construct(
+                public readonly RuntimeException $exception = new RuntimeException('ERROR'),
+            ) {
+            }
+
+            #[Subscribe(ProfileVisited::class)]
+            public function handle(Message $message): void
+            {
+                throw $this->exception;
+            }
+
+            #[OnFailed]
+            public function onFailed(): void
+            {
+                throw new RuntimeException('RECOVERY ERROR');
             }
         };
 

--- a/tests/Unit/Subscription/RetryStrategy/ClockBasedRetryStrategyTest.php
+++ b/tests/Unit/Subscription/RetryStrategy/ClockBasedRetryStrategyTest.php
@@ -66,4 +66,35 @@ final class ClockBasedRetryStrategyTest extends TestCase
         yield [5, 160, false];
         yield [5, 320, false];
     }
+
+    #[DataProvider('canRetryProvider')]
+    public function testCanRetry(int $maxAttempts, int $attempt, bool $expected): void
+    {
+        $strategy = new ClockBasedRetryStrategy(
+            $this->clock,
+            maxAttempts: $maxAttempts,
+        );
+
+        $subscription = new Subscription(
+            'test',
+            'default',
+            RunMode::FromBeginning,
+            Status::Error,
+            0,
+            null,
+            $attempt,
+            $this->clock->now(),
+        );
+
+        self::assertEquals(
+            $expected,
+            $strategy->canRetry($subscription),
+        );
+    }
+
+    public static function canRetryProvider(): Generator
+    {
+        yield [0, 0, false];
+        yield [1, 0, true];
+    }
 }


### PR DESCRIPTION
Allows you to react when a subscription is set to failed. This allows you to do the following:

* save the message to try again later
* execute a compensation action to undo a change

If an error occurs in this (onFailed) method, the subscription will still be set to failed.
If no error occurs, the position is set further and the retry counter is reset.

fix: https://github.com/patchlevel/event-sourcing/issues/652