### PR TITLE
Repository store adapter

### DIFF
--- a/src/Repository/DefaultRepository.php
+++ b/src/Repository/DefaultRepository.php
@@ -11,20 +11,13 @@ use Patchlevel\EventSourcing\Identifier\Identifier;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadata;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StoreAdapter;
 use Patchlevel\EventSourcing\Snapshot\SnapshotNotFound;
 use Patchlevel\EventSourcing\Snapshot\SnapshotStore;
 use Patchlevel\EventSourcing\Snapshot\SnapshotVersionInvalid;
-use Patchlevel\EventSourcing\Store\Criteria\ArchivedCriterion;
-use Patchlevel\EventSourcing\Store\Criteria\Criteria;
-use Patchlevel\EventSourcing\Store\Criteria\FromPlayheadCriterion;
-use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
-use Patchlevel\EventSourcing\Store\Criteria\ToPlayheadCriterion;
 use Patchlevel\EventSourcing\Store\Header\PlayheadHeader;
 use Patchlevel\EventSourcing\Store\Header\RecordedOnHeader;
-use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
-use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Store\Stream;
-use Patchlevel\EventSourcing\Store\StreamStartHeader;
 use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
@@ -32,7 +25,6 @@ use Psr\Log\NullLogger;
 use Throwable;
 use Traversable;
 use WeakMap;
-
 use function array_map;
 use function assert;
 use function count;
@@ -52,7 +44,7 @@ final class DefaultRepository implements Repository
 
     /** @param AggregateRootMetadata<T> $metadata */
     public function __construct(
-        private readonly Store $store,
+        private readonly StoreAdapter $messageAdapter,
         private readonly AggregateRootMetadata $metadata,
         private readonly EventBus|null $eventBus = null,
         private readonly SnapshotStore|null $snapshotStore = null,
@@ -110,15 +102,12 @@ final class DefaultRepository implements Repository
             }
         }
 
