### PR TITLE
allow to refresh subscriptions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.14.1",
+            "version": "0.14.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "f05858549e5f9d7bb45875a75583240a38a281d0"
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/f05858549e5f9d7bb45875a75583240a38a281d0",
-                "reference": "f05858549e5f9d7bb45875a75583240a38a281d0",
+                "url": "https://api.github.com/repos/brick/math/zipball/63422359a44b7f06cae63c3b429b59e8efcc0629",
+                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.1"
+                "source": "https://github.com/brick/math/tree/0.14.8"
             },
             "funding": [
                 {
@@ -64,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-24T14:40:29+00:00"
+            "time": "2026-02-10T14:33:43+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -174,29 +174,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
-                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<=7.5 || >=13"
+                "phpunit/phpunit": "<=7.5 || >=14"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12 || ^13",
-                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -216,22 +216,22 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2025-04-07T20:06:18+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "doctrine/event-manager",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/event-manager.git",
-                "reference": "c07799fcf5ad362050960a0fd068dded40b1e312"
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/c07799fcf5ad362050960a0fd068dded40b1e312",
-                "reference": "c07799fcf5ad362050960a0fd068dded40b1e312",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
                 "shasum": ""
             },
             "require": {
@@ -293,7 +293,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/event-manager/issues",
-                "source": "https://github.com/doctrine/event-manager/tree/2.1.0"
+                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
             },
             "funding": [
                 {
@@ -309,20 +309,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-17T22:40:21+00:00"
+            "time": "2026-01-29T07:11:08+00:00"
         },
         {
             "name": "doctrine/migrations",
-            "version": "3.9.5",
+            "version": "3.9.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "1b823afbc40f932dae8272574faee53f2755eac5"
+                "reference": "ffd8355cdd8505fc650d9604f058bf62aedd80a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/1b823afbc40f932dae8272574faee53f2755eac5",
-                "reference": "1b823afbc40f932dae8272574faee53f2755eac5",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/ffd8355cdd8505fc650d9604f058bf62aedd80a1",
+                "reference": "ffd8355cdd8505fc650d9604f058bf62aedd80a1",
                 "shasum": ""
             },
             "require": {
@@ -396,7 +396,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/migrations/issues",
-                "source": "https://github.com/doctrine/migrations/tree/3.9.5"
+                "source": "https://github.com/doctrine/migrations/tree/3.9.6"
             },
             "funding": [
                 {
@@ -412,20 +412,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-20T11:15:36+00:00"
+            "time": "2026-02-11T06:46:11+00:00"
         },
         {
             "name": "patchlevel/hydrator",
-            "version": "1.13.0",
+            "version": "1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/patchlevel/hydrator.git",
-                "reference": "dc6fe9a835edaa2d6972ad148738eaeb95a6cb35"
+                "reference": "27b29f806f366194752cbaaa241e426bed2d942f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/patchlevel/hydrator/zipball/dc6fe9a835edaa2d6972ad148738eaeb95a6cb35",
-                "reference": "dc6fe9a835edaa2d6972ad148738eaeb95a6cb35",
+                "url": "https://api.github.com/repos/patchlevel/hydrator/zipball/27b29f806f366194752cbaaa241e426bed2d942f",
+                "reference": "27b29f806f366194752cbaaa241e426bed2d942f",
                 "shasum": ""
             },
             "require": {
@@ -437,13 +437,13 @@
                 "symfony/type-info": "^7.3.0 || ^8.0.0"
             },
             "require-dev": {
-                "infection/infection": "^0.31.9",
+                "infection/infection": "^0.32.4",
                 "patchlevel/coding-standard": "^1.3.0",
-                "phpat/phpat": "^0.12.0",
-                "phpbench/phpbench": "^1.2.15",
-                "phpstan/phpstan": "^2.1.32",
-                "phpstan/phpstan-phpunit": "^2.0.8",
-                "phpunit/phpunit": "^11.5.17",
+                "phpat/phpat": "^0.12.2",
+                "phpbench/phpbench": "^1.4.3",
+                "phpstan/phpstan": "^2.1.39",
+                "phpstan/phpstan-phpunit": "^2.0.15",
+                "phpunit/phpunit": "^11.5.53",
                 "symfony/var-dumper": "^5.4.29 || ^6.4.0 || ^7.0.0 || ^8.0.0"
             },
             "type": "library",
@@ -474,9 +474,9 @@
             ],
             "support": {
                 "issues": "https://github.com/patchlevel/hydrator/issues",
-                "source": "https://github.com/patchlevel/hydrator/tree/1.13.0"
+                "source": "https://github.com/patchlevel/hydrator/tree/1.16.0"
             },
-            "time": "2025-11-27T16:58:40+00:00"
+            "time": "2026-02-17T11:56:35+00:00"
         },
         {
             "name": "patchlevel/worker",
@@ -995,16 +995,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.0.3",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6145b304a5c1ea0bdbd0b04d297a5864f9a7d587"
+                "reference": "ace03c4cf9805080ff40cbeec69fca180c339a3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6145b304a5c1ea0bdbd0b04d297a5864f9a7d587",
-                "reference": "6145b304a5c1ea0bdbd0b04d297a5864f9a7d587",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ace03c4cf9805080ff40cbeec69fca180c339a3b",
+                "reference": "ace03c4cf9805080ff40cbeec69fca180c339a3b",
                 "shasum": ""
             },
             "require": {
@@ -1061,7 +1061,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.0.3"
+                "source": "https://github.com/symfony/console/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -1081,7 +1081,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:52:06+00:00"
+            "time": "2026-01-13T13:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1152,16 +1152,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.0.0",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "573f95783a2ec6e38752979db139f09fec033f03"
+                "reference": "99301401da182b6cfaa4700dbe9987bb75474b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/573f95783a2ec6e38752979db139f09fec033f03",
-                "reference": "573f95783a2ec6e38752979db139f09fec033f03",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/99301401da182b6cfaa4700dbe9987bb75474b47",
+                "reference": "99301401da182b6cfaa4700dbe9987bb75474b47",
                 "shasum": ""
             },
             "require": {
@@ -1213,7 +1213,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -1233,7 +1233,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T14:17:19+00:00"
+            "time": "2026-01-05T11:45:55+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -1313,16 +1313,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v8.0.3",
+            "version": "v8.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "dd3a2953570a283a2ba4e17063bb98c734cf5b12"
+                "reference": "8bd576e97c67d45941365bf824e18dc8538e6eb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/dd3a2953570a283a2ba4e17063bb98c734cf5b12",
-                "reference": "dd3a2953570a283a2ba4e17063bb98c734cf5b12",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8bd576e97c67d45941365bf824e18dc8538e6eb0",
+                "reference": "8bd576e97c67d45941365bf824e18dc8538e6eb0",
                 "shasum": ""
             },
             "require": {
@@ -1357,7 +1357,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v8.0.3"
+                "source": "https://github.com/symfony/finder/tree/v8.0.5"
             },
             "funding": [
                 {
@@ -1377,7 +1377,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:52:06+00:00"
+            "time": "2026-01-26T15:08:38+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1869,16 +1869,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.1",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc"
+                "reference": "758b372d6882506821ed666032e43020c4f57194"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ba65a969ac918ce0cc3edfac6cdde847eba231dc",
-                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/758b372d6882506821ed666032e43020c4f57194",
+                "reference": "758b372d6882506821ed666032e43020c4f57194",
                 "shasum": ""
             },
             "require": {
@@ -1935,7 +1935,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.1"
+                "source": "https://github.com/symfony/string/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -1955,20 +1955,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2026-01-12T12:37:40+00:00"
         },
         {
             "name": "symfony/type-info",
-            "version": "v8.0.1",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "bb091cec1f70383538c7d000699781813f8d1a6a"
+                "reference": "106a2d3bbf0d4576b2f70e6ca866fa420956ed0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/bb091cec1f70383538c7d000699781813f8d1a6a",
-                "reference": "bb091cec1f70383538c7d000699781813f8d1a6a",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/106a2d3bbf0d4576b2f70e6ca866fa420956ed0d",
+                "reference": "106a2d3bbf0d4576b2f70e6ca866fa420956ed0d",
                 "shasum": ""
             },
             "require": {
@@ -2017,7 +2017,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v8.0.1"
+                "source": "https://github.com/symfony/type-info/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -2037,7 +2037,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T14:08:45+00:00"
+            "time": "2026-01-09T12:15:10+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -2926,16 +2926,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "3.6.1",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "2148940290e4c44b9101095707e71fb590832fa5"
+                "reference": "4262eb495b4d2a53b45de1ac58881e0091f2970f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/2148940290e4c44b9101095707e71fb590832fa5",
-                "reference": "2148940290e4c44b9101095707e71fb590832fa5",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/4262eb495b4d2a53b45de1ac58881e0091f2970f",
+                "reference": "4262eb495b4d2a53b45de1ac58881e0091f2970f",
                 "shasum": ""
             },
             "require": {
@@ -3008,9 +3008,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/3.6.1"
+                "source": "https://github.com/doctrine/orm/tree/3.6.2"
             },
-            "time": "2026-01-09T05:28:15+00:00"
+            "time": "2026-01-30T21:41:41+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -3345,16 +3345,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.32.3",
+            "version": "0.32.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "3654db483619b63b9bcb04c24caeb03677c6d057"
+                "reference": "a2b0a3e47b56bd2f27ca13caecae47baa7e5abe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/3654db483619b63b9bcb04c24caeb03677c6d057",
-                "reference": "3654db483619b63b9bcb04c24caeb03677c6d057",
+                "url": "https://api.github.com/repos/infection/infection/zipball/a2b0a3e47b56bd2f27ca13caecae47baa7e5abe8",
+                "reference": "a2b0a3e47b56bd2f27ca13caecae47baa7e5abe8",
                 "shasum": ""
             },
             "require": {
@@ -3375,11 +3375,11 @@
                 "ondram/ci-detector": "^4.1.0",
                 "php": "^8.2",
                 "psr/log": "^2.0 || ^3.0",
-                "sanmai/di-container": "^0.1.4",
+                "sanmai/di-container": "^0.1.12",
                 "sanmai/duoclock": "^0.1.0",
                 "sanmai/later": "^0.1.7",
-                "sanmai/pipeline": "^7.0",
-                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "sanmai/pipeline": "^7.2",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
                 "symfony/console": "^6.4 || ^7.0 || ^8.0",
                 "symfony/filesystem": "^6.4 || ^7.0 || ^8.0",
                 "symfony/finder": "^6.4 || ^7.0 || ^8.0",
@@ -3465,7 +3465,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.32.3"
+                "source": "https://github.com/infection/infection/tree/0.32.4"
             },
             "funding": [
                 {
@@ -3477,7 +3477,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-01-13T14:23:38+00:00"
+            "time": "2026-02-09T13:24:18+00:00"
         },
         {
             "name": "infection/mutator",
@@ -3534,16 +3534,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.6.4",
+            "version": "v6.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "2eeb75d21cf73211335888e7f5e6fd7440723ec7"
+                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2eeb75d21cf73211335888e7f5e6fd7440723ec7",
-                "reference": "2eeb75d21cf73211335888e7f5e6fd7440723ec7",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/6fea66c7204683af437864e7c4e7abf383d14bc0",
+                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0",
                 "shasum": ""
             },
             "require": {
@@ -3603,9 +3603,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.4"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/v6.7.2"
             },
-            "time": "2025-12-19T15:01:32+00:00"
+            "time": "2026-02-15T15:06:22+00:00"
         },
         {
             "name": "league/commonmark",
@@ -3931,16 +3931,16 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.3",
+            "version": "v1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
+                "reference": "086497a2f34b82fede9b5a41cc8e131d087cd8f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "url": "https://api.github.com/repos/nette/schema/zipball/086497a2f34b82fede9b5a41cc8e131d087cd8f7",
+                "reference": "086497a2f34b82fede9b5a41cc8e131d087cd8f7",
                 "shasum": ""
             },
             "require": {
@@ -3948,8 +3948,8 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/tester": "^2.6",
+                "phpstan/phpstan": "^2.0@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -3990,22 +3990,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.4"
             },
-            "time": "2025-10-30T22:57:59+00:00"
+            "time": "2026-02-08T02:54:00+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.1",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72"
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c99059c0315591f1a0db7ad6002000288ab8dc72",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72",
+                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
                 "shasum": ""
             },
             "require": {
@@ -4017,8 +4017,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -4079,9 +4081,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.1"
+                "source": "https://github.com/nette/utils/tree/v4.1.3"
             },
