### PR TITLE
Add QueryBus integration test, also add "full cycle" bench

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43,12 +43,6 @@ parameters:
 			path: src/Message/Serializer/DefaultHeadersSerializer.php
 
 		-
-			message: '#^Call to an undefined method Patchlevel\\EventSourcing\\Store\\Store\:\:archive\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Repository/DefaultRepository.php
-
-		-
 			message: '#^Parameter \#1 \.\.\.\$streamName of class Patchlevel\\EventSourcing\\Store\\Criteria\\StreamCriterion constructor expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -169,6 +163,24 @@ parameters:
 			path: src/Subscription/ThrowableToErrorContextTransformer.php
 
 		-
+			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Benchmark\\BasicImplementation\\ProfileWithCommands\:\:\$id is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: tests/Benchmark/BasicImplementation/ProfileWithCommands.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\<string, mixed\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
+
+		-
+			message: '#^Method Patchlevel\\EventSourcing\\Tests\\Benchmark\\BasicImplementation\\Projection\\ProfileProjector\:\:getProfileName\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
+
+		-
 			message: '#^Parameter \#1 \$id of static method Patchlevel\\EventSourcing\\Tests\\Benchmark\\BasicImplementation\\Profile\:\:create\(\) expects Patchlevel\\EventSourcing\\Tests\\Benchmark\\BasicImplementation\\ProfileId, Patchlevel\\EventSourcing\\Aggregate\\AggregateRootId given\.$#'
 			identifier: argument.type
 			count: 1
@@ -233,6 +245,18 @@ parameters:
 			identifier: property.onlyWritten
 			count: 1
 			path: tests/Integration/BasicImplementation/ProfileWithCommands.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\<string, mixed\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Integration/BasicImplementation/Projection/ProfileProjector.php
+
+		-
+			message: '#^Method Patchlevel\\EventSourcing\\Tests\\Integration\\BasicImplementation\\Projection\\ProfileProjector\:\:getProfileName\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: tests/Integration/BasicImplementation/Projection/ProfileProjector.php
 
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Patchlevel\\\\EventSourcing\\\\Tests\\\\Integration\\\\ChildAggregate\\\\Profile'' and Patchlevel\\EventSourcing\\Tests\\Integration\\ChildAggregate\\Profile will always evaluate to true\.$#'

