### PR TITLE
feat: add transactional to config to allow deactivation of transactions

### DIFF
--- a/src/Store/DoctrineDbalStore.php
+++ b/src/Store/DoctrineDbalStore.php
@@ -62,12 +62,12 @@ final class DoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchem
 
     private readonly HeadersSerializer $headersSerializer;
 
-    /** @var array{table_name: string, aggregate_id_type: 'string'|'uuid', locking: bool, lock_id: int, lock_timeout: int} */
+    /** @var array{table_name: string, aggregate_id_type: 'string'|'uuid', locking: bool, lock_id: int, lock_timeout: int, transactional: bool} */
     private readonly array $config;
 
     private bool $hasLock = false;
 
-    /** @param array{table_name?: string, aggregate_id_type?: 'string'|'uuid', locking?: bool, lock_id?: int, lock_timeout?: int} $config */
+    /** @param array{table_name?: string, aggregate_id_type?: 'string'|'uuid', locking?: bool, lock_id?: int, lock_timeout?: int, transactional: bool} $config */
     public function __construct(
         private readonly Connection $connection,
         private readonly EventSerializer $eventSerializer,
@@ -82,6 +82,7 @@ final class DoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchem
             'locking' => true,
             'lock_id' => self::DEFAULT_LOCK_ID,
             'lock_timeout' => -1,
+            'transactional' => true,
         ], $config);
     }
 
@@ -298,17 +299,21 @@ final class DoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchem
      */
     public function transactional(Closure $function): void
     {
+        if ($this->config['transactional']) {
+            $function = function () use ($function): void {
+                $this->connection->transactional($function);
+            };
+        }
+
         if ($this->hasLock || !$this->config['locking']) {
-            $this->connection->transactional($function);
+            $function();
         } else {
-            $this->connection->transactional(function () use ($function): void {
-                $this->lock();
-                try {
-                    $function();
-                } finally {
-                    $this->unlock();
-                }
-            });
+            $this->lock();
+            try {
+                $function();
+            } finally {
+                $this->unlock();
+            }
         }
     }
 


### PR DESCRIPTION
Hi, when I try to use mariadb and the `DoctrineDbalStore` inside a doctrine migration, transactions are not working as expected.

For know I'm not 100% sure how to reproduce it. I only know that when I'm using the Event-Store Repository as part of a migration, the first run always ends up with an error like this:
```
[error] Migration App\MigrationsEventSourcing\Version20250527155847 failed during Execution. Error: "An exception occurred in the driver: There is no active transaction"

In ExceptionConverter.php line 91:

  An exception occurred in the driver: There is no active transaction


In Exception.php line 24:

  There is no active transaction


In Connection.php line 123:

  There is no active transaction


In ExceptionConverter.php line 91:

  An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT DOCTRINE_2 does not exist


In Exception.php line 24:

  SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT DOCTRINE_2 does not exist


In Connection.php line 27:

  SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT DOCTRINE_2 does not exist
```

This PR allows to deactivate transactions via the config. (It's a first draft for now to start a discussion)