### PR TITLE
Use in the upgrade docs our preferred message loader: GapResolverStoreMessageLoader

### DIFF
--- a/docs/UPGRADE-4.0.md
+++ b/docs/UPGRADE-4.0.md
@@ -67,7 +67,7 @@ after:
 ```php
 use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Subscription\Engine\DefaultSubscriptionEngine;
-use Patchlevel\EventSourcing\Subscription\Engine\StoreMessageLoader;
+use Patchlevel\EventSourcing\Subscription\Engine\GapResolverStoreMessageLoader;
 use Patchlevel\EventSourcing\Subscription\RetryStrategy\RetryStrategy;
 use Patchlevel\EventSourcing\Subscription\RetryStrategy\RetryStrategyRepository;
 use Patchlevel\EventSourcing\Subscription\Store\DoctrineSubscriptionStore;
@@ -80,7 +80,7 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessorR
  * @var RetryStrategy $retryStrategy
  */
 $subscriptionEngine = new DefaultSubscriptionEngine(
-    new StoreMessageLoader($store),
+    new GapResolverStoreMessageLoader($store),
     $subscriptionStore,
     $subscriberAccessorRepository,
     RetryStrategyRepository::withDefault($retryStrategy),


### PR DESCRIPTION
in 3.x we are already auto configuring it via flex: https://github.com/symfony/recipes-contrib/blob/main/patchlevel/event-sourcing-bundle/3.14/config/packages/patchlevel_event_sourcing.yaml#L16-L17