-            "time": "2025-12-22T12:14:32+00:00"
+            "time": "2026-02-13T03:05:33+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -4394,16 +4396,16 @@
         },
         {
             "name": "phpat/phpat",
-            "version": "0.12.1",
+            "version": "0.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/carlosas/phpat.git",
-                "reference": "67b9e179757fbaa8b87e1469a66f103725858ee0"
+                "reference": "fe9caef4f8633a57c1d19643d37b58050b11806c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/carlosas/phpat/zipball/67b9e179757fbaa8b87e1469a66f103725858ee0",
-                "reference": "67b9e179757fbaa8b87e1469a66f103725858ee0",
+                "url": "https://api.github.com/repos/carlosas/phpat/zipball/fe9caef4f8633a57c1d19643d37b58050b11806c",
+                "reference": "fe9caef4f8633a57c1d19643d37b58050b11806c",
                 "shasum": ""
             },
             "require": {
@@ -4445,9 +4447,9 @@
             "description": "PHP Architecture Tester",
             "support": {
                 "issues": "https://github.com/carlosas/phpat/issues",
-                "source": "https://github.com/carlosas/phpat/tree/0.12.1"
+                "source": "https://github.com/carlosas/phpat/tree/0.12.2"
             },
-            "time": "2025-12-25T17:53:07+00:00"
+            "time": "2026-01-27T11:41:37+00:00"
         },
         {
             "name": "phpbench/container",
@@ -4600,16 +4602,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.1",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "16dbf9937da8d4528ceb2145c9c7c0bd29e26374"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/16dbf9937da8d4528ceb2145c9c7c0bd29e26374",
-                "reference": "16dbf9937da8d4528ceb2145c9c7c0bd29e26374",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -4641,17 +4643,17 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2026-01-12T11:33:04+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.1.39",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
                 "shasum": ""
             },
             "require": {
@@ -4696,20 +4698,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-02-11T14:48:56+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.11",
+            "version": "2.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "5e30669bef866eff70db8b58d72a5c185aa82414"
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/5e30669bef866eff70db8b58d72a5c185aa82414",
-                "reference": "5e30669bef866eff70db8b58d72a5c185aa82414",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
                 "shasum": ""
             },
             "require": {
@@ -4745,11 +4747,14 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.11"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.16"
             },
