### PR TITLE
Use `Pdo\Pgsql::getNotify` if PHP version is `>= 8.4` instead of `PDO::pgsqlGetNotify`.

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -34,7 +34,6 @@ jobs:
                   coverage: none
                   php-version: "${{ matrix.php-version }}"
                   ini-values: memory_limit=-1, opcache.enable_cli=1
-                  extensions: pdo_sqlite
 
             - uses: ramsey/composer-install@3.1.1
               with:

--- a/.github/workflows/deptrac.yml
+++ b/.github/workflows/deptrac.yml
@@ -34,7 +34,6 @@ jobs:
                   coverage: "pcov"
                   php-version: "${{ matrix.php-version }}"
                   ini-values: memory_limit=-1
-                  extensions: pdo_sqlite
 
             - uses: ramsey/composer-install@3.1.1
               with:

--- a/.github/workflows/mutation-tests-diff.yml
+++ b/.github/workflows/mutation-tests-diff.yml
@@ -32,7 +32,7 @@ jobs:
                   coverage: "pcov"
                   php-version: "${{ matrix.php-version }}"
                   ini-values: memory_limit=-1
-                  extensions: pdo_sqlite
+                  extensions: pdo_sqlite, pdo_pgsql
 
             - uses: ramsey/composer-install@3.1.1
               with:

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -34,7 +34,7 @@ jobs:
                   coverage: "pcov"
                   php-version: "${{ matrix.php-version }}"
                   ini-values: memory_limit=-1
-                  extensions: pdo_sqlite
+                  extensions: pdo_sqlite, pdo_pgsql
 
             - uses: ramsey/composer-install@3.1.1
               with:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -34,7 +34,6 @@ jobs:
                   coverage: none
                   php-version: "${{ matrix.php-version }}"
                   ini-values: memory_limit=-1, opcache.enable_cli=1
-                  extensions: pdo_sqlite
 
             - uses: ramsey/composer-install@3.1.1
               with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -46,7 +46,7 @@ jobs:
                   coverage: "pcov"
                   php-version: "${{ matrix.php-version }}"
                   ini-values: memory_limit=-1
-                  extensions: pdo_sqlite
+                  extensions: pdo_sqlite, pdo_pgsql
 
             - uses: ramsey/composer-install@3.1.1
               with:

--- a/src/Store/DoctrineDbalStore.php
+++ b/src/Store/DoctrineDbalStore.php
@@ -34,6 +34,7 @@ use Patchlevel\EventSourcing\Store\Criteria\FromPlayheadCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\ToIndexCriterion;
 use Patchlevel\EventSourcing\Store\Header\IndexHeader;
 use PDO;
+use Pdo\Pgsql;
 
 use function array_fill;
 use function array_filter;
@@ -48,6 +49,8 @@ use function in_array;
 use function is_int;
 use function is_string;
 use function sprintf;
+
+use const PHP_VERSION_ID;
 
 final class DoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchemaConfigurator
 {
@@ -386,10 +389,15 @@ final class DoctrineDbalStore implements Store, SubscriptionStore, DoctrineSchem
 
         $this->connection->executeStatement(sprintf('LISTEN "%s"', $this->config['table_name']));
 
-        /** @var PDO $nativeConnection */
-        $nativeConnection = $this->connection->getNativeConnection();
-
-        $nativeConnection->pgsqlGetNotify(PDO::FETCH_ASSOC, $timeoutMilliseconds);
+        if (PHP_VERSION_ID >= 80400) {
+            /** @var Pgsql $nativeConnection */
+            $nativeConnection = $this->connection->getNativeConnection();
+            $nativeConnection->getNotify(PDO::FETCH_ASSOC, $timeoutMilliseconds);
+        } else {
+            /** @var PDO $nativeConnection */
+            $nativeConnection = $this->connection->getNativeConnection();
+            $nativeConnection->pgsqlGetNotify(PDO::FETCH_ASSOC, $timeoutMilliseconds);
+        }
     }
 
     public function setupSubscription(): void

--- a/src/Store/StreamDoctrineDbalStore.php
+++ b/src/Store/StreamDoctrineDbalStore.php
@@ -39,6 +39,7 @@ use Patchlevel\EventSourcing\Store\Header\PlayheadHeader;
 use Patchlevel\EventSourcing\Store\Header\RecordedOnHeader;
 use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
 use PDO;
