### PR TITLE
remove double quotes for mysql database

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,7 +77,7 @@ jobs:
           image: "mariadb:${{ matrix.mariadb-version }}"
           env:
             MYSQL_ALLOW_EMPTY_PASSWORD: yes
-            MYSQL_DATABASE: "eventstore"
+            MYSQL_DATABASE: eventstore
 
           options: >-
             --health-cmd "mariadb-admin ping --silent"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,6 @@ services:
     image: mysql:8
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD="yes"
-      - MYSQL_DATABASE="eventstore"
+      - MYSQL_DATABASE=eventstore
     ports:
       - 3306:3306


### PR DESCRIPTION
Hi, it seams that the database contains the double quotes.

Steps to reproduce:
```
$ docker compose up -d
$ docker compose exec -ti mysql bash
$ mysql -uroot
mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| "eventstore"
```