### PR TITLE
Dont allow subscribing same event multiple times in one subscriber

### DIFF
--- a/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
+++ b/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
@@ -53,6 +53,15 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
                 $instance = $attribute->newInstance();
                 $eventClass = $instance->eventClass;
 
+                if (array_key_exists($eventClass, $subscribeMethods)) {
+                    throw DuplicateSubscribeMethod::duplicateEvent(
+                        $subscriber,
+                        $eventClass,
+                        $subscribeMethods[$eventClass][0]->name,
+                        $method->getName()
+                    );
+                }
+
                 $subscribeMethods[$eventClass][] = $this->subscribeMethod($method);
             }
 
@@ -93,6 +102,10 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
             }
 
             $teardownMethod = $method->getName();
+        }
+
+        if (array_key_exists(Subscribe::ALL, $subscribeMethods) && count($subscribeMethods) > 1) {
+            throw DuplicateSubscribeMethod::mixedWithAll($subscriber);
         }
 
         $metadata = new SubscriberMetadata(

--- a/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
+++ b/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
@@ -16,6 +16,7 @@ use ReflectionMethod;
 use ReflectionNamedType;
 
 use function array_key_exists;
+use function count;
 
 final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFactory
 {
@@ -58,7 +59,7 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
                         $subscriber,
                         $eventClass,
                         $subscribeMethods[$eventClass][0]->name,
-                        $method->getName()
+                        $method->getName(),
                     );
                 }
 

--- a/src/Metadata/Subscriber/DuplicateSubscribeMethod.php
+++ b/src/Metadata/Subscriber/DuplicateSubscribeMethod.php
@@ -14,7 +14,7 @@ final class DuplicateSubscribeMethod extends MetadataException
         string $subscriber,
         string $event,
         string $fistMethod,
-        string $secondMethod
+        string $secondMethod,
     ): self {
         return new self(
             sprintf(
@@ -22,7 +22,7 @@ final class DuplicateSubscribeMethod extends MetadataException
                 $fistMethod,
                 $secondMethod,
                 $subscriber,
-                $event
+                $event,
             ),
         );
     }

--- a/src/Metadata/Subscriber/DuplicateSubscribeMethod.php
+++ b/src/Metadata/Subscriber/DuplicateSubscribeMethod.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\MetadataException;
+
+use function sprintf;
+
+final class DuplicateSubscribeMethod extends MetadataException
+{
+    public static function duplicateEvent(
+        string $subscriber,
+        string $event,
+        string $fistMethod,
+        string $secondMethod
+    ): self {
+        return new self(
+            sprintf(
+                'Two methods "%s" and "%s" on the subscriber "%s" are subscribing the event "%s". A subscriber can only listen once to a event, thus this is not allowed.',
+                $fistMethod,
+                $secondMethod,
+                $subscriber,
+                $event
+            ),
+        );
+    }
+
+    public static function mixedWithAll(string $subscriber): self
+    {
+        return new self(sprintf(
+            'The subscriber "%s" is subscribing explicit events and all events. A subscriber can only listen once to a event, thus this is not allowed.',
+            $subscriber,
+        ));
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
@@ -264,6 +264,7 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
             public function profileVisited(ProfileVisited $event): void
             {
             }
+
             #[Subscribe(Subscribe::ALL)]
             public function listenAll(ProfileVisited $event): void
             {
@@ -284,6 +285,7 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
             public function profileVisited(ProfileVisited $event): void
             {
             }
+
             #[Subscribe(ProfileVisited::class)]
             public function profileVisitedAgain(ProfileVisited $event): void
             {

--- a/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
@@ -16,6 +16,7 @@ use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentTypeNotSupported;
 use Patchlevel\EventSourcing\Metadata\Subscriber\AttributeSubscriberMetadataFactory;
 use Patchlevel\EventSourcing\Metadata\Subscriber\ClassIsNotASubscriber;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateSetupMethod;
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateSubscribeMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateTeardownMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\SubscribeMethodMetadata;
 use Patchlevel\EventSourcing\Subscription\RunMode;
@@ -245,6 +246,46 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
         class {
             #[Subscribe(ProfileVisited::class)]
             public function profileVisited(ProfileVisited&Stringable $event): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadataFactory->metadata($subscriber::class);
+    }
+
+    public function testSubscribeAllWithExplicitSubscribeMethod(): void
+    {
+        $this->expectException(DuplicateSubscribeMethod::class);
+
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[Subscribe(ProfileVisited::class)]
+            public function profileVisited(ProfileVisited $event): void
+            {
+            }
+            #[Subscribe(Subscribe::ALL)]
+            public function listenAll(ProfileVisited $event): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadataFactory->metadata($subscriber::class);
+    }
+
+    public function testSubscribeSameEvent(): void
+    {
+        $this->expectException(DuplicateSubscribeMethod::class);
+
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[Subscribe(ProfileVisited::class)]
+            public function profileVisited(ProfileVisited $event): void
+            {
+            }
+            #[Subscribe(ProfileVisited::class)]
+            public function profileVisitedAgain(ProfileVisited $event): void
             {
             }
         };

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
@@ -15,7 +15,6 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\EventArgum
 use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\MessageArgumentResolver;
 use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
 use Patchlevel\EventSourcing\Subscription\Subscriber\NoSuitableResolver;
-use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
@@ -100,39 +100,6 @@ final class MetadataSubscriberAccessorTest extends TestCase
         self::assertSame($message, $subscriber->message);
     }
 
-    public function testMultipleSubscribeMethod(): void
-    {
-        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
-        class {
-            #[Subscribe(ProfileCreated::class)]
-            public function onProfileCreated(Message $message): void
-            {
-            }
-
-            #[Subscribe(ProfileCreated::class)]
-            public function onFoo(Message $message): void
-            {
-            }
-        };
-
-        $accessor = new MetadataSubscriberAccessor(
-            $subscriber,
-            (new AttributeSubscriberMetadataFactory())->metadata($subscriber::class),
-            [
-                new MessageArgumentResolver(),
-            ],
-        );
-
-        $result = $accessor->subscribeMethods(ProfileCreated::class);
-
-        self::assertCount(2, $result);
-
-        self::assertEquals([
-            $subscriber->onProfileCreated(...),
-            $subscriber->onFoo(...),
-        ], $result);
-    }
-
     public function testSubscribeAllMethod(): void
     {
         $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]


### PR DESCRIPTION
This patch here fixes https://github.com/patchlevel/event-sourcing/issues/655. Listening on the same event multiple times in one subscriber is dangerous. This is all described in the issue.

The patch itself does not contain any BC-Break regarding our API but it is a BC-Break behaviour wise. In my opinion this change is important enough to land as a bugfix due to the high risk this may disrupt production systems significantly.

We should also adjust the API in a dedicated PR so that the `SubscriberMetadata` can not hold anymore a list of methods for a given event.