### PR TITLE
Add subscriber information to `event-sourcing:debug`

### DIFF
--- a/src/Console/Command/DebugCommand.php
+++ b/src/Console/Command/DebugCommand.php
@@ -7,18 +7,22 @@ namespace Patchlevel\EventSourcing\Console\Command;
 use Patchlevel\EventSourcing\Console\OutputStyle;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Metadata\Event\EventRegistry;
+use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
+use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessorRepository;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_intersect_key;
 use function array_keys;
 use function array_map;
+use function array_shift;
 use function array_values;
 
 #[AsCommand(
     'event-sourcing:debug',
-    'show event sourcing debug information',
+    'Show event sourcing information (aggregates, events, subscribers)',
     ['debug:event-sourcing'],
 )]
 final class DebugCommand extends Command
@@ -26,6 +30,7 @@ final class DebugCommand extends Command
     public function __construct(
         private readonly AggregateRootRegistry $aggregateRootRegistry,
         private readonly EventRegistry $eventRegistry,
+        private readonly SubscriberAccessorRepository|null $subscriberAccessorRepository = null,
     ) {
         parent::__construct();
     }
@@ -36,8 +41,9 @@ final class DebugCommand extends Command
 
         $this->showAggregates($console);
         $this->showEvents($console);
+        $this->showSubscribers($console);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function showAggregates(OutputStyle $console): void
@@ -61,6 +67,45 @@ final class DebugCommand extends Command
         $console->table(
             ['name', 'class'],
             array_map(null, array_keys($events), array_values($events)),
+        );
+    }
+
+    private function showSubscribers(OutputStyle $console): void
+    {
+        $eventNames = $this->eventRegistry->eventNames();
+
+        $subscribers = [];
+
+        /** @var MetadataSubscriberAccessor $subscriberAccessor */
+        foreach ($this->subscriberAccessorRepository?->all() ?? [] as $subscriberAccessor) {
+            $metadata = $subscriberAccessor->metadata();
+
+            $eventsHandled = array_values(array_intersect_key($eventNames, $metadata->subscribeMethods));
+
+            $subscribers[] = [
+                $metadata->id,
+                $metadata->group,
+                $metadata->runMode->value,
+                // first event name handled
+                array_shift($eventsHandled),
+            ];
+
+            // display more event names that the subscriber can handle (if any)
+            foreach ($eventsHandled as $eventName) {
+                $subscribers[] = ['', '', '', $eventName];
+            }
+        }
+
+        $console->title('Subscribers');
+
+        $console->table(
+            [
+                'id',
+                'group',
+                'run mode',
+                'events handled',
+            ],
+            $subscribers,
         );
     }
 }

--- a/src/Console/Command/DebugCommand.php
+++ b/src/Console/Command/DebugCommand.php
@@ -71,8 +71,6 @@ final class DebugCommand extends Command
 
     private function showSubscribers(OutputStyle $console): void
     {
-        $eventNames = $this->eventRegistry->eventNames();
-
         $subscribers = [];
 
         /** @var MetadataSubscriberAccessor $subscriberAccessor */
@@ -85,11 +83,11 @@ final class DebugCommand extends Command
                 $metadata->id,
                 $metadata->group,
                 $metadata->runMode->value,
-                // first event name handled
+                // first event class name handled
                 array_shift($eventsHandled),
             ];
 
-            // display more event names that the subscriber can handle (if any)
+            // display more event class names that the subscriber can handle (if any)
             foreach ($eventsHandled as $eventName) {
                 $subscribers[] = ['', '', '', $eventName];
             }

