### PR TITLE
Add nullable information to Subscriber ArgumentMetadata

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -463,7 +463,7 @@ parameters:
 			path: tests/Unit/Message/Translator/ReplaceEventTranslatorTest.php
 
 		-
-			message: '#^Method class@anonymous/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest\.php\:212\:\:profileVisited\(\) has parameter \$message with no type specified\.$#'
+			message: '#^Method class@anonymous/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest\.php\:237\:\:profileVisited\(\) has parameter \$message with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php

--- a/src/Metadata/Subscriber/ArgumentMetadata.php
+++ b/src/Metadata/Subscriber/ArgumentMetadata.php
@@ -9,6 +9,7 @@ final class ArgumentMetadata
     public function __construct(
         public readonly string $name,
         public readonly string $type,
+        public readonly bool $allowsNull = false,
     ) {
     }
 }

--- a/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
+++ b/src/Metadata/Subscriber/AttributeSubscriberMetadataFactory.php
@@ -151,6 +151,7 @@ final class AttributeSubscriberMetadataFactory implements SubscriberMetadataFact
             $arguments[] = new ArgumentMetadata(
                 $parameter->getName(),
                 $type->getName(),
+                $parameter->allowsNull(),
             );
         }
 

--- a/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
@@ -191,13 +191,38 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
             [
                 ProfileVisited::class => [
                     new SubscribeMethodMetadata('profileVisited', [
-                        new ArgumentMetadata('message', Message::class),
+                        new ArgumentMetadata('message', Message::class, false),
                     ]),
                 ],
                 ProfileCreated::class => [
                     new SubscribeMethodMetadata('profileCreated', [
-                        new ArgumentMetadata('profileCreated', ProfileCreated::class),
-                        new ArgumentMetadata('aggregateId', 'string'),
+                        new ArgumentMetadata('profileCreated', ProfileCreated::class, false),
+                        new ArgumentMetadata('aggregateId', 'string', false),
+                    ]),
+                ],
+            ],
+            $metadata->subscribeMethods,
+        );
+    }
+
+    public function testSubscribeNullableAttribute(): void
+    {
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[Subscribe(ProfileVisited::class)]
+            public function profileVisited(ProfileVisited|null $message): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadata = $metadataFactory->metadata($subscriber::class);
+
+        self::assertEquals(
+            [
+                ProfileVisited::class => [
+                    new SubscribeMethodMetadata('profileVisited', [
+                        new ArgumentMetadata('message', ProfileVisited::class, true),
                     ]),
                 ],
             ],

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/AggregateIdArgumentResolverTest.php
@@ -26,21 +26,21 @@ final class AggregateIdArgumentResolverTest extends TestCase
 
         self::assertTrue(
             $resolver->support(
-                new ArgumentMetadata('aggregateId', Uuid::class),
+                new ArgumentMetadata('aggregateId', Uuid::class, false),
                 ProfileCreated::class,
             ),
         );
 
         self::assertTrue(
             $resolver->support(
-                new ArgumentMetadata('aggregateRootId', ProfileId::class),
+                new ArgumentMetadata('aggregateRootId', ProfileId::class, false),
                 ProfileCreated::class,
             ),
         );
 
         self::assertFalse(
             $resolver->support(
-                new ArgumentMetadata('foo', ProfileCreated::class),
+                new ArgumentMetadata('foo', ProfileCreated::class, false),
                 ProfileCreated::class,
             ),
         );
@@ -58,7 +58,7 @@ final class AggregateIdArgumentResolverTest extends TestCase
         self::assertEquals(
             new CustomId('bar'),
             $resolver->resolve(
-                new ArgumentMetadata('foo', CustomId::class),
+                new ArgumentMetadata('foo', CustomId::class, false),
                 $message,
             ),
         );

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/EventArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/EventArgumentResolverTest.php
@@ -22,14 +22,14 @@ final class EventArgumentResolverTest extends TestCase
 
         self::assertTrue(
             $resolver->support(
-                new ArgumentMetadata('foo', ProfileCreated::class),
+                new ArgumentMetadata('foo', ProfileCreated::class, false),
                 ProfileCreated::class,
             ),
         );
 
         self::assertFalse(
             $resolver->support(
-                new ArgumentMetadata('foo', ProfileVisited::class),
+                new ArgumentMetadata('foo', ProfileVisited::class, false),
                 ProfileCreated::class,
             ),
         );
@@ -45,7 +45,7 @@ final class EventArgumentResolverTest extends TestCase
         self::assertSame(
             $event,
             $resolver->resolve(
-                new ArgumentMetadata('foo', ProfileVisited::class),
+                new ArgumentMetadata('foo', ProfileVisited::class, false),
                 $message,
             ),
         );

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/LookupResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/LookupResolverTest.php
@@ -32,14 +32,14 @@ final class LookupResolverTest extends TestCase
 
         self::assertTrue(
             $resolver->support(
-                new ArgumentMetadata('lookup', Lookup::class),
+                new ArgumentMetadata('lookup', Lookup::class, false),
                 ProfileCreated::class,
             ),
         );
 
         self::assertFalse(
             $resolver->support(
-                new ArgumentMetadata('foo', ProfileCreated::class),
+                new ArgumentMetadata('foo', ProfileCreated::class, false),
                 ProfileCreated::class,
             ),
         );
@@ -61,7 +61,7 @@ final class LookupResolverTest extends TestCase
         );
 
         $lookup = $resolver->resolve(
-            new ArgumentMetadata('foo', Lookup::class),
+            new ArgumentMetadata('foo', Lookup::class, false),
             $message,
         );
 

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/MessageArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/MessageArgumentResolverTest.php
@@ -20,14 +20,14 @@ final class MessageArgumentResolverTest extends TestCase
 
         self::assertTrue(
             $resolver->support(
-                new ArgumentMetadata('foo', Message::class),
+                new ArgumentMetadata('foo', Message::class, false),
                 'qux',
             ),
         );
 
         self::assertFalse(
             $resolver->support(
-                new ArgumentMetadata('foo', 'bar'),
+                new ArgumentMetadata('foo', 'bar', false),
                 'qux',
             ),
         );
@@ -41,7 +41,7 @@ final class MessageArgumentResolverTest extends TestCase
         self::assertSame(
             $message,
             $resolver->resolve(
-                new ArgumentMetadata('foo', Message::class),
+                new ArgumentMetadata('foo', Message::class, false),
                 $message,
             ),
         );

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/RecordedOnArgumentResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/RecordedOnArgumentResolverTest.php
@@ -23,14 +23,14 @@ final class RecordedOnArgumentResolverTest extends TestCase
 
         self::assertTrue(
             $resolver->support(
-                new ArgumentMetadata('foo', DateTimeImmutable::class),
+                new ArgumentMetadata('foo', DateTimeImmutable::class, false),
                 'qux',
             ),
         );
 
         self::assertFalse(
             $resolver->support(
-                new ArgumentMetadata('foo', 'bar'),
+                new ArgumentMetadata('foo', 'bar', false),
                 'qux',
             ),
         );
@@ -53,7 +53,7 @@ final class RecordedOnArgumentResolverTest extends TestCase
         self::assertSame(
             $date,
             $resolver->resolve(
-                new ArgumentMetadata('foo', DateTimeImmutable::class),
+                new ArgumentMetadata('foo', DateTimeImmutable::class, false),
                 $message,
             ),
         );
@@ -69,7 +69,7 @@ final class RecordedOnArgumentResolverTest extends TestCase
         self::assertSame(
             $date,
             $resolver->resolve(
-                new ArgumentMetadata('foo', DateTimeImmutable::class),
+                new ArgumentMetadata('foo', DateTimeImmutable::class, false),
                 $message,
             ),
         );


### PR DESCRIPTION
Not sure if to make this argument mandatory, would be a breaking change if this is considered public API. Do not like default here either though (no reasonable default value)