### PR TITLE
SubscribeMetadata dont hold a list of methods for events

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -439,7 +439,7 @@ parameters:
 			path: tests/Unit/Message/Translator/ReplaceEventTranslatorTest.php
 
 		-
-			message: '#^Method class@anonymous/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest\.php\:212\:\:profileVisited\(\) has parameter \$message with no type specified\.$#'
+			message: '#^Method class@anonymous/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest\.php\:211\:\:profileVisited\(\) has parameter \$message with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php

--- a/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
+++ b/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
@@ -58,12 +58,12 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
                     throw DuplicateSubscribeMethod::duplicateEvent(
                         $subscriber,
                         $eventClass,
-                        $subscribeMethods[$eventClass][0]->name,
+                        $subscribeMethods[$eventClass]->name,
                         $method->getName(),
                     );
                 }
 
-                $subscribeMethods[$eventClass][] = $this->subscribeMethod($method);
+                $subscribeMethods[$eventClass] = $this->subscribeMethod($method);
             }
 
             if ($method->getAttributes(OnFailed::class)) {

--- a/src/Metadata/Subscriber/SubscriberMetadata.php
+++ b/src/Metadata/Subscriber/SubscriberMetadata.php
@@ -13,7 +13,7 @@ final class SubscriberMetadata
         public readonly string $id,
         public readonly string $group = Subscription::DEFAULT_GROUP,
         public readonly RunMode $runMode = RunMode::FromBeginning,
-        /** @var array<class-string|"*", list<SubscribeMethodMetadata>> */
+        /** @var array<class-string|"*", SubscribeMethodMetadata> */
         public readonly array $subscribeMethods = [],
         public readonly string|null $setupMethod = null,
         public readonly string|null $teardownMethod = null,

--- a/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
@@ -16,7 +16,6 @@ use Throwable;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
-use function array_merge;
 
 /** @template T of object */
 final class MetadataSubscriberAccessor implements SubscriberAccessor, RealSubscriberAccessor

--- a/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
+++ b/src/Subscription/Subscriber/MetadataSubscriberAccessor.php
@@ -115,10 +115,15 @@ final class MetadataSubscriberAccessor implements SubscriberAccessor, RealSubscr
             return $this->subscribeCache[$eventClass];
         }
 
-        $methods = array_merge(
-            $this->metadata->subscribeMethods[$eventClass] ?? [],
-            $this->metadata->subscribeMethods[Subscribe::ALL] ?? [],
-        );
+        $methods = [];
+
+        if (array_key_exists($eventClass, $this->metadata->subscribeMethods)) {
+            $methods[] = $this->metadata->subscribeMethods[$eventClass];
+        }
+
+        if (array_key_exists(Subscribe::ALL, $this->metadata->subscribeMethods)) {
+            $methods[] = $this->metadata->subscribeMethods[Subscribe::ALL];
+        }
 
         $this->subscribeCache[$eventClass] = array_map(
             fn (SubscribeMethodMetadata $method): Closure => $this->createClosure($eventClass, $method),

--- a/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
@@ -114,9 +114,7 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
 
         self::assertEquals(
             [
-                ProfileVisited::class => [
-                    new SubscribeMethodMetadata('handle', []),
-                ],
+                ProfileVisited::class => new SubscribeMethodMetadata('handle', []),
             ],
             $metadata->subscribeMethods,
         );
@@ -141,8 +139,8 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
 
         self::assertEquals(
             [
-                ProfileVisited::class => [new SubscribeMethodMetadata('handle', [])],
-                ProfileCreated::class => [new SubscribeMethodMetadata('handle', [])],
+                ProfileVisited::class => new SubscribeMethodMetadata('handle', []),
+                ProfileCreated::class => new SubscribeMethodMetadata('handle', []),
             ],
             $metadata->subscribeMethods,
         );
@@ -163,7 +161,7 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
 
         self::assertEquals(
             [
-                '*' => [new SubscribeMethodMetadata('handle', [])],
+                '*' => new SubscribeMethodMetadata('handle', []),
             ],
             $metadata->subscribeMethods,
         );
@@ -189,17 +187,18 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
 
         self::assertEquals(
             [
-                ProfileVisited::class => [
-                    new SubscribeMethodMetadata('profileVisited', [
-                        new ArgumentMetadata('message', Message::class),
-                    ]),
-                ],
-                ProfileCreated::class => [
-                    new SubscribeMethodMetadata('profileCreated', [
+                ProfileVisited::class => new SubscribeMethodMetadata(
+                    'profileVisited',
+                    [new ArgumentMetadata('message', Message::class)],
+                ),
+
+                ProfileCreated::class => new SubscribeMethodMetadata(
+                    'profileCreated',
+                    [
                         new ArgumentMetadata('profileCreated', ProfileCreated::class),
                         new ArgumentMetadata('aggregateId', 'string'),
-                    ]),
-                ],
+                    ]
+                ),
             ],
             $metadata->subscribeMethods,
         );

--- a/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
@@ -197,7 +197,7 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
                     [
                         new ArgumentMetadata('profileCreated', ProfileCreated::class),
                         new ArgumentMetadata('aggregateId', 'string'),
-                    ]
+                    ],
                 ),
             ],
             $metadata->subscribeMethods,


### PR DESCRIPTION
As mentioned in https://github.com/patchlevel/event-sourcing/pull/701 this PR adjusts the API so that the metadata isnt holding a list of methods for an event anymore as this is not supported.