--- a/src/Subscription/Engine/SubscriptionManager.php
+++ b/src/Subscription/Engine/SubscriptionManager.php
@@ -77,28 +77,28 @@ final class SubscriptionManager
     public function add(Subscription ...$subscriptions): void
     {
         foreach ($subscriptions as $sub) {
-            $this->forAdd->attach($sub);
+            $this->forAdd->offsetSet($sub);
         }
     }
 
     public function update(Subscription ...$subscriptions): void
     {
         foreach ($subscriptions as $sub) {
-            $this->forUpdate->attach($sub);
+            $this->forUpdate->offsetSet($sub);
         }
     }
 
     public function remove(Subscription ...$subscriptions): void
     {
         foreach ($subscriptions as $sub) {
-            $this->forRemove->attach($sub);
+            $this->forRemove->offsetSet($sub);
         }
     }
 
     public function flush(): void
     {
         foreach ($this->forAdd as $subscription) {
-            if ($this->forRemove->contains($subscription)) {
+            if ($this->forRemove->offsetExists($subscription)) {
                 continue;
             }
 
@@ -106,11 +106,11 @@ final class SubscriptionManager
         }
 
         foreach ($this->forUpdate as $subscription) {
-            if ($this->forAdd->contains($subscription)) {
+            if ($this->forAdd->offsetExists($subscription)) {
                 continue;
             }
 
-            if ($this->forRemove->contains($subscription)) {
+            if ($this->forRemove->offsetExists($subscription)) {
                 continue;
             }
 
@@ -118,7 +118,7 @@ final class SubscriptionManager
         }
 
         foreach ($this->forRemove as $subscription) {
-            if ($this->forAdd->contains($subscription)) {
+            if ($this->forAdd->offsetExists($subscription)) {
                 continue;
             }
 

--- a/tests/Benchmark/BasicImplementation/Command/ChangeProfileName.php
+++ b/tests/Benchmark/BasicImplementation/Command/ChangeProfileName.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Command;
+
+use Patchlevel\EventSourcing\Attribute\Id;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
+
+final class ChangeProfileName
+{
+    public function __construct(
+        #[Id]
+        public readonly ProfileId $id,
+        public readonly string $name,
+    ) {
+    }
+}

--- a/tests/Benchmark/BasicImplementation/Command/CreateProfile.php
+++ b/tests/Benchmark/BasicImplementation/Command/CreateProfile.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Command;
+
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
+
+final class CreateProfile
+{
+    public function __construct(
+        public readonly ProfileId $id,
+        public readonly string $name,
+    ) {
+    }
+}

--- a/tests/Benchmark/BasicImplementation/Events/NameChanged.php
+++ b/tests/Benchmark/BasicImplementation/Events/NameChanged.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events;
 
 use Patchlevel\EventSourcing\Attribute\Event;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
 
 #[Event('profile.name_changed')]
-final class NameChanged
+final readonly class NameChanged
 {
     public function __construct(
+        public ProfileId $profileId,
         public string $name,
     ) {
     }

--- a/tests/Benchmark/BasicImplementation/Profile.php
+++ b/tests/Benchmark/BasicImplementation/Profile.php
@@ -33,7 +33,7 @@ final class Profile extends BasicAggregateRoot
 
     public function changeName(string $name): void
     {
-        $this->recordThat(new NameChanged($name));
+        $this->recordThat(new NameChanged($this->id, $name));
     }
 
     public function changeEmail(string $email): void

--- a/tests/Benchmark/BasicImplementation/ProfileWithCommands.php
+++ b/tests/Benchmark/BasicImplementation/ProfileWithCommands.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Apply;
+use Patchlevel\EventSourcing\Attribute\Handle;
+use Patchlevel\EventSourcing\Attribute\Id;
+use Patchlevel\EventSourcing\Attribute\Inject;
+use Patchlevel\EventSourcing\Attribute\Snapshot;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Command\ChangeProfileName;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Command\CreateProfile;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\NameChanged;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\ProfileCreated;
+use Psr\Clock\ClockInterface;
+
+#[Aggregate('profile_with_commands')]
+#[Snapshot('default', 100)]
+final class ProfileWithCommands extends BasicAggregateRoot
+{
+    #[Id]
+    private ProfileId $id;
+    private string $name;
+
+    #[Handle]
+    public static function create(
+        CreateProfile $command,
+        ClockInterface $clock,
+        #[Inject('env')]
+        string $env,
+    ): self {
+        $self = new self();
+        $self->recordThat(new ProfileCreated($command->id, $command->name, null));
+
+        return $self;
+    }
+
+    #[Handle]
+    public function changeName(
+        ChangeProfileName $command,
+        ClockInterface $clock,
+        #[Inject('env')]
+        string $env,
+    ): void {
+        $this->recordThat(new NameChanged($this->id, $command->name));
+    }
+
+    #[Apply]
+    protected function applyProfileCreated(ProfileCreated $event): void
+    {
+        $this->id = $event->profileId;
+        $this->name = $event->name;
+    }
+
+    #[Apply]
+    protected function applyNameChanged(NameChanged $event): void
+    {
+        $this->name = $event->name;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Benchmark/BasicImplementation/Projection/BatchProfileProjector.php
+++ b/tests/Benchmark/BasicImplementation/Projection/BatchProfileProjector.php
@@ -13,7 +13,6 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\BatchableSubscriber;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberUtil;
 use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\NameChanged;
 use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\ProfileCreated;
-use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
 
 #[Projector('profile')]
 final class BatchProfileProjector implements BatchableSubscriber
@@ -53,9 +52,9 @@ final class BatchProfileProjector implements BatchableSubscriber
     }
 
     #[Subscribe(NameChanged::class)]
-    public function onNameChanged(NameChanged $nameChanged, ProfileId $profileId): void
+    public function onNameChanged(NameChanged $nameChanged): void
     {
-        $this->nameChanged[$profileId->toString()] = $nameChanged->name;
+        $this->nameChanged[$nameChanged->profileId->toString()] = $nameChanged->name;
     }
 
     public function table(): string

--- a/tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
+++ b/tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Projection;
 
 use Doctrine\DBAL\Connection;
+use Patchlevel\EventSourcing\Attribute\Answer;
 use Patchlevel\EventSourcing\Attribute\Projector;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
@@ -12,7 +13,7 @@ use Patchlevel\EventSourcing\Attribute\Teardown;
 use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberUtil;
 use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\NameChanged;
 use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Events\ProfileCreated;
-use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Query\QueryProfileName;
 
 #[Projector('profile')]
 final class ProfileProjector
@@ -49,13 +50,22 @@ final class ProfileProjector
     }
 
     #[Subscribe(NameChanged::class)]
-    public function onNameChanged(NameChanged $nameChanged, ProfileId $profileId): void
+    public function onNameChanged(NameChanged $nameChanged): void
     {
         $this->connection->update(
             $this->table(),
             ['name' => $nameChanged->name],
-            ['id' => $profileId->toString()],
+            ['id' => $nameChanged->profileId->toString()],
         );
+    }
+
+    #[Answer]
+    public function getProfileName(QueryProfileName $queryProfileName): string
+    {
+        return $this->connection->fetchAssociative(
+            "SELECT name FROM {$this->table()} WHERE id = :id;",
+            ['id' => $queryProfileName->id->toString()],
+        )['name'];
     }
 
     public function table(): string

--- a/tests/Benchmark/BasicImplementation/Query/QueryProfileName.php
+++ b/tests/Benchmark/BasicImplementation/Query/QueryProfileName.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Query;
+
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
+
+final readonly class QueryProfileName
+{
+    public function __construct(public ProfileId $id)
+    {
+    }
+}

--- a/tests/Benchmark/CommandToQueryBench.php
+++ b/tests/Benchmark/CommandToQueryBench.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Benchmark;
+
+use Patchlevel\EventSourcing\Clock\SystemClock;
+use Patchlevel\EventSourcing\CommandBus\CommandBus;
+use Patchlevel\EventSourcing\CommandBus\ServiceLocator;
+use Patchlevel\EventSourcing\CommandBus\SyncCommandBus;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
+use Patchlevel\EventSourcing\QueryBus\QueryBus;
+use Patchlevel\EventSourcing\QueryBus\ServiceHandlerProvider;
+use Patchlevel\EventSourcing\QueryBus\SyncQueryBus;
+use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
+use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
+use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
+use Patchlevel\EventSourcing\Snapshot\Adapter\InMemorySnapshotAdapter;
+use Patchlevel\EventSourcing\Snapshot\DefaultSnapshotStore;
+use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
+use Patchlevel\EventSourcing\Subscription\Engine\DefaultSubscriptionEngine;
+use Patchlevel\EventSourcing\Subscription\Repository\RunSubscriptionEngineRepositoryManager;
+use Patchlevel\EventSourcing\Subscription\Store\InMemorySubscriptionStore;
+use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorRepository;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Command\ChangeProfileName;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Command\CreateProfile;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Processor\SendEmailProcessor;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileId;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\ProfileWithCommands;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Projection\ProfileProjector;
+use Patchlevel\EventSourcing\Tests\Benchmark\BasicImplementation\Query\QueryProfileName;
+use Patchlevel\EventSourcing\Tests\DbalManager;
+use PhpBench\Attributes as Bench;
+use Psr\Clock\ClockInterface;
+
+use function assert;
+
+#[Bench\BeforeMethods('setUp')]
+final class CommandToQueryBench
+{
+    private CommandBus $commandBus;
+    private QueryBus $queryBus;
+
+    private ProfileId $updateId;
+
+    public function setUp(): void
+    {
+        $connection = DbalManager::createConnection();
+        $store = new StreamDoctrineDbalStore(
+            $connection,
+            DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
+        );
+
+        $aggregateRootRegistry = new AggregateRootRegistry(['profile_with_commands' => ProfileWithCommands::class]);
+
+        $manager = new DefaultRepositoryManager(
+            $aggregateRootRegistry,
+            $store,
+            null,
+            new DefaultSnapshotStore(['default' => new InMemorySnapshotAdapter()]),
+        );
+
+        $projectionConnection = DbalManager::createConnection();
+        $profileProjection = new ProfileProjector($projectionConnection);
+
+        $engine = new DefaultSubscriptionEngine(
+            $store,
+            new InMemorySubscriptionStore(),
+            new MetadataSubscriberAccessorRepository([
+                $profileProjection,
+                new SendEmailProcessor(),
+            ]),
+        );
+
+        $manager = new RunSubscriptionEngineRepositoryManager($manager, $engine);
+
+        $this->commandBus = SyncCommandBus::createForAggregateHandlers(
+            $aggregateRootRegistry,
+            $manager,
+            new ServiceLocator([
+                ClockInterface::class => new SystemClock(),
+                'env' => 'test',
+            ]),
+        );
+
+        $this->queryBus = new SyncQueryBus(new ServiceHandlerProvider([$profileProjection]));
+
+        $schemaDirector = new DoctrineSchemaDirector($connection, $store);
+
+        $schemaDirector->create();
+        $engine->setup(skipBooting: true);
+
+        $this->updateId = ProfileId::generate();
+        $this->commandBus->dispatch(new CreateProfile($this->updateId, 'Peter'));
+    }
+
+    #[Bench\Revs(10)]
+    public function benchCreate(): void
+    {
+        $id = ProfileId::generate();
+        $this->commandBus->dispatch(new CreateProfile($id, 'James'));
+        $result = $this->queryBus->dispatch(new QueryProfileName($id));
+
+        assert($result === 'James');
+    }
+
+    #[Bench\Revs(10)]
+    public function benchUpdate(): void
+    {
+        $this->commandBus->dispatch(new ChangeProfileName($this->updateId, 'James Doe'));
+        $result = $this->queryBus->dispatch(new QueryProfileName($this->updateId));
+
+        assert($result === 'James Doe');
+    }
+
+    #[Bench\Revs(10)]
+    public function benchBoth(): void
+    {
+        $id = ProfileId::generate();
+        $this->commandBus->dispatch(new CreateProfile($id, 'James'));
+        $result = $this->queryBus->dispatch(new QueryProfileName($id));
+        assert($result === 'James');
+
+        $this->commandBus->dispatch(new ChangeProfileName($id, 'James Doe'));
+        $result = $this->queryBus->dispatch(new QueryProfileName($id));
+        assert($result === 'James Doe');
+    }
+}

--- a/tests/Integration/BasicImplementation/BasicIntegrationTest.php
+++ b/tests/Integration/BasicImplementation/BasicIntegrationTest.php
@@ -15,6 +15,8 @@ use Patchlevel\EventSourcing\Message\Reducer;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
 use Patchlevel\EventSourcing\Message\Translator\UntilEventTranslator;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
+use Patchlevel\EventSourcing\QueryBus\ServiceHandlerProvider;
+use Patchlevel\EventSourcing\QueryBus\SyncQueryBus;
 use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
@@ -36,6 +38,7 @@ use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\Profil
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\MessageDecorator\FooMessageDecorator;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Processor\SendEmailProcessor;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Projection\ProfileProjector;
+use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Query\QueryProfileName;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
@@ -323,5 +326,70 @@ final class BasicIntegrationTest extends TestCase
         self::assertSame(2, $profile->playhead());
         self::assertSame('John Doe', $profile->name());
         self::assertSame(1, SendEmailMock::count());
+    }
+
+    public function testQueryBus(): void
+    {
+        $store = new DoctrineDbalStore(
+            $this->connection,
+            DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
+            DefaultHeadersSerializer::createFromPaths([
+                __DIR__ . '/Header',
+            ]),
+        );
+
+        $aggregateRootRegistry = new AggregateRootRegistry(['profile_with_commands' => ProfileWithCommands::class]);
+
+        $manager = new DefaultRepositoryManager(
+            new AggregateRootRegistry(['profile_with_commands' => ProfileWithCommands::class]),
+            $store,
+            null,
+            new DefaultSnapshotStore(['default' => new InMemorySnapshotAdapter()]),
+            new FooMessageDecorator(),
+        );
+
+        $profileProjection = new ProfileProjector($this->connection);
+
+        $engine = new DefaultSubscriptionEngine(
+            $store,
+            new InMemorySubscriptionStore(),
+            new MetadataSubscriberAccessorRepository([
+                $profileProjection,
+                new SendEmailProcessor(),
+            ]),
+        );
+
+        $manager = new RunSubscriptionEngineRepositoryManager(
+            $manager,
+            $engine,
+        );
+
+        $commandBus = SyncCommandBus::createForAggregateHandlers(
+            $aggregateRootRegistry,
+            $manager,
+            new ServiceLocator([
+                ClockInterface::class => new SystemClock(),
+                'env' => 'test',
+            ]),
+        );
+
+        $queryBus = new SyncQueryBus(new ServiceHandlerProvider([$profileProjection]));
+
+        $schemaDirector = new DoctrineSchemaDirector(
+            $this->connection,
+            $store,
+        );
+
+        $schemaDirector->create();
+        $engine->setup(skipBooting: true);
+
+        $profileId = ProfileId::generate();
+
+        $commandBus->dispatch(new CreateProfile($profileId, 'John'));
+        $commandBus->dispatch(new ChangeProfileName($profileId, 'John Doe'));
+
+        $result = $queryBus->dispatch(new QueryProfileName($profileId));
+
+        self::assertSame('John Doe', $result);
     }
 }

--- a/tests/Integration/BasicImplementation/Projection/ProfileProjector.php
+++ b/tests/Integration/BasicImplementation/Projection/ProfileProjector.php
@@ -6,6 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Project
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Table;
+use Patchlevel\EventSourcing\Attribute\Answer;
 use Patchlevel\EventSourcing\Attribute\Projector;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
@@ -13,6 +14,7 @@ use Patchlevel\EventSourcing\Attribute\Teardown;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\NameChanged;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Events\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\ProfileId;
+use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Query\QueryProfileName;
 
 #[Projector('profile-1')]
 final class ProfileProjector
@@ -61,5 +63,14 @@ final class ProfileProjector
                 'name' => $nameChanged->name,
             ],
         );
+    }
+
+    #[Answer]
+    public function getProfileName(QueryProfileName $queryProfileName): string
+    {
+        return $this->connection->fetchAssociative(
+            'SELECT name FROM projection_profile WHERE id = :id',
+            ['id' => $queryProfileName->id->toString()],
+        )['name'];
     }
 }

--- a/tests/Integration/BasicImplementation/Query/QueryProfileName.php
+++ b/tests/Integration/BasicImplementation/Query/QueryProfileName.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\Query;
+
+use Patchlevel\EventSourcing\Tests\Integration\BasicImplementation\ProfileId;
+
+final readonly class QueryProfileName
+{
+    public function __construct(public ProfileId $id)
+    {
+    }
+}


### PR DESCRIPTION
Add QueryBus integration test which was missing, also add "full cycle" bench which dispatches a command and then query the name.

Fix a deprecation notice regarding `SplObjectStorage`