### PR TITLE
Add `Throwable` to `CommandBus::dispatch` @throws

### DIFF
--- a/src/CommandBus/CommandBus.php
+++ b/src/CommandBus/CommandBus.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\CommandBus;
 
+use Throwable;
+
 interface CommandBus
 {
-    /** @throws HandlerNotFound */
+    /**
+     * @throws HandlerNotFound
+     * @throws Throwable
+     */
     public function dispatch(object $command): void;
 }


### PR DESCRIPTION
Without declaring it, catching the exception forces `@phpstan-ignore catch.neverThrown` everywhere, which is a bad pattern.