-            "time": "2025-12-19T09:05:35+00:00"
+            "time": "2026-02-14T09:05:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4843,28 +4848,28 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
-                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -4892,15 +4897,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-08-27T05:02:59+00:00"
+            "time": "2026-02-02T13:52:54+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -5088,16 +5105,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.50",
+            "version": "11.5.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fdfc727f0fcacfeb8fcb30c7e5da173125b58be3"
+                "reference": "a997a653a82845f1240d73ee73a8a4e97e4b0607"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fdfc727f0fcacfeb8fcb30c7e5da173125b58be3",
-                "reference": "fdfc727f0fcacfeb8fcb30c7e5da173125b58be3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a997a653a82845f1240d73ee73a8a4e97e4b0607",
+                "reference": "a997a653a82845f1240d73ee73a8a4e97e4b0607",
                 "shasum": ""
             },
             "require": {
@@ -5112,7 +5129,7 @@
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
                 "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-file-iterator": "^5.1.1",
                 "phpunit/php-invoker": "^5.0.1",
                 "phpunit/php-text-template": "^4.0.1",
                 "phpunit/php-timer": "^7.0.1",
@@ -5124,6 +5141,7 @@
                 "sebastian/exporter": "^6.3.2",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
                 "sebastian/type": "^5.1.3",
                 "sebastian/version": "^5.0.2",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -5169,7 +5187,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.50"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.53"
             },
             "funding": [
                 {
@@ -5193,20 +5211,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-27T05:59:18+00:00"
+            "time": "2026-02-10T12:28:25+00:00"
         },
         {
             "name": "sanmai/di-container",
-            "version": "0.1.11",
+            "version": "0.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sanmai/di-container.git",
-                "reference": "4723e235e04589f88c0a114a4e438ff57a7cbb8a"
+                "reference": "8b9ad72f6ac1f9e185e5bd060dc9479cb5191d8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sanmai/di-container/zipball/4723e235e04589f88c0a114a4e438ff57a7cbb8a",
-                "reference": "4723e235e04589f88c0a114a4e438ff57a7cbb8a",
+                "url": "https://api.github.com/repos/sanmai/di-container/zipball/8b9ad72f6ac1f9e185e5bd060dc9479cb5191d8b",
+                "reference": "8b9ad72f6ac1f9e185e5bd060dc9479cb5191d8b",
                 "shasum": ""
             },
             "require": {
@@ -5264,7 +5282,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sanmai/di-container/issues",
-                "source": "https://github.com/sanmai/di-container/tree/0.1.11"
+                "source": "https://github.com/sanmai/di-container/tree/0.1.12"
             },
             "funding": [
                 {
@@ -5272,7 +5290,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-13T07:38:17+00:00"
+            "time": "2026-01-27T08:25:46+00:00"
         },
         {
             "name": "sanmai/duoclock",
@@ -6864,16 +6882,16 @@
         },
         {
             "name": "symfony/messenger",
-            "version": "v8.0.3",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/messenger.git",
-                "reference": "b56b89aee16ceb623f76c8739ab62202ec198190"
+                "reference": "3483db96bcc33310cd1807d2b962e7e01d9f41c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/messenger/zipball/b56b89aee16ceb623f76c8739ab62202ec198190",
-                "reference": "b56b89aee16ceb623f76c8739ab62202ec198190",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/3483db96bcc33310cd1807d2b962e7e01d9f41c2",
+                "reference": "3483db96bcc33310cd1807d2b962e7e01d9f41c2",
                 "shasum": ""
             },
             "require": {
@@ -6883,7 +6901,9 @@
             },
             "conflict": {
                 "symfony/console": "<7.4",
-                "symfony/event-dispatcher-contracts": "<2.5"
+                "symfony/event-dispatcher-contracts": "<2.5",
+                "symfony/lock": "<7.4",
+                "symfony/serializer": "<7.4.4|>=8.0,<8.0.4"
             },
             "require-dev": {
                 "psr/cache": "^1.0|^2.0|^3.0",
@@ -6896,7 +6916,7 @@
                 "symfony/property-access": "^7.4|^8.0",
                 "symfony/rate-limiter": "^7.4|^8.0",
                 "symfony/routing": "^7.4|^8.0",
-                "symfony/serializer": "^7.4|^8.0",
+                "symfony/serializer": "^7.4.4|^8.0.4",
                 "symfony/service-contracts": "^2.5|^3",
                 "symfony/stopwatch": "^7.4|^8.0",
                 "symfony/validator": "^7.4|^8.0",
@@ -6928,7 +6948,7 @@
             "description": "Helps applications send and receive messages to/from other applications or via message queues",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/messenger/tree/v8.0.3"
+                "source": "https://github.com/symfony/messenger/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -6948,7 +6968,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:52:06+00:00"
+            "time": "2026-01-08T22:36:47+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -7267,16 +7287,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.0.3",
+            "version": "v8.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "0cbbd88ec836f8757641c651bb995335846abb78"
+                "reference": "b5f3aa6762e33fd95efbaa2ec4f4bc9fdd16d674"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/0cbbd88ec836f8757641c651bb995335846abb78",
-                "reference": "0cbbd88ec836f8757641c651bb995335846abb78",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b5f3aa6762e33fd95efbaa2ec4f4bc9fdd16d674",
+                "reference": "b5f3aa6762e33fd95efbaa2ec4f4bc9fdd16d674",
                 "shasum": ""
             },
             "require": {
@@ -7308,7 +7328,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.3"
+                "source": "https://github.com/symfony/process/tree/v8.0.5"
             },
             "funding": [
                 {
@@ -7328,20 +7348,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-19T10:01:18+00:00"
+            "time": "2026-01-26T15:08:38+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v8.0.3",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "3bc368228532ad538cc216768caa8968be95a8d6"
+                "reference": "326e0406fc315eca57ef5740fa4a280b7a068c82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/3bc368228532ad538cc216768caa8968be95a8d6",
-                "reference": "3bc368228532ad538cc216768caa8968be95a8d6",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/326e0406fc315eca57ef5740fa4a280b7a068c82",
+                "reference": "326e0406fc315eca57ef5740fa4a280b7a068c82",
                 "shasum": ""
             },
             "require": {
@@ -7395,7 +7415,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v8.0.3"
+                "source": "https://github.com/symfony/var-dumper/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -7415,20 +7435,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-18T11:23:51+00:00"
+            "time": "2026-01-01T23:07:29+00:00"
         },
         {
             "name": "thecodingmachine/safe",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thecodingmachine/safe.git",
-                "reference": "2cdd579eeaa2e78e51c7509b50cc9fb89a956236"
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/2cdd579eeaa2e78e51c7509b50cc9fb89a956236",
-                "reference": "2cdd579eeaa2e78e51c7509b50cc9fb89a956236",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
                 "shasum": ""
             },
             "require": {
@@ -7538,7 +7558,7 @@
             "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
             "support": {
                 "issues": "https://github.com/thecodingmachine/safe/issues",
-                "source": "https://github.com/thecodingmachine/safe/tree/v3.3.0"
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -7550,11 +7570,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
                     "url": "https://github.com/staabm",
                     "type": "github"
                 }
             ],
-            "time": "2025-05-14T06:15:44+00:00"
+            "time": "2026-02-04T18:08:13+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -7608,16 +7632,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.2",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+                "reference": "b39f1870fc7c3e9e4a26106df5053354b9260a33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
-                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/b39f1870fc7c3e9e4a26106df5053354b9260a33",
+                "reference": "b39f1870fc7c3e9e4a26106df5053354b9260a33",
                 "shasum": ""
             },
             "require": {
@@ -7664,9 +7688,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+                "source": "https://github.com/webmozarts/assert/tree/2.1.4"
             },
-            "time": "2026-01-13T14:02:24+00:00"
+            "time": "2026-02-17T12:17:51+00:00"
         },
         {
             "name": "webmozart/glob",

--- a/docs/pages/subscription.md
+++ b/docs/pages/subscription.md
@@ -1315,6 +1315,18 @@ foreach ($subscriptions as $subscription) {
     echo $subscription->status()->value;
 }
 ```
+### Refresh
+
+If you change the metadata of a subscriber in the code (e.g. `runMode`, `group` or `cleanupTasks`),
+you can use the `refresh` method to update the existing subscriptions in the store.
+
+```php
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
+
+/** @var SubscriptionEngine $subscriptionEngine */
+$subscriptionEngine->refresh(new SubscriptionEngineCriteria());
+```
 ## Learn more
 
 * [How to use CLI commands](./cli.md)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Cannot unset offset ''url'' on array\{application_name\?\: string, charset\?\: string, dbname\?\: string, defaultTableOptions\?\: array\<string, mixed\>, driver\?\: ''ibm_db2''\|''mysqli''\|''oci8''\|''pdo_mysql''\|''pdo_oci''\|''pdo_pgsql''\|''pdo_sqlite''\|''pdo_sqlsrv''\|''pgsql''\|''sqlite3''\|''sqlsrv'', driverClass\?\: class\-string\<Doctrine\\DBAL\\Driver\>, driverOptions\?\: array\<mixed\>, host\?\: string, \.\.\.\}\.$#'
+			message: '#^Cannot unset offset ''url'' on array\{application_name\?\: string, charset\?\: string, defaultTableOptions\?\: array\<string, mixed\>, driver\?\: ''ibm_db2''\|''mysqli''\|''oci8''\|''pdo_mysql''\|''pdo_oci''\|''pdo_pgsql''\|''pdo_sqlite''\|''pdo_sqlsrv''\|''pgsql''\|''sqlite3''\|''sqlsrv'', driverClass\?\: class\-string\<Doctrine\\DBAL\\Driver\>, driverOptions\?\: array\<mixed\>, host\?\: string, keepReplica\?\: bool, \.\.\.\}\.$#'
 			identifier: unset.offset
 			count: 1
 			path: src/Console/DoctrineHelper.php

--- a/src/Console/Command/SubscriptionRefreshCommand.php
+++ b/src/Console/Command/SubscriptionRefreshCommand.php
@@ -22,14 +22,14 @@ final class SubscriptionRefreshCommand extends SubscriptionCommand
     {
         if (!$this->engine instanceof CanRefreshSubscriptions) {
             throw new LogicException(sprintf(
-                '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
+                '"%s" does not implement "%s" and cannot call refresh.',
                 $this->engine::class,
                 CanRefreshSubscriptions::class,
             ));
         }
 
         $criteria = $this->subscriptionEngineCriteria($input);
-        $this->engine->refreshSubscriptions($criteria);
+        $this->engine->refresh($criteria);
 
         return 0;
     }

--- a/src/Console/Command/SubscriptionRefreshCommand.php
+++ b/src/Console/Command/SubscriptionRefreshCommand.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function sprintf;
+
 #[AsCommand(
     'event-sourcing:subscription:refresh',
     'Refresh subscriptions (run-mode, group)',

--- a/src/Console/Command/SubscriptionRefreshCommand.php
+++ b/src/Console/Command/SubscriptionRefreshCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Console\Command;
 
 use LogicException;
-use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionRefreshable;
+use Patchlevel\EventSourcing\Subscription\Engine\CanRefreshSubscriptions;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,11 +20,11 @@ final class SubscriptionRefreshCommand extends SubscriptionCommand
 {
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (!$this->engine instanceof SubscriptionRefreshable) {
+        if (!$this->engine instanceof CanRefreshSubscriptions) {
             throw new LogicException(sprintf(
                 '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
                 $this->engine::class,
-                SubscriptionRefreshable::class,
+                CanRefreshSubscriptions::class,
             ));
         }
 

--- a/src/Console/Command/SubscriptionRefreshCommand.php
+++ b/src/Console/Command/SubscriptionRefreshCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Console\Command;
+
+use LogicException;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionRefreshable;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    'event-sourcing:subscription:refresh',
+    'Refresh subscriptions (run-mode, group)',
+)]
+final class SubscriptionRefreshCommand extends SubscriptionCommand
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->engine instanceof SubscriptionRefreshable) {
+            throw new LogicException(sprintf(
+                '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
+                $this->engine::class,
+                SubscriptionRefreshable::class,
+            ));
+        }
+
+        $criteria = $this->subscriptionEngineCriteria($input);
+        $this->engine->refreshSubscriptions($criteria);
+
+        return 0;
+    }
+}

--- a/src/Subscription/Engine/CanRefreshSubscriptions.php
+++ b/src/Subscription/Engine/CanRefreshSubscriptions.php
@@ -6,5 +6,5 @@ namespace Patchlevel\EventSourcing\Subscription\Engine;
 
 interface CanRefreshSubscriptions
 {
-    public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result;
+    public function refresh(SubscriptionEngineCriteria|null $criteria = null): Result;
 }

--- a/src/Subscription/Engine/CanRefreshSubscriptions.php
+++ b/src/Subscription/Engine/CanRefreshSubscriptions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Subscription\Engine;
 
-interface SubscriptionRefreshable
+interface CanRefreshSubscriptions
 {
     public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result;
 }

--- a/src/Subscription/Engine/CatchUpSubscriptionEngine.php
+++ b/src/Subscription/Engine/CatchUpSubscriptionEngine.php
@@ -8,6 +8,7 @@ use LogicException;
 use Patchlevel\EventSourcing\Subscription\Subscription;
 
 use function array_merge;
+use function sprintf;
 
 use const PHP_INT_MAX;
 

--- a/src/Subscription/Engine/CatchUpSubscriptionEngine.php
+++ b/src/Subscription/Engine/CatchUpSubscriptionEngine.php
@@ -12,7 +12,7 @@ use function sprintf;
 
 use const PHP_INT_MAX;
 
-final class CatchUpSubscriptionEngine implements SubscriptionEngine, SubscriptionRefreshable
+final class CatchUpSubscriptionEngine implements SubscriptionEngine, CanRefreshSubscriptions
 {
     public function __construct(
         private readonly SubscriptionEngine $parent,
@@ -90,11 +90,11 @@ final class CatchUpSubscriptionEngine implements SubscriptionEngine, Subscriptio
 
     public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result
     {
-        if (!$this->parent instanceof SubscriptionRefreshable) {
+        if (!$this->parent instanceof CanRefreshSubscriptions) {
             throw new LogicException(sprintf(
                 '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
                 $this->parent::class,
-                SubscriptionRefreshable::class,
+                CanRefreshSubscriptions::class,
             ));
         }
 

--- a/src/Subscription/Engine/CatchUpSubscriptionEngine.php
+++ b/src/Subscription/Engine/CatchUpSubscriptionEngine.php
@@ -88,17 +88,17 @@ final class CatchUpSubscriptionEngine implements SubscriptionEngine, CanRefreshS
         return $this->parent->subscriptions($criteria);
     }
 
-    public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result
+    public function refresh(SubscriptionEngineCriteria|null $criteria = null): Result
     {
         if (!$this->parent instanceof CanRefreshSubscriptions) {
             throw new LogicException(sprintf(
-                '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
+                '"%s" does not implement "%s" and cannot call refresh.',
                 $this->parent::class,
                 CanRefreshSubscriptions::class,
             ));
         }
 
-        return $this->parent->refreshSubscriptions($criteria);
+        return $this->parent->refresh($criteria);
     }
 
     private function mergeResult(ProcessedResult ...$results): ProcessedResult

--- a/src/Subscription/Engine/CatchUpSubscriptionEngine.php
+++ b/src/Subscription/Engine/CatchUpSubscriptionEngine.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Subscription\Engine;
 
+use LogicException;
 use Patchlevel\EventSourcing\Subscription\Subscription;
 
 use function array_merge;
 
 use const PHP_INT_MAX;
 
-final class CatchUpSubscriptionEngine implements SubscriptionEngine
+final class CatchUpSubscriptionEngine implements SubscriptionEngine, SubscriptionRefreshable
 {
     public function __construct(
         private readonly SubscriptionEngine $parent,
@@ -84,6 +85,19 @@ final class CatchUpSubscriptionEngine implements SubscriptionEngine
     public function subscriptions(SubscriptionEngineCriteria|null $criteria = null): array
     {
         return $this->parent->subscriptions($criteria);
+    }
+
+    public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result
+    {
+        if (!$this->parent instanceof SubscriptionRefreshable) {
+            throw new LogicException(sprintf(
+                '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
+                $this->parent::class,
+                SubscriptionRefreshable::class,
+            ));
+        }
+
+        return $this->parent->refreshSubscriptions($criteria);
     }
 
     private function mergeResult(ProcessedResult ...$results): ProcessedResult

--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -29,7 +29,7 @@ use function array_values;
 use function count;
 use function sprintf;
 
-final class DefaultSubscriptionEngine implements SubscriptionEngine, SubscriptionRefreshable
+final class DefaultSubscriptionEngine implements SubscriptionEngine, CanRefreshSubscriptions
 {
     private SubscriptionManager $subscriptionManager;
 

--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -873,6 +873,20 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine, Subscriptio
                 );
             }
 
+            $cleanupTasks = $this->cleanupTasks($subscriber);
+
+            if ($subscription->cleanupTasks() !== $cleanupTasks) {
+                $changed = true;
+                $subscription->replaceCleanupTasks($cleanupTasks);
+
+                $this->logger?->info(
+                    sprintf(
+                        'Subscription Engine: Subscription "%s" cleanup tasks changed.',
+                        $subscription->id(),
+                    ),
+                );
+            }
+
             if (!$changed) {
                 continue;
             }

--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -823,7 +823,7 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine, CanRefreshS
         );
     }
 
-    public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result
+    public function refresh(SubscriptionEngineCriteria|null $criteria = null): Result
     {
         $criteria ??= new SubscriptionEngineCriteria();
 

--- a/src/Subscription/Engine/DefaultSubscriptionEngine.php
+++ b/src/Subscription/Engine/DefaultSubscriptionEngine.php
@@ -29,7 +29,7 @@ use function array_values;
 use function count;
 use function sprintf;
 
-final class DefaultSubscriptionEngine implements SubscriptionEngine
+final class DefaultSubscriptionEngine implements SubscriptionEngine, SubscriptionRefreshable
 {
     private SubscriptionManager $subscriptionManager;
 
@@ -821,6 +821,68 @@ final class DefaultSubscriptionEngine implements SubscriptionEngine
                 groups: $criteria->groups,
             ),
         );
+    }
+
+    public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result
+    {
+        $criteria ??= new SubscriptionEngineCriteria();
+
+        $this->discoverNewSubscriptions();
+
+        $subscriptions = $this->subscriptionManager->find(new SubscriptionCriteria(
+            ids: $criteria->ids,
+            groups: $criteria->groups,
+        ));
+
+        foreach ($subscriptions as $subscription) {
+            $subscriber = $this->subscriber($subscription->id());
+
+            if (!$subscriber) {
+                continue;
+            }
+
+            $changed = false;
+
+            if ($subscription->runMode() !== $subscriber->runMode()) {
+                $changed = true;
+                $oldRunMode = $subscription->runMode();
+                $subscription->changeRunMode($subscriber->runMode());
+
+                $this->logger?->info(
+                    sprintf(
+                        'Subscription Engine: Subscription "%s" run mode changed from "%s" to "%s".',
+                        $subscription->id(),
+                        $oldRunMode->value,
+                        $subscription->runMode()->value,
+                    ),
+                );
+            }
+
+            if ($subscription->group() !== $subscriber->group()) {
+                $changed = true;
+                $oldGroup = $subscription->group();
+                $subscription->changeGroup($subscriber->group());
+
+                $this->logger?->info(
+                    sprintf(
+                        'Subscription Engine: Subscription "%s" group changed from "%s" to "%s".',
+                        $subscription->id(),
+                        $oldGroup,
+                        $subscription->group(),
+                    ),
+                );
+            }
+
+            if (!$changed) {
+                continue;
+            }
+
+            $this->subscriptionManager->update($subscription);
+        }
+
+        $this->subscriptionManager->flush();
+
+        return new Result();
     }
 
     private function handleMessage(int $index, Message $message, Subscription $subscription): Error|null

--- a/src/Subscription/Engine/SubscriptionRefreshable.php
+++ b/src/Subscription/Engine/SubscriptionRefreshable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Patchlevel\EventSourcing\Subscription\Engine;
+
+interface SubscriptionRefreshable
+{
+    public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result;
+}

--- a/src/Subscription/Engine/SubscriptionRefreshable.php
+++ b/src/Subscription/Engine/SubscriptionRefreshable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Patchlevel\EventSourcing\Subscription\Engine;
 
 interface SubscriptionRefreshable

--- a/src/Subscription/Engine/ThrowOnErrorSubscriptionEngine.php
+++ b/src/Subscription/Engine/ThrowOnErrorSubscriptionEngine.php
@@ -7,6 +7,8 @@ namespace Patchlevel\EventSourcing\Subscription\Engine;
 use LogicException;
 use Patchlevel\EventSourcing\Subscription\Subscription;
 
+use function sprintf;
+
 final class ThrowOnErrorSubscriptionEngine implements SubscriptionEngine, SubscriptionRefreshable
 {
     public function __construct(

--- a/src/Subscription/Engine/ThrowOnErrorSubscriptionEngine.php
+++ b/src/Subscription/Engine/ThrowOnErrorSubscriptionEngine.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Subscription\Engine;
 
+use LogicException;
 use Patchlevel\EventSourcing\Subscription\Subscription;
 
-final class ThrowOnErrorSubscriptionEngine implements SubscriptionEngine
+final class ThrowOnErrorSubscriptionEngine implements SubscriptionEngine, SubscriptionRefreshable
 {
     public function __construct(
         private readonly SubscriptionEngine $parent,
@@ -52,6 +53,19 @@ final class ThrowOnErrorSubscriptionEngine implements SubscriptionEngine
     public function subscriptions(SubscriptionEngineCriteria|null $criteria = null): array
     {
         return $this->parent->subscriptions($criteria);
+    }
+
+    public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result
+    {
+        if (!$this->parent instanceof SubscriptionRefreshable) {
+            throw new LogicException(sprintf(
+                '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
+                $this->parent::class,
+                SubscriptionRefreshable::class,
+            ));
+        }
+
+        return $this->throwOnError($this->parent->refreshSubscriptions($criteria));
     }
 
     /**

--- a/src/Subscription/Engine/ThrowOnErrorSubscriptionEngine.php
+++ b/src/Subscription/Engine/ThrowOnErrorSubscriptionEngine.php
@@ -57,17 +57,17 @@ final class ThrowOnErrorSubscriptionEngine implements SubscriptionEngine, CanRef
         return $this->parent->subscriptions($criteria);
     }
 
-    public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result
+    public function refresh(SubscriptionEngineCriteria|null $criteria = null): Result
     {
         if (!$this->parent instanceof CanRefreshSubscriptions) {
             throw new LogicException(sprintf(
-                '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
+                '"%s" does not implement "%s" and cannot call refresh.',
                 $this->parent::class,
                 CanRefreshSubscriptions::class,
             ));
         }
 
-        return $this->throwOnError($this->parent->refreshSubscriptions($criteria));
+        return $this->throwOnError($this->parent->refresh($criteria));
     }
 
     /**

--- a/src/Subscription/Engine/ThrowOnErrorSubscriptionEngine.php
+++ b/src/Subscription/Engine/ThrowOnErrorSubscriptionEngine.php
@@ -9,7 +9,7 @@ use Patchlevel\EventSourcing\Subscription\Subscription;
 
 use function sprintf;
 
-final class ThrowOnErrorSubscriptionEngine implements SubscriptionEngine, SubscriptionRefreshable
+final class ThrowOnErrorSubscriptionEngine implements SubscriptionEngine, CanRefreshSubscriptions
 {
     public function __construct(
         private readonly SubscriptionEngine $parent,
@@ -59,11 +59,11 @@ final class ThrowOnErrorSubscriptionEngine implements SubscriptionEngine, Subscr
 
     public function refreshSubscriptions(SubscriptionEngineCriteria|null $criteria = null): Result
     {
-        if (!$this->parent instanceof SubscriptionRefreshable) {
+        if (!$this->parent instanceof CanRefreshSubscriptions) {
             throw new LogicException(sprintf(
                 '"%s" does not implement "%s" and can therefore not refresh subscriptions.',
                 $this->parent::class,
-                SubscriptionRefreshable::class,
+                CanRefreshSubscriptions::class,
             ));
         }
 

--- a/src/Subscription/Subscription.php
+++ b/src/Subscription/Subscription.php
@@ -203,6 +203,12 @@ final class Subscription
         $this->lastSavedAt = $lastSavedAt;
     }
 
+    /** @param list<object>|null $cleanupTask */
+    public function replaceCleanupTasks(array|null $cleanupTask): void
+    {
+        $this->cleanupTasks = $cleanupTask;
+    }
+
     /** @return list<object>|null */
     public function cleanupTasks(): array|null
     {

--- a/src/Subscription/Subscription.php
+++ b/src/Subscription/Subscription.php
@@ -14,8 +14,8 @@ final class Subscription
     /** @param list<object>|null $cleanupTasks */
     public function __construct(
         private readonly string $id,
-        private readonly string $group = self::DEFAULT_GROUP,
-        private readonly RunMode $runMode = RunMode::FromBeginning,
+        private string $group = self::DEFAULT_GROUP,
+        private RunMode $runMode = RunMode::FromBeginning,
         private Status $status = Status::New,
         private int $position = 0,
         private SubscriptionError|null $error = null,
@@ -35,9 +35,19 @@ final class Subscription
         return $this->group;
     }
 
+    public function changeGroup(string $group): void
+    {
+        $this->group = $group;
+    }
+
     public function runMode(): RunMode
     {
         return $this->runMode;
+    }
+
+    public function changeRunMode(RunMode $runMode): void
+    {
+        $this->runMode = $runMode;
     }
 
     public function status(): Status

--- a/tests/Integration/Subscription/SubscriptionTest.php
+++ b/tests/Integration/Subscription/SubscriptionTest.php
@@ -28,6 +28,7 @@ use Patchlevel\EventSourcing\Subscription\Engine\CatchUpSubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\DefaultSubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\EventFilteredStoreMessageLoader;
 use Patchlevel\EventSourcing\Subscription\Engine\GapResolverStoreMessageLoader;
+use Patchlevel\EventSourcing\Subscription\Engine\MessageLoader;
 use Patchlevel\EventSourcing\Subscription\Engine\StoreMessageLoader;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
 use Patchlevel\EventSourcing\Subscription\RetryStrategy\ClockBasedRetryStrategy;
@@ -1563,6 +1564,72 @@ final class SubscriptionTest extends TestCase
         self::assertArrayHasKey('id', $result);
         self::assertSame($profileId->toString(), $result['id']);
         self::assertSame('Hans', $result['name']);
+    }
+
+    public function testRefreshSubscriptions(): void
+    {
+        $store = new DoctrineDbalStore(
+            $this->connection,
+            DefaultEventSerializer::createFromPaths([__DIR__ . '/Events']),
+        );
+
+        $clock = new FrozenClock(new DateTimeImmutable('2021-01-01T00:00:00'));
+
+        $subscriptionStore = new DoctrineSubscriptionStore(
+            $this->connection,
+            $clock,
+        );
+
+        $schemaDirector = new DoctrineSchemaDirector(
+            $this->connection,
+            new ChainDoctrineSchemaConfigurator([
+                $store,
+                $subscriptionStore,
+            ]),
+        );
+
+        $schemaDirector->create();
+
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning, group: 'default')]
+        class {
+        };
+
+        $subscriberRepository = new MetadataSubscriberAccessorRepository([$subscriber]);
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(MessageLoader::class),
+            $subscriptionStore,
+            $subscriberRepository,
+        );
+
+        $engine->setup();
+
+        $subscriptions = $engine->subscriptions();
+        self::assertCount(1, $subscriptions);
+        self::assertEquals('test', $subscriptions[0]->id());
+        self::assertEquals('default', $subscriptions[0]->group());
+        self::assertEquals(RunMode::FromBeginning, $subscriptions[0]->runMode());
+
+        // change subscriber metadata
+        $newSubscriber = new #[Subscriber('test', RunMode::FromNow, group: 'new-group')]
+        class {
+        };
+
+        $newSubscriberRepository = new MetadataSubscriberAccessorRepository([$newSubscriber]);
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(MessageLoader::class),
+            $subscriptionStore,
+            $newSubscriberRepository,
+        );
+
+        $engine->refreshSubscriptions();
+
+        $subscriptions = $engine->subscriptions();
+        self::assertCount(1, $subscriptions);
+        self::assertEquals('test', $subscriptions[0]->id());
+        self::assertEquals('new-group', $subscriptions[0]->group());
+        self::assertEquals(RunMode::FromNow, $subscriptions[0]->runMode());
     }
 
     /** @param list<Subscription> $subscriptions */

--- a/tests/Integration/Subscription/SubscriptionTest.php
+++ b/tests/Integration/Subscription/SubscriptionTest.php
@@ -1623,7 +1623,7 @@ final class SubscriptionTest extends TestCase
             $newSubscriberRepository,
         );
 
-        $engine->refreshSubscriptions();
+        $engine->refresh();
 
         $subscriptions = $engine->subscriptions();
         self::assertCount(1, $subscriptions);

--- a/tests/Unit/Subscription/Engine/CatchUpSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/CatchUpSubscriptionEngineTest.php
@@ -231,8 +231,8 @@ final class CatchUpSubscriptionEngineTest extends TestCase
 
         $expectedResult = new Result();
 
-        $parent->expects($this->once())->method('refreshSubscriptions')->with($criteria)->willReturn($expectedResult);
-        $result = $engine->refreshSubscriptions($criteria);
+        $parent->expects($this->once())->method('refresh')->with($criteria)->willReturn($expectedResult);
+        $result = $engine->refresh($criteria);
 
         self::assertSame($expectedResult, $result);
     }
@@ -244,6 +244,6 @@ final class CatchUpSubscriptionEngineTest extends TestCase
         $engine = new CatchUpSubscriptionEngine($parent);
 
         $this->expectException(LogicException::class);
-        $engine->refreshSubscriptions();
+        $engine->refresh();
     }
 }

--- a/tests/Unit/Subscription/Engine/CatchUpSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/CatchUpSubscriptionEngineTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
 
+use LogicException;
+use Patchlevel\EventSourcing\Subscription\Engine\CanRefreshSubscriptions;
 use Patchlevel\EventSourcing\Subscription\Engine\CatchUpSubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\Error;
 use Patchlevel\EventSourcing\Subscription\Engine\ProcessedResult;
@@ -215,5 +217,33 @@ final class CatchUpSubscriptionEngineTest extends TestCase
         $subscriptions = $engine->subscriptions($criteria);
 
         self::assertEquals($expectedSubscriptions, $subscriptions);
+    }
+
+    public function testRefreshSubscriptions(): void
+    {
+        $parent = $this->createMockForIntersectionOfInterfaces([
+            SubscriptionEngine::class,
+            CanRefreshSubscriptions::class,
+        ]);
+
+        $engine = new CatchUpSubscriptionEngine($parent);
+        $criteria = new SubscriptionEngineCriteria();
+
+        $expectedResult = new Result();
+
+        $parent->expects($this->once())->method('refreshSubscriptions')->with($criteria)->willReturn($expectedResult);
+        $result = $engine->refreshSubscriptions($criteria);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function testRefreshSubscriptionsNotSupported(): void
+    {
+        $parent = $this->createMock(SubscriptionEngine::class);
+
+        $engine = new CatchUpSubscriptionEngine($parent);
+
+        $this->expectException(LogicException::class);
+        $engine->refreshSubscriptions();
     }
 }

--- a/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
@@ -17,6 +17,7 @@ use Patchlevel\EventSourcing\Store\ArrayStream;
 use Patchlevel\EventSourcing\Store\Criteria\Criteria;
 use Patchlevel\EventSourcing\Store\Criteria\FromIndexCriterion;
 use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Subscription\Cleanup\Cleaner;
 use Patchlevel\EventSourcing\Subscription\Cleanup\CleanupFailed;
 use Patchlevel\EventSourcing\Subscription\Cleanup\CleanupTaskHandler;
 use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DropTableTask;
@@ -4571,5 +4572,263 @@ final class DefaultSubscriptionEngineTest extends TestCase
     private function criteria(int $fromIndex = 0): Criteria
     {
         return new Criteria(new FromIndexCriterion($fromIndex));
+    }
+
+    public function testRefreshSubscriptionsNoChanges(): void
+    {
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning, group: 'default')]
+        class {
+        };
+
+        $subscription = new Subscription(
+            'test',
+            'default',
+            RunMode::FromBeginning,
+            Status::Active,
+        );
+
+        $subscriptionStore = new DummySubscriptionStore([$subscription]);
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(Store::class),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            logger: new NullLogger(),
+            cleaner: $this->createMock(Cleaner::class),
+        );
+
+        $engine->refreshSubscriptions();
+
+        $subscriptionStore->assertNoChanges();
+    }
+
+    public function testRefreshSubscriptionsChangeRunMode(): void
+    {
+        $subscriber = new #[Subscriber('test', RunMode::FromNow)]
+        class {
+        };
+
+        $subscription = new Subscription(
+            'test',
+            'default',
+            RunMode::FromBeginning,
+            Status::Active,
+        );
+
+        $subscriptionStore = new DummySubscriptionStore([$subscription]);
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(Store::class),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            logger: new NullLogger(),
+            cleaner: $this->createMock(Cleaner::class),
+        );
+
+        $engine->refreshSubscriptions();
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                'test',
+                'default',
+                RunMode::FromNow,
+                Status::Active,
+            ),
+        );
+    }
+
+    public function testRefreshSubscriptionsChangeGroup(): void
+    {
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning, group: 'new-group')]
+        class {
+        };
+
+        $subscription = new Subscription(
+            'test',
+            'default',
+            RunMode::FromBeginning,
+            Status::Active,
+        );
+
+        $subscriptionStore = new DummySubscriptionStore([$subscription]);
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(Store::class),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            logger: new NullLogger(),
+            cleaner: $this->createMock(Cleaner::class),
+        );
+
+        $engine->refreshSubscriptions();
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                'test',
+                'new-group',
+                RunMode::FromBeginning,
+                Status::Active,
+            ),
+        );
+    }
+
+    public function testRefreshSubscriptionsChangeCleanupTasks(): void
+    {
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class {
+            /** @return iterable<object> */
+            #[Cleanup]
+            public function cleanup(): iterable
+            {
+                yield new DropTableTask('test');
+            }
+        };
+
+        $subscription = new Subscription(
+            'test',
+            'default',
+            RunMode::FromBeginning,
+            Status::Active,
+        );
+
+        $subscriptionStore = new DummySubscriptionStore([$subscription]);
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(Store::class),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            logger: new NullLogger(),
+            cleaner: $this->createMock(Cleaner::class),
+        );
+
+        $engine->refreshSubscriptions();
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                'test',
+                'default',
+                RunMode::FromBeginning,
+                Status::Active,
+                cleanupTasks: [new DropTableTask('test')],
+            ),
+        );
+    }
+
+    public function testRefreshSubscriptionsMultipleChanges(): void
+    {
+        $subscriber = new #[Subscriber('test', RunMode::FromNow, group: 'new-group')]
+        class {
+            /** @return iterable<object> */
+            #[Cleanup]
+            public function cleanup(): iterable
+            {
+                yield new DropTableTask('test');
+            }
+        };
+
+        $subscription = new Subscription(
+            'test',
+            'default',
+            RunMode::FromBeginning,
+            Status::Active,
+        );
+
+        $subscriptionStore = new DummySubscriptionStore([$subscription]);
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(Store::class),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            logger: new NullLogger(),
+            cleaner: $this->createMock(Cleaner::class),
+        );
+
+        $engine->refreshSubscriptions();
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                'test',
+                'new-group',
+                RunMode::FromNow,
+                Status::Active,
+                cleanupTasks: [new DropTableTask('test')],
+            ),
+        );
+    }
+
+    public function testRefreshSubscriptionsWithCriteria(): void
+    {
+        $subscriber1 = new #[Subscriber('test1', RunMode::FromNow)]
+        class {
+        };
+
+        $subscriber2 = new #[Subscriber('test2', RunMode::FromNow)]
+        class {
+        };
+
+        $subscription1 = new Subscription(
+            'test1',
+            'default',
+            RunMode::FromBeginning,
+            Status::Active,
+        );
+
+        $subscription2 = new Subscription(
+            'test2',
+            'default',
+            RunMode::FromBeginning,
+            Status::Active,
+        );
+
+        $subscriptionStore = new DummySubscriptionStore([$subscription1, $subscription2]);
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(Store::class),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber1, $subscriber2]),
+            logger: new NullLogger(),
+            cleaner: $this->createMock(Cleaner::class),
+        );
+
+        $engine->refreshSubscriptions(new SubscriptionEngineCriteria(['test1']));
+
+        $subscriptionStore->assertUpdated(
+            new Subscription(
+                'test1',
+                'default',
+                RunMode::FromNow,
+                Status::Active,
+            ),
+        );
+
+        self::assertCount(1, $subscriptionStore->updatedSubscriptions);
+    }
+
+    public function testRefreshSubscriptionsDiscoverNewSubscribers(): void
+    {
+        $subscriber = new #[Subscriber('test', RunMode::FromBeginning)]
+        class {
+        };
+
+        $subscriptionStore = new DummySubscriptionStore();
+
+        $engine = new DefaultSubscriptionEngine(
+            $this->createMock(Store::class),
+            $subscriptionStore,
+            new MetadataSubscriberAccessorRepository([$subscriber]),
+            logger: new NullLogger(),
+            cleaner: $this->createMock(Cleaner::class),
+        );
+
+        $engine->refreshSubscriptions();
+
+        $subscriptionStore->assertAdded(
+            new Subscription(
+                'test',
+                'default',
+                RunMode::FromBeginning,
+                Status::New,
+            ),
+        );
     }
 }

--- a/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/DefaultSubscriptionEngineTest.php
@@ -4597,7 +4597,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
             cleaner: $this->createMock(Cleaner::class),
         );
 
-        $engine->refreshSubscriptions();
+        $engine->refresh();
 
         $subscriptionStore->assertNoChanges();
     }
@@ -4625,7 +4625,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
             cleaner: $this->createMock(Cleaner::class),
         );
 
-        $engine->refreshSubscriptions();
+        $engine->refresh();
 
         $subscriptionStore->assertUpdated(
             new Subscription(
@@ -4660,7 +4660,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
             cleaner: $this->createMock(Cleaner::class),
         );
 
-        $engine->refreshSubscriptions();
+        $engine->refresh();
 
         $subscriptionStore->assertUpdated(
             new Subscription(
@@ -4701,7 +4701,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
             cleaner: $this->createMock(Cleaner::class),
         );
 
-        $engine->refreshSubscriptions();
+        $engine->refresh();
 
         $subscriptionStore->assertUpdated(
             new Subscription(
@@ -4743,7 +4743,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
             cleaner: $this->createMock(Cleaner::class),
         );
 
-        $engine->refreshSubscriptions();
+        $engine->refresh();
 
         $subscriptionStore->assertUpdated(
             new Subscription(
@@ -4790,7 +4790,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
             cleaner: $this->createMock(Cleaner::class),
         );
 
-        $engine->refreshSubscriptions(new SubscriptionEngineCriteria(['test1']));
+        $engine->refresh(new SubscriptionEngineCriteria(['test1']));
 
         $subscriptionStore->assertUpdated(
             new Subscription(
@@ -4820,7 +4820,7 @@ final class DefaultSubscriptionEngineTest extends TestCase
             cleaner: $this->createMock(Cleaner::class),
         );
 
-        $engine->refreshSubscriptions();
+        $engine->refresh();
 
         $subscriptionStore->assertAdded(
             new Subscription(

--- a/tests/Unit/Subscription/Engine/ThrowOnErrorSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/ThrowOnErrorSubscriptionEngineTest.php
@@ -276,8 +276,8 @@ final class ThrowOnErrorSubscriptionEngineTest extends TestCase
 
         $expectedResult = new Result();
 
-        $parent->expects($this->once())->method('refreshSubscriptions')->with($criteria)->willReturn($expectedResult);
-        $result = $engine->refreshSubscriptions($criteria);
+        $parent->expects($this->once())->method('refresh')->with($criteria)->willReturn($expectedResult);
+        $result = $engine->refresh($criteria);
 
         self::assertSame($expectedResult, $result);
     }
@@ -298,8 +298,8 @@ final class ThrowOnErrorSubscriptionEngineTest extends TestCase
             new Error('id1', 'error1', new RuntimeException('error1')),
         ]);
 
-        $parent->expects($this->once())->method('refreshSubscriptions')->with($criteria)->willReturn($expectedResult);
-        $engine->refreshSubscriptions($criteria);
+        $parent->expects($this->once())->method('refresh')->with($criteria)->willReturn($expectedResult);
+        $engine->refresh($criteria);
     }
 
     public function testRefreshSubscriptionsNotSupported(): void
@@ -309,6 +309,6 @@ final class ThrowOnErrorSubscriptionEngineTest extends TestCase
         $engine = new ThrowOnErrorSubscriptionEngine($parent);
 
         $this->expectException(LogicException::class);
-        $engine->refreshSubscriptions();
+        $engine->refresh();
     }
 }

--- a/tests/Unit/Subscription/Engine/ThrowOnErrorSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/ThrowOnErrorSubscriptionEngineTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
 
+use LogicException;
+use Patchlevel\EventSourcing\Subscription\Engine\CanRefreshSubscriptions;
 use Patchlevel\EventSourcing\Subscription\Engine\Error;
 use Patchlevel\EventSourcing\Subscription\Engine\ErrorDetected;
 use Patchlevel\EventSourcing\Subscription\Engine\ProcessedResult;
@@ -260,5 +262,53 @@ final class ThrowOnErrorSubscriptionEngineTest extends TestCase
         $result = $engine->subscriptions($criteria);
 
         self::assertSame([], $result);
+    }
+
+    public function testRefreshSubscriptionsSuccess(): void
+    {
+        $parent = $this->createMockForIntersectionOfInterfaces([
+            SubscriptionEngine::class,
+            CanRefreshSubscriptions::class,
+        ]);
+
+        $engine = new ThrowOnErrorSubscriptionEngine($parent);
+        $criteria = new SubscriptionEngineCriteria();
+
+        $expectedResult = new Result();
+
+        $parent->expects($this->once())->method('refreshSubscriptions')->with($criteria)->willReturn($expectedResult);
+        $result = $engine->refreshSubscriptions($criteria);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function testRefreshSubscriptionsError(): void
+    {
+        $this->expectException(ErrorDetected::class);
+
+        $parent = $this->createMockForIntersectionOfInterfaces([
+            SubscriptionEngine::class,
+            CanRefreshSubscriptions::class,
+        ]);
+
+        $engine = new ThrowOnErrorSubscriptionEngine($parent);
+        $criteria = new SubscriptionEngineCriteria();
+
+        $expectedResult = new Result([
+            new Error('id1', 'error1', new RuntimeException('error1')),
+        ]);
+
+        $parent->expects($this->once())->method('refreshSubscriptions')->with($criteria)->willReturn($expectedResult);
+        $engine->refreshSubscriptions($criteria);
+    }
+
+    public function testRefreshSubscriptionsNotSupported(): void
+    {
+        $parent = $this->createMock(SubscriptionEngine::class);
+
+        $engine = new ThrowOnErrorSubscriptionEngine($parent);
+
+        $this->expectException(LogicException::class);
+        $engine->refreshSubscriptions();
     }
 }


### PR DESCRIPTION
fix: https://github.com/patchlevel/event-sourcing/issues/747

Allow the refreshing of subscriptions, such as run-mode and group. If the PR https://github.com/patchlevel/event-sourcing/pull/807 is merged, cleanup tasks will also be added here.