### PR TITLE
Add ConsoleLogger on Watch Command

### DIFF
--- a/src/Console/Command/WatchCommand.php
+++ b/src/Console/Command/WatchCommand.php
@@ -17,6 +17,8 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
@@ -36,6 +38,24 @@ final class WatchCommand extends Command
     protected function configure(): void
     {
         $this
+            ->addOption(
+                'run-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The maximum number of runs this command should execute',
+            )
+            ->addOption(
+                'memory-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'How much memory consumption should the worker be terminated (e.g. 250MB)',
+            )
+            ->addOption(
+                'time-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'What is the maximum time the worker can run in seconds',
+            )
             ->addOption(
                 'sleep',
                 null,
@@ -67,6 +87,9 @@ final class WatchCommand extends Command
     {
         $console = new OutputStyle($input, $output);
 
+        $runLimit = InputHelper::nullablePositiveInt($input->getOption('run-limit'));
+        $memoryLimit = InputHelper::nullableString($input->getOption('memory-limit'));
+        $timeLimit = InputHelper::nullablePositiveInt($input->getOption('time-limit'));
         $sleep = InputHelper::positiveIntOrZero($input->getOption('sleep'));
         $stream = InputHelper::nullableString($input->getOption('stream'));
         $aggregate = InputHelper::nullableString($input->getOption('aggregate'));
@@ -92,6 +115,9 @@ final class WatchCommand extends Command
 
         $criteria = $criteriaBuilder->build();
 
+        $errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+        $logger = new ConsoleLogger($errOutput);
+
         $worker = DefaultWorker::create(
             function () use ($console, &$index, $criteria, $sleep): void {
                 $stream = $this->store->load(
@@ -113,12 +139,18 @@ final class WatchCommand extends Command
 
                 $this->store->wait($sleep);
             },
+            [
+                'runLimit' => $runLimit,
+                'memoryLimit' => $memoryLimit,
+                'timeLimit' => $timeLimit,
+            ],
+            $logger,
         );
 
         $supportSubscription = $this->store instanceof SubscriptionStore && $this->store->supportSubscription();
         $worker->run($supportSubscription ? 0 : $sleep);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function currentIndex(): int

--- a/tests/Unit/Console/Command/WatchCommandTest.php
+++ b/tests/Unit/Console/Command/WatchCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\WatchCommand;
+use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
+use Patchlevel\EventSourcing\Serializer\EventSerializer;
+use Patchlevel\EventSourcing\Store\InMemoryStore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use function sprintf;
+
+#[CoversClass(WatchCommand::class)]
+final class WatchCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testSuccessfulWithLogger(): void
+    {
+        $store = new InMemoryStore();
+
+        $serializer = $this->prophesize(EventSerializer::class);
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $commandTest = new CommandTester(
+            new WatchCommand(
+                $store,
+                $serializer->reveal(),
+                $headersSerializer->reveal(),
+            ),
+        );
+
+        $commandTest->execute(
+            // inputs
+            ['--run-limit' => 1],
+            // options
+            [
+                'verbosity' => OutputInterface::VERBOSITY_DEBUG,
+                'capture_stderr_separately' => true,
+            ],
+        );
+
+        $display = $commandTest->getErrorOutput();
+        self::assertStringContainsString('Worker terminated', $display);
+    }
+
+    public function testMaxIterationReached(): void
+    {
+        $store = new InMemoryStore();
+
+        $serializer = $this->prophesize(EventSerializer::class);
+
+        $headersSerializer = $this->prophesize(HeadersSerializer::class);
+
+        $commandTest = new CommandTester(
+            new WatchCommand(
+                $store,
+                $serializer->reveal(),
+                $headersSerializer->reveal(),
+            ),
+        );
+
+        $runLimit = 2;
+
+        $commandTest->execute(
+            // inputs
+            [
+                '--sleep' => 0,
+                '--run-limit' => $runLimit,
+            ],
+            // options
+            [
+                'verbosity' => OutputInterface::VERBOSITY_DEBUG,
+                'capture_stderr_separately' => true,
+            ],
+        );
+
+        $display = $commandTest->getErrorOutput();
+        self::assertStringContainsString(
+            sprintf('Worker stopped due to maximum iteration of %d', $runLimit),
+            $display,
+        );
+    }
+}


### PR DESCRIPTION
Hello,

This PR fixe #712 

- I've introduced a basic unit test for watch command that did not exists yet !

- I've also used the InMemoryStore in unit test because I cannot prophetysed the Store

With this code
```php
$store = $this->prophesize(Store::class);
```

I got this error 
```
TypeError: Double\Store\P1::load(): Return value must be of type Patchlevel\EventSourcing\Store\Stream, null returned
```
