### PR TITLE
Add a `--force` param to skip the prompt

### DIFF
--- a/src/Console/Command/SubscriptionRemoveCommand.php
+++ b/src/Console/Command/SubscriptionRemoveCommand.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Console\Command;
 
+use Patchlevel\EventSourcing\Console\InputHelper;
 use Patchlevel\EventSourcing\Console\OutputStyle;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
@@ -15,13 +17,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 final class SubscriptionRemoveCommand extends SubscriptionCommand
 {
+    protected function configure(): void
+    {
+        $this
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Set this parameter to execute this action without prompting');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new OutputStyle($input, $output);
 
         $criteria = $this->subscriptionEngineCriteria($input);
+        $force = InputHelper::bool($input->getOption('force'));
 
-        if ($criteria->ids === null) {
+        if ($criteria->ids === null && !$force) {
             if (!$io->confirm('do you want to remove all subscriptions?', false)) {
                 return 1;
             }


### PR DESCRIPTION
I personally like the option to skip a confirm prompt with a parameter. This allows me to use this command in some other tooling where I don't have the interactive prompt.  