--- a/src/Console/Command/DebugCommand.php
+++ b/src/Console/Command/DebugCommand.php
@@ -80,7 +80,7 @@ final class DebugCommand extends Command
         foreach ($this->subscriberAccessorRepository?->all() ?? [] as $subscriberAccessor) {
             $metadata = $subscriberAccessor->metadata();
 
-            $eventsHandled = array_values(array_intersect_key($eventNames, $metadata->subscribeMethods));
+            $eventsHandled = array_intersect_key($eventNames, $metadata->subscribeMethods);
 
             $subscribers[] = [
                 $metadata->id,

--- a/src/Console/Command/DebugCommand.php
+++ b/src/Console/Command/DebugCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function array_intersect_key;
 use function array_keys;
 use function array_map;
 use function array_shift;
@@ -80,7 +79,7 @@ final class DebugCommand extends Command
         foreach ($this->subscriberAccessorRepository?->all() ?? [] as $subscriberAccessor) {
             $metadata = $subscriberAccessor->metadata();
 
-            $eventsHandled = array_intersect_key($eventNames, $metadata->subscribeMethods);
+            $eventsHandled = array_keys($metadata->subscribeMethods);
 
             $subscribers[] = [
                 $metadata->id,

--- a/tests/Unit/Console/Command/DebugCommandTest.php
+++ b/tests/Unit/Console/Command/DebugCommandTest.php
@@ -76,7 +76,12 @@ final class DebugCommandTest extends TestCase
 
         $content = $output->fetch();
 
+        self::assertStringContainsString('Subscribers', $content);
+        self::assertStringContainsString('events handled', $content);
+        self::assertStringContainsString('profile.test', $content);
         self::assertStringContainsString('default', $content);
+        self::assertStringContainsString('profile.projection', $content);
         self::assertStringContainsString('projector', $content);
+        self::assertStringContainsString('profile.created', $content);
     }
 }

--- a/tests/Unit/Console/Command/DebugCommandTest.php
+++ b/tests/Unit/Console/Command/DebugCommandTest.php
@@ -4,18 +4,27 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
 
+use Patchlevel\EventSourcing\Attribute\Projector;
+use Patchlevel\EventSourcing\Attribute\Subscribe;
+use Patchlevel\EventSourcing\Attribute\Subscriber;
 use Patchlevel\EventSourcing\Console\Command\DebugCommand;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Metadata\Event\EventRegistry;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorRepository;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
-/** @covers \Patchlevel\EventSourcing\Console\Command\DebugCommand */
+#[CoversClass(DebugCommand::class)]
 final class DebugCommandTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testSuccessful(): void
     {
         $command = new DebugCommand(
@@ -36,5 +45,38 @@ final class DebugCommandTest extends TestCase
         self::assertStringContainsString(Profile::class, $content);
         self::assertStringContainsString('profile.created', $content);
         self::assertStringContainsString(ProfileCreated::class, $content);
+    }
+
+    public function testSuccessfulWithSubscribers(): void
+    {
+        $subscriber1 = new #[Subscriber('profile.test', RunMode::FromBeginning)]
+        class {
+        };
+
+        $subscriber2 = new #[Projector('profile.projection')]
+        class {
+            #[Subscribe(ProfileCreated::class)]
+            public function onProfileCreated(ProfileCreated $event): void
+            {
+            }
+        };
+
+        $command = new DebugCommand(
+            new AggregateRootRegistry(['profile' => Profile::class]),
+            new EventRegistry(['profile.created' => ProfileCreated::class]),
+            new MetadataSubscriberAccessorRepository([$subscriber1, $subscriber2]),
+        );
+
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $exitCode = $command->run($input, $output);
+
+        self::assertSame(0, $exitCode);
+
+        $content = $output->fetch();
+
+        self::assertStringContainsString('default', $content);
+        self::assertStringContainsString('projector', $content);
     }
 }

--- a/tests/Unit/Console/Command/DebugCommandTest.php
+++ b/tests/Unit/Console/Command/DebugCommandTest.php
@@ -77,11 +77,18 @@ final class DebugCommandTest extends TestCase
         $content = $output->fetch();
 
         self::assertStringContainsString('Subscribers', $content);
+        self::assertStringContainsString('id', $content);
+        self::assertStringContainsString('group', $content);
+        self::assertStringContainsString('run mode', $content);
         self::assertStringContainsString('events handled', $content);
+
         self::assertStringContainsString('profile.test', $content);
         self::assertStringContainsString('default', $content);
+        self::assertStringContainsString('from_beginning', $content);
+
         self::assertStringContainsString('profile.projection', $content);
         self::assertStringContainsString('projector', $content);
+        self::assertStringContainsString('from_beginning', $content);
         self::assertStringContainsString('profile.created', $content);
     }
 }


### PR DESCRIPTION
Hello,

Here is the PR to improve `debug:event-sourcing` command, following principles presented into #719