+use Pdo\Pgsql;
 use Psr\Clock\ClockInterface;
 use Ramsey\Uuid\Uuid;
 
@@ -57,6 +58,8 @@ use function is_string;
 use function sprintf;
 use function str_contains;
 use function str_replace;
+
+use const PHP_VERSION_ID;
 
 final class StreamDoctrineDbalStore implements StreamStore, SubscriptionStore, DoctrineSchemaConfigurator
 {
@@ -465,10 +468,15 @@ final class StreamDoctrineDbalStore implements StreamStore, SubscriptionStore, D
 
         $this->connection->executeStatement(sprintf('LISTEN "%s"', $this->config['table_name']));
 
-        /** @var PDO $nativeConnection */
-        $nativeConnection = $this->connection->getNativeConnection();
-
-        $nativeConnection->pgsqlGetNotify(PDO::FETCH_ASSOC, $timeoutMilliseconds);
+        if (PHP_VERSION_ID >= 80400) {
+            /** @var Pgsql $nativeConnection */
+            $nativeConnection = $this->connection->getNativeConnection();
+            $nativeConnection->getNotify(PDO::FETCH_ASSOC, $timeoutMilliseconds);
+        } else {
+            /** @var PDO $nativeConnection */
+            $nativeConnection = $this->connection->getNativeConnection();
+            $nativeConnection->pgsqlGetNotify(PDO::FETCH_ASSOC, $timeoutMilliseconds);
+        }
     }
 
     public function setupSubscription(): void

--- a/tests/Unit/Store/DoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/DoctrineDbalStoreTest.php
@@ -41,6 +41,7 @@ use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileEmailChanged;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PDO;
+use Pdo\Pgsql;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
@@ -1343,7 +1344,39 @@ final class DoctrineDbalStoreTest extends TestCase
         $doctrineDbalStore->setupSubscription();
     }
 
+    #[RequiresPhp('>= 8.4')]
     public function testWait(): void
+    {
+        $nativeConnection = $this->createMock(Pgsql::class);
+        $nativeConnection
+            ->expects($this->once())
+            ->method('getNotify')
+            ->with(PDO::FETCH_ASSOC, 100)
+            ->willReturn([]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('executeStatement')->with('LISTEN "eventstore"')
+            ->willReturn(1);
+        $connection->expects($this->once())->method('getNativeConnection')
+            ->willReturn($nativeConnection);
+
+        $abstractPlatform = $this->createMock(PostgreSQLPlatform::class);
+        $connection->expects($this->once())->method('getDatabasePlatform')->willReturn($abstractPlatform);
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new DoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $doctrineDbalStore->wait(100);
+    }
+
+    #[RequiresPhp('< 8.4')]
+    public function testWaitDeprecatedFunction(): void
     {
         $nativeConnection = $this->getMockBuilder(PDO::class)
             ->disableOriginalConstructor()

--- a/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
@@ -44,7 +44,9 @@ use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileEmailChanged;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PDO;
+use Pdo\Pgsql;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
 use RuntimeException;
@@ -1367,7 +1369,43 @@ final class StreamDoctrineDbalStoreTest extends TestCase
         $doctrineDbalStore->setupSubscription();
     }
 
+    #[RequiresPhp('>= 8.4')]
     public function testWait(): void
+    {
+        $nativeConnection = $this->createMock(Pgsql::class);
+        $nativeConnection
+            ->expects($this->once())
+            ->method('getNotify')
+            ->with(PDO::FETCH_ASSOC, 100)
+            ->willReturn([]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with('LISTEN "event_store"')
+            ->willReturn(1);
+        $connection
+            ->expects($this->once())
+            ->method('getNativeConnection')
+            ->willReturn($nativeConnection);
+
+        $abstractPlatform = $this->createMock(PostgreSQLPlatform::class);
+        $connection->method('getDatabasePlatform')->willReturn($abstractPlatform);
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+        $doctrineDbalStore->wait(100);
+    }
+
+    #[RequiresPhp('< 8.4')]
+    public function testWaitDeprecatedFunction(): void
     {
         $nativeConnection = $this->getMockBuilder(PDO::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
fix #827 