-        $criteria = new Criteria(
-            new StreamCriterion($this->metadata->streamName($id->toString())),
-            new ArchivedCriterion(false),
-        );
-
         $stream = null;
 
         try {
-            $stream = $this->store->load($criteria);
+            $stream = $this->messageAdapter->load(
+                $this->metadata->streamName($id->toString()),
+            );
 
             $firstMessage = $stream->current();
 
@@ -163,11 +152,7 @@ final class DefaultRepository implements Repository
 
     public function has(Identifier $id): bool
     {
-        $criteria = new Criteria(
-            new StreamCriterion($this->metadata->streamName($id->toString())),
-        );
-
-        return $this->store->count($criteria) > 0;
+        return $this->messageAdapter->count($this->metadata->streamName($id->toString())) > 0;
     }
 
     /** @param T $aggregate */
@@ -223,27 +208,18 @@ final class DefaultRepository implements Repository
 
             $streamName = $this->metadata->streamName($aggregateId);
 
-            $archiveTo = null;
-
             $messages = array_map(
                 static function (object $event) use (
                     &$playhead,
-                    &$archiveTo,
                     $messageDecorator,
                     $clock,
-                    $streamName,
                 ) {
                     $message = Message::create($event)
-                        ->withHeader(new StreamNameHeader($streamName))
                         ->withHeader(new PlayheadHeader(++$playhead))
                         ->withHeader(new RecordedOnHeader($clock->now()));
 
                     if ($messageDecorator) {
                         $message = $messageDecorator($message);
-                    }
-
-                    if ($message->hasHeader(StreamStartHeader::class)) {
-                        $archiveTo = $playhead;
                     }
 
                     return $message;
@@ -252,21 +228,7 @@ final class DefaultRepository implements Repository
             );
 
             try {
-                if ($archiveTo !== null) {
-                    $this->store->transactional(
-                        function () use ($messages, $streamName, $archiveTo): void {
-                            $this->store->save(...$messages);
-                            $this->store->archive(
-                                new Criteria(
-                                    new StreamCriterion($streamName),
-                                    new ToPlayheadCriterion($archiveTo),
-                                ),
-                            );
-                        },
-                    );
-                } else {
-                    $this->store->save(...$messages);
-                }
+                $this->messageAdapter->write($streamName, $messages);
             } catch (UniqueConstraintViolation) {
                 if ($newAggregate) {
                     $this->logger->error(
@@ -320,15 +282,10 @@ final class DefaultRepository implements Repository
 
         $aggregate = $this->snapshotStore->load($aggregateClass, $id);
 
-        $criteria = new Criteria(
-            new StreamCriterion($this->metadata->streamName($id->toString())),
-            new FromPlayheadCriterion($aggregate->playhead()),
-        );
-
         $stream = null;
 
         try {
-            $stream = $this->store->load($criteria);
+            $stream = $this->messageAdapter->load($this->metadata->streamName($id->toString()), $aggregate->playhead());
 
             if ($stream->current() === null) {
                 $this->aggregateIsValid[$aggregate] = true;

--- a/src/Repository/DefaultRepositoryManager.php
+++ b/src/Repository/DefaultRepositoryManager.php
@@ -12,12 +12,11 @@ use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadataAwareMe
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadataFactory;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StoreAdapter;
 use Patchlevel\EventSourcing\Snapshot\SnapshotStore;
-use Patchlevel\EventSourcing\Store\Store;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-
 use function array_key_exists;
 
 final class DefaultRepositoryManager implements RepositoryManager
@@ -31,7 +30,7 @@ final class DefaultRepositoryManager implements RepositoryManager
 
     public function __construct(
         private readonly AggregateRootRegistry $aggregateRootRegistry,
-        private readonly Store $store,
+        private readonly StoreAdapter $storeAdapter,
         private readonly EventBus|null $eventBus = null,
         private readonly SnapshotStore|null $snapshotStore = null,
         private readonly MessageDecorator|null $messageDecorator = null,
@@ -65,7 +64,7 @@ final class DefaultRepositoryManager implements RepositoryManager
         }
 
         return $this->instances[$aggregateClass] = new DefaultRepository(
-            $this->store,
+            $this->storeAdapter,
             $this->metadataFactory->metadata($aggregateClass),
             $this->eventBus,
             $this->snapshotStore,

--- a/src/Repository/StoreAdapter/StoreAdapter.php
+++ b/src/Repository/StoreAdapter/StoreAdapter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Patchlevel\EventSourcing\Repository\StoreAdapter;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Store\Stream;
+
+interface StoreAdapter
+{
+    public function load(string $stream, int|null $fromPlayhead = null): Stream;
+
+    public function count(string $stream): int;
+
+    /**
+     * @param iterable<Message> $messages
+     */
+    public function write(string $stream, iterable $messages): void;
+}

--- a/src/Repository/StoreAdapter/StreamDoctrineDbalStoreAdapter.php
+++ b/src/Repository/StoreAdapter/StreamDoctrineDbalStoreAdapter.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Patchlevel\EventSourcing\Repository\StoreAdapter;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Store\Criteria\ArchivedCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\Criteria;
+use Patchlevel\EventSourcing\Store\Criteria\FromPlayheadCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\ToPlayheadCriterion;
+use Patchlevel\EventSourcing\Store\Header\PlayheadHeader;
+use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
+use Patchlevel\EventSourcing\Store\Stream;
+use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
+use Patchlevel\EventSourcing\Store\StreamStartHeader;
+use Throwable;
+
+final readonly class StreamDoctrineDbalStoreAdapter implements StoreAdapter
+{
+    public function __construct(
+        private StreamDoctrineDbalStore $store,
+    ) {
+    }
+
+    public function load(string $stream, int|null $fromPlayhead = null): Stream
+    {
+        $criteria = new Criteria(
+            new StreamCriterion($stream),
+            new ArchivedCriterion(false),
+        );
+
+        if ($fromPlayhead !== null) {
+            $criteria->add(new FromPlayheadCriterion($fromPlayhead));
+        }
+
+        return $this->store->load($criteria);
+    }
+
+    public function count(string $stream): int
+    {
+        $criteria = new Criteria(
+            new StreamCriterion($stream),
+        );
+
+        return $this->store->count($criteria);
+    }
+
+    /**
+     * @param iterable<Message> $messages
+     */
+    public function write(string $stream, iterable $messages): void
+    {
+        $archiveTo = null;
+
+        $this->store->save(
+            ...array_map(
+                static function (Message $message) use (
+                    $stream,
+                    &$archiveTo
+                ) {
+                    if ($message->hasHeader(StreamStartHeader::class)) {
+                        try {
+                            $archiveTo = $message->header(PlayheadHeader::class)->playhead;
+                        } catch (Throwable) {
+                        }
+                    }
+
+                    return $message->withHeader(new StreamNameHeader($stream));
+                },
+                $messages,
+            )
+        );
+
+        if ($archiveTo === null) {
+            $this->store->save(...$messages);
+
+            return;
+        }
+
+        $this->store->transactional(
+            static function () use ($stream, $archiveTo, $messages): void {
+                $this->store->save(...$messages);
+
+                $this->store->archive(
+                    new Criteria(
+                        new StreamCriterion($stream),
+                        new ToPlayheadCriterion($archiveTo),
+                    ),
+                );
+            }
+        );
+    }
+}

--- a/src/Repository/StoreAdapter/TaggableDoctrineDbalStoreAdapter.php
+++ b/src/Repository/StoreAdapter/TaggableDoctrineDbalStoreAdapter.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Patchlevel\EventSourcing\Repository\StoreAdapter;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Store\Criteria\ArchivedCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\Criteria;
+use Patchlevel\EventSourcing\Store\Criteria\FromPlayheadCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\ToPlayheadCriterion;
+use Patchlevel\EventSourcing\Store\Header\PlayheadHeader;
+use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
+use Patchlevel\EventSourcing\Store\Stream;
+use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
+use Patchlevel\EventSourcing\Store\StreamStartHeader;
+use Patchlevel\EventSourcing\Store\TaggableDoctrineDbalStore;
+use Throwable;
+
+final readonly class TaggableDoctrineDbalStoreAdapter implements StoreAdapter
+{
+    public function __construct(
+        private TaggableDoctrineDbalStore $store,
+    ) {
+    }
+
+    public function load(string $stream, int|null $fromPlayhead = null): Stream
+    {
+        $criteria = new Criteria(
+            new StreamCriterion($stream),
+            new ArchivedCriterion(false),
+        );
+
+        if ($fromPlayhead !== null) {
+            $criteria->add(new FromPlayheadCriterion($fromPlayhead));
+        }
+
+        return $this->store->load($criteria);
+    }
+
+    public function count(string $stream): int
+    {
+        $criteria = new Criteria(
+            new StreamCriterion($stream),
+        );
+
+        return $this->store->count($criteria);
+    }
+
+    /**
+     * @param iterable<Message> $messages
+     */
+    public function write(string $stream, iterable $messages): void
+    {
+        $archiveTo = null;
+
+        $this->store->save(
+            ...array_map(
+                static function (Message $message) use (
+                    $stream,
+                    &$archiveTo
+                ) {
+                    if ($message->hasHeader(StreamStartHeader::class)) {
+                        try {
+                            $archiveTo = $message->header(PlayheadHeader::class)->playhead;
+                        } catch (Throwable) {
+                        }
+                    }
+
+                    return $message->withHeader(new StreamNameHeader($stream));
+                },
+                $messages,
+            )
+        );
+
+        if ($archiveTo === null) {
+            $this->store->save(...$messages);
+
+            return;
+        }
+
+        $this->store->transactional(
+            static function () use ($stream, $archiveTo, $messages): void {
+                $this->store->save(...$messages);
+
+                $this->store->archive(
+                    new Criteria(
+                        new StreamCriterion($stream),
+                        new ToPlayheadCriterion($archiveTo),
+                    ),
+                );
+            }
+        );
+    }
+}

--- a/tests/Benchmark/CommandToQueryBench.php
+++ b/tests/Benchmark/CommandToQueryBench.php
@@ -13,6 +13,7 @@ use Patchlevel\EventSourcing\QueryBus\QueryBus;
 use Patchlevel\EventSourcing\QueryBus\ServiceHandlerProvider;
 use Patchlevel\EventSourcing\QueryBus\SyncQueryBus;
 use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StreamDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Snapshot\Adapter\InMemorySnapshotAdapter;
@@ -56,7 +57,7 @@ final class CommandToQueryBench
 
         $manager = new DefaultRepositoryManager(
             $aggregateRootRegistry,
-            $store,
+            new StreamDoctrineDbalStoreAdapter($store),
             null,
             new DefaultSnapshotStore(['default' => new InMemorySnapshotAdapter()]),
         );

--- a/tests/Benchmark/PersonalDataBench.php
+++ b/tests/Benchmark/PersonalDataBench.php
@@ -8,6 +8,7 @@ use Patchlevel\EventSourcing\Cryptography\DoctrineCipherKeyStore;
 use Patchlevel\EventSourcing\Identifier\Identifier;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StreamDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\ChainDoctrineSchemaConfigurator;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
@@ -46,7 +47,10 @@ final class PersonalDataBench
             ),
         );
 
-        $this->repository = new DefaultRepository($this->store, Profile::metadata());
+        $this->repository = new DefaultRepository(
+            new StreamDoctrineDbalStoreAdapter($this->store),
+            Profile::metadata()
+        );
 
         $schemaDirector = new DoctrineSchemaDirector(
             $connection,

--- a/tests/Benchmark/SimpleSetupStreamStoreBench.php
+++ b/tests/Benchmark/SimpleSetupStreamStoreBench.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\Tests\Benchmark;
 use Patchlevel\EventSourcing\Identifier\Identifier;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StreamDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\Store;
@@ -34,7 +35,10 @@ final class SimpleSetupStreamStoreBench
             DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
         );
 
-        $this->repository = new DefaultRepository($this->store, Profile::metadata());
+        $this->repository = new DefaultRepository(
+            new StreamDoctrineDbalStoreAdapter($this->store),
+            Profile::metadata()
+        );
 
         $schemaDirector = new DoctrineSchemaDirector(
             $connection,

--- a/tests/Benchmark/SimpleSetupTaggableStoreBench.php
+++ b/tests/Benchmark/SimpleSetupTaggableStoreBench.php
@@ -9,6 +9,7 @@ use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\Event\AttributeEventRegistryFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\TaggableDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\TaggableDoctrineDbalStore;
@@ -37,7 +38,10 @@ final class SimpleSetupTaggableStoreBench
             (new AttributeEventRegistryFactory())->create([__DIR__ . '/BasicImplementation/Events']),
         );
 
-        $this->repository = new DefaultRepository($this->store, Profile::metadata());
+        $this->repository = new DefaultRepository(
+            new TaggableDoctrineDbalStoreAdapter($this->store),
+            Profile::metadata()
+        );
 
         $schemaDirector = new DoctrineSchemaDirector(
             $connection,

--- a/tests/Benchmark/SnapshotsBench.php
+++ b/tests/Benchmark/SnapshotsBench.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\Tests\Benchmark;
 use Patchlevel\EventSourcing\Identifier\Identifier;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StreamDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Snapshot\Adapter\InMemorySnapshotAdapter;
@@ -43,7 +44,12 @@ final class SnapshotsBench
 
         $this->snapshotStore = new DefaultSnapshotStore(['default' => $this->adapter]);
 
-        $this->repository = new DefaultRepository($this->store, Profile::metadata(), null, $this->snapshotStore);
+        $this->repository = new DefaultRepository(
+            new StreamDoctrineDbalStoreAdapter($this->store),
+            Profile::metadata(),
+            null,
+            $this->snapshotStore
+        );
 
         $schemaDirector = new DoctrineSchemaDirector(
             $connection,

--- a/tests/Benchmark/SplitStreamBench.php
+++ b/tests/Benchmark/SplitStreamBench.php
@@ -8,6 +8,7 @@ use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
 use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StreamDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\Store;
@@ -37,7 +38,7 @@ final class SplitStreamBench
         );
 
         $this->repository = new DefaultRepository(
-            $this->store,
+            new StreamDoctrineDbalStoreAdapter($this->store),
             Profile::metadata(),
             null,
             null,

--- a/tests/Benchmark/SubscriptionEngineBatchBench.php
+++ b/tests/Benchmark/SubscriptionEngineBatchBench.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\Tests\Benchmark;
 use Patchlevel\EventSourcing\Identifier\Identifier;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StreamDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\ChainDoctrineSchemaConfigurator;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
@@ -43,7 +44,10 @@ final class SubscriptionEngineBatchBench
             DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
         );
 
-        $this->repository = new DefaultRepository($this->store, Profile::metadata());
+        $this->repository = new DefaultRepository(
+            new StreamDoctrineDbalStoreAdapter($this->store),
+            Profile::metadata()
+        );
 
         $subscriptionStore = new DoctrineSubscriptionStore(
             $connection,

--- a/tests/Benchmark/SubscriptionEngineBench.php
+++ b/tests/Benchmark/SubscriptionEngineBench.php
@@ -8,6 +8,7 @@ use Patchlevel\EventSourcing\Identifier\Identifier;
 use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
 use Patchlevel\EventSourcing\Repository\Repository;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StreamDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\ChainDoctrineSchemaConfigurator;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
@@ -44,7 +45,10 @@ final class SubscriptionEngineBench
             DefaultEventSerializer::createFromPaths([__DIR__ . '/BasicImplementation/Events']),
         );
 
-        $this->repository = new DefaultRepository($this->store, Profile::metadata());
+        $this->repository = new DefaultRepository(
+            new StreamDoctrineDbalStoreAdapter($this->store),
+            Profile::metadata()
+        );
 
         $subscriptionStore = new DoctrineSubscriptionStore(
             $connection,

--- a/tests/Integration/BankAccountSplitStream/IntegrationTest.php
+++ b/tests/Integration/BankAccountSplitStream/IntegrationTest.php
@@ -10,6 +10,7 @@ use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
 use Patchlevel\EventSourcing\Repository\DefaultRepositoryManager;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\ChainMessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
+use Patchlevel\EventSourcing\Repository\StoreAdapter\StreamDoctrineDbalStoreAdapter;
 use Patchlevel\EventSourcing\Schema\DoctrineSchemaDirector;
 use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
 use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
@@ -59,7 +60,7 @@ final class IntegrationTest extends TestCase
 
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
-            $store,
+            new StreamDoctrineDbalStoreAdapter($store),
             null,
             null,
             new ChainMessageDecorator([
@@ -98,7 +99,7 @@ final class IntegrationTest extends TestCase
 
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
-            $store,
+            new StreamDoctrineDbalStoreAdapter($store),
             null,
             null,
             new ChainMessageDecorator([
@@ -137,7 +138,7 @@ final class IntegrationTest extends TestCase
 
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
-            $store,
+            new StreamDoctrineDbalStoreAdapter($store),
             null,
             null,
             new ChainMessageDecorator([
@@ -174,7 +175,7 @@ final class IntegrationTest extends TestCase
 
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
-            $store,
+            new StreamDoctrineDbalStoreAdapter($store),
             null,
             null,
             new ChainMessageDecorator([
@@ -213,7 +214,7 @@ final class IntegrationTest extends TestCase
 
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
-            $store,
+            new StreamDoctrineDbalStoreAdapter($store),
             null,
             null,
             new ChainMessageDecorator([
@@ -252,7 +253,7 @@ final class IntegrationTest extends TestCase
 
         $manager = new DefaultRepositoryManager(
             new AggregateRootRegistry(['bank_account' => BankAccount::class]),
-            $store,
+            new StreamDoctrineDbalStoreAdapter($store),
             null,
             null,
             new ChainMessageDecorator([


### PR DESCRIPTION
We have often had to check specific store implementations in the repository to build the query.

https://github.com/patchlevel/event-sourcing/blob/3.17.x/src/Repository/DefaultRepository.php#L72

and

https://github.com/patchlevel/event-sourcing/blob/3.17.x/src/Repository/DefaultRepository.php#L120-L130

With this adapter, i am trying to outsource this logic to specific adapter classes.