### PR TITLE
Improve docs around worker

### DIFF
--- a/docs/pages/cli.md
+++ b/docs/pages/cli.md
@@ -43,7 +43,7 @@ To manage your subscriptions there are the following cli commands.
 !!! note
 
     You can find out more about subscriptions [here](subscription.md).
-    
+
 ## Inspector commands
 
 The inspector is a tool to inspect the event streams.

--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -335,6 +335,12 @@ $hotelRepository = $repositoryManager->get(Hotel::class);
     `DefaultRepositoryManager` and a worker to run the Subscription Engine.
     
     Learn more [here](subscription.md).
+
+!!! warning
+    From version 4.x onward, a MessageLoader will be required for the SubscriptionEngine 
+    instead of a Store implementation. 
+    Read more about it [here](./subscription.md#message-loader). In current versions, 
+    you can still provide a Store, the SubscriptionEngine will wrap it internally. 
     
 ## Database setup
 

--- a/docs/pages/subscription.md
+++ b/docs/pages/subscription.md
@@ -838,13 +838,28 @@ In order for the subscription engine to be able to do its work, you have to asse
 ### Message Loader
 
 The subscription engine needs a message loader to load the messages.
-We provide two implementations by default.
+We provide three implementations by default.
 Which one has a better performance depends on the use case.
 
 !!! tip
 
-    We recommend the `GapResolverStoreMessageLoader` as it handles gaps in the stream.
+    We recommend the recent `GapResolverStoreMessageLoader` as it handles gaps in the stream.
+
+!!! note
+
+    If you followed the confiration in the [Getting Started](./getting_started.md#configuration) section,
+    the Message Loader implementation replaces the $eventStore in the DefaultSubscriptionEngine.
     
+    ```php
+        $messageLoader = // whatever implementation you choose
+        $engine = new DefaultSubscriptionEngine(
+    -       $eventStore,
+    +       $messageLoader,
+            $subscriptionStore,
+            $subscriberRepository,
+        );
+    ```
+
 #### Store Message Loader
 
 The store message loader loads all the messages from the event store.

--- a/docs/pages/subscription.md
+++ b/docs/pages/subscription.md
@@ -1184,6 +1184,12 @@ $catchupSubscriptionEngine = new CatchUpSubscriptionEngine($subscriptionEngine);
 !!! tip
 
     You can use the `CatchUpSubscriptionEngine` in your tests to process the events immediately.
+
+!!! Note
+
+    Learn more about the worker [here](./cli.md#subscription-commands).
+    
+## Subscription Lifecycle
     
 ### Throw on error Subscription Engine
 
@@ -1237,7 +1243,10 @@ $eventBus = new RunSubscriptionEngineRepositoryManager(
 !!! tip
 
     You can perfectly use it in development or testing.
-    Especially in combination with the `CatchUpSubscriptionEngine` and `ThrowOnErrorSubscriptionEngine` decorators.
+    Especially in combination with the `CatchUpSubscriptionEngine` and `ThrowOnErrorSubscriptionEngine` 
+    decorators.
+    Do note that, if you use this, you still need to make sure subscriptions are set up and booted. 
+    Otherwise, subscriptions will only be processed on subsequent requests.
     
 ## Usage
 
@@ -1255,7 +1264,9 @@ $criteria = new SubscriptionEngineCriteria(
 !!! note
 
     An `OR` check is made for the respective criteria and all criteria are checked with an `AND`.
-    
+
+All of the following steps have equivalent commands in the [CLI](./cli.md).
+
 ### Setup
 
 New subscriptions need to be set up before they can be used.
@@ -1374,6 +1385,16 @@ use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
 /** @var SubscriptionEngine $subscriptionEngine */
 $subscriptionEngine->refresh(new SubscriptionEngineCriteria());
 ```
+
+## Basic workflow for the worker
+
+Use `event-sourcing:subscription:boot --setup` to first run the setup of any new subscriptions
+and immediately boot them.
+
+The `event-sourcing:subscription:run` command will continue to run and process new events
+until the process is killed. After adding a new subscriber and booting it, you should
+restart the `run` command.
+
 ## Learn more
 
 * [How to use CLI commands](./cli.md)


### PR DESCRIPTION
While setting up patchlevel myself, I found the docs a little lacking around the Message Loader stuff and the process getting the worker set up. I think it can still be improved, it's mainly my own lack of knowledge about the subscription commands holding me back. 