### PR TITLE
Add many missing Unit-Tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
     "doctrine/dbal": "^4.4.0",
     "doctrine/migrations": "^3.3.2",
-    "patchlevel/hydrator": "^1.8.0",
+    "patchlevel/hydrator": "^1.24.0",
     "patchlevel/worker": "^1.4.0",
     "psr/cache": "^2.0.0 || ^3.0.0",
     "psr/clock": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8cf3383e3c323c67f6456b7cb8e765fd",
+    "content-hash": "0e9502d1c80c844be7148084542ae739",
     "packages": [
         {
             "name": "brick/math",

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -16,7 +16,7 @@
   "mutators": {
     "@default": true
   },
-  "minMsi": 69,
-  "minCoveredMsi": 86,
+  "minMsi": 90,
+  "minCoveredMsi": 90,
   "testFrameworkOptions": "--testsuite=unit"
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -307,54 +307,6 @@ parameters:
 			path: tests/Benchmark/BasicImplementation/Projection/ProfileProjector.php
 
 		-
-			message: '#^Call to an undefined method Patchlevel\\EventSourcing\\Subscription\\Engine\\SubscriptionEngine\:\:boot\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/Benchmark/NoopSubscriptionEngineBench.php
-
-		-
-			message: '#^Call to an undefined method Patchlevel\\EventSourcing\\Subscription\\Engine\\SubscriptionEngine\:\:remove\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/Benchmark/NoopSubscriptionEngineBench.php
-
-		-
-			message: '#^Call to an undefined method Patchlevel\\EventSourcing\\Subscription\\Engine\\SubscriptionEngine\:\:setup\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/Benchmark/NoopSubscriptionEngineBench.php
-
-		-
-			message: '#^Instantiated class Patchlevel\\EventSourcing\\Store\\DoctrineDbalStore not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Benchmark/NoopSubscriptionEngineBench.php
-
-		-
-			message: '#^Parameter \#1 \$schemaConfigurator of class Patchlevel\\EventSourcing\\Schema\\ChainDoctrineSchemaConfigurator constructor expects iterable\<Patchlevel\\EventSourcing\\Schema\\DoctrineSchemaConfigurator\>, array\<int, \(Patchlevel\\EventSourcing\\Store\\DoctrineDbalStore&Patchlevel\\EventSourcing\\Store\\Store\)\|Patchlevel\\EventSourcing\\Subscription\\Store\\DoctrineSubscriptionStore\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/Benchmark/NoopSubscriptionEngineBench.php
-
-		-
-			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Benchmark\\NoopSubscriptionEngineBench\:\:\$id \(Patchlevel\\EventSourcing\\Aggregate\\AggregateRootId\) does not accept Patchlevel\\EventSourcing\\Tests\\Benchmark\\BasicImplementation\\ProfileId\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/Benchmark/NoopSubscriptionEngineBench.php
-
-		-
-			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Benchmark\\NoopSubscriptionEngineBench\:\:\$id has unknown class Patchlevel\\EventSourcing\\Aggregate\\AggregateRootId as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: tests/Benchmark/NoopSubscriptionEngineBench.php
-
-		-
-			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Benchmark\\NoopSubscriptionEngineBench\:\:\$store \(Patchlevel\\EventSourcing\\Store\\Store\) does not accept Patchlevel\\EventSourcing\\Store\\DoctrineDbalStore\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/Benchmark/NoopSubscriptionEngineBench.php
-
-		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Patchlevel\\\\EventSourcing\\\\Tests\\\\Integration\\\\BankAccountSplitStream\\\\BankAccount'' and Patchlevel\\EventSourcing\\Tests\\Integration\\BankAccountSplitStream\\BankAccount will always evaluate to true\.$#'
 			identifier: staticMethod.alreadyNarrowedType
 			count: 4
@@ -523,6 +475,12 @@ parameters:
 			path: tests/Unit/Fixture/ProfileInvalid.php
 
 		-
+			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithAggregateStream\:\:\$id is unused\.$#'
+			identifier: property.unused
+			count: 1
+			path: tests/Unit/Fixture/ProfileWithAggregateStream.php
+
+		-
 			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithBrokenApplyBothUsage\:\:\$id is unused\.$#'
 			identifier: property.unused
 			count: 1
@@ -553,10 +511,28 @@ parameters:
 			path: tests/Unit/Fixture/ProfileWithBrokenApplyNoType.php
 
 		-
+			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithBrokenApplyStringType\:\:\$id is unused\.$#'
+			identifier: property.unused
+			count: 1
+			path: tests/Unit/Fixture/ProfileWithBrokenApplyStringType.php
+
+		-
+			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithBrokenApplyUnionIntersection\:\:\$id is unused\.$#'
+			identifier: property.unused
+			count: 1
+			path: tests/Unit/Fixture/ProfileWithBrokenApplyUnionIntersection.php
+
+		-
 			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithBrokenId\:\:\$id is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: tests/Unit/Fixture/ProfileWithBrokenId.php
+
+		-
+			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithDuplicateApply\:\:\$id is unused\.$#'
+			identifier: property.unused
+			count: 1
+			path: tests/Unit/Fixture/ProfileWithDuplicateApply.php
 
 		-
 			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithEmptyApply\:\:\$id is unused\.$#'
@@ -583,13 +559,19 @@ parameters:
 			path: tests/Unit/Fixture/ProfileWithSuppressAll.php
 
 		-
+			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithoutAggregateAttribute\:\:\$id is unused\.$#'
+			identifier: property.unused
+			count: 1
+			path: tests/Unit/Fixture/ProfileWithoutAggregateAttribute.php
+
+		-
 			message: '#^Parameter \#2 \$callable of class Patchlevel\\EventSourcing\\Message\\Translator\\ReplaceEventTranslator constructor expects callable\(Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\MessagePublished\)\: object, Closure\(Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileCreated\)\: Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileVisited given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/Unit/Message/Translator/ReplaceEventTranslatorTest.php
 
 		-
-			message: '#^Method class@anonymous/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest\.php\:278\:\:profileVisited\(\) has parameter \$message with no type specified\.$#'
+			message: '#^Method class@anonymous/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest\.php\:284\:\:profileVisited\(\) has parameter \$message with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -475,6 +475,12 @@ parameters:
 			path: tests/Unit/Fixture/ProfileInvalid.php
 
 		-
+			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\BrokenAutoInitializableProfile\:\:\$id is unused\.$#'
+			identifier: property.unused
+			count: 1
+			path: tests/Unit/Fixture/BrokenAutoInitializableProfile.php
+
+		-
 			message: '#^Property Patchlevel\\EventSourcing\\Tests\\Unit\\Fixture\\ProfileWithAggregateStream\:\:\$id is unused\.$#'
 			identifier: property.unused
 			count: 1

--- a/src/Console/Command/SubscriptionRemoveCommand.php
+++ b/src/Console/Command/SubscriptionRemoveCommand.php
@@ -20,6 +20,8 @@ final class SubscriptionRemoveCommand extends SubscriptionCommand
 {
     protected function configure(): void
     {
+        parent::configure();
+
         $this
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Set this parameter to execute this action without prompting');
     }

--- a/src/Serializer/AttributeEventTagExtractor.php
+++ b/src/Serializer/AttributeEventTagExtractor.php
@@ -10,9 +10,11 @@ use ReflectionClass;
 use Stringable;
 
 use function array_keys;
+use function array_map;
 use function hash;
 use function is_int;
 use function is_string;
+use function strval;
 
 /** @experimental */
 final class AttributeEventTagExtractor implements EventTagExtractor
@@ -63,6 +65,6 @@ final class AttributeEventTagExtractor implements EventTagExtractor
             $tags[$value] = true;
         }
 
-        return array_keys($tags);
+        return array_map(strval(...), array_keys($tags));
     }
 }

--- a/tests/Unit/Aggregate/InvalidAggregateStreamNameTest.php
+++ b/tests/Unit/Aggregate/InvalidAggregateStreamNameTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Aggregate;
+
+use Patchlevel\EventSourcing\Aggregate\InvalidAggregateStreamName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InvalidAggregateStreamName::class)]
+final class InvalidAggregateStreamNameTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new InvalidAggregateStreamName('foo');
+
+        self::assertSame(
+            'Invalid aggregate stream name "foo". Expected format is "[aggregateName]-[aggregateId]".',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Attribute/AnswerTest.php
+++ b/tests/Unit/Attribute/AnswerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\Answer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+#[CoversClass(Answer::class)]
+final class AnswerTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new Answer(stdClass::class);
+
+        self::assertSame(stdClass::class, $attribute->queryClass);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $attribute = new Answer();
+
+        self::assertNull($attribute->queryClass);
+    }
+}

--- a/tests/Unit/Attribute/BatchFlushTest.php
+++ b/tests/Unit/Attribute/BatchFlushTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\BatchFlush;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BatchFlush::class)]
+final class BatchFlushTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new BatchFlush(100);
+
+        self::assertSame(100, $attribute->afterMessages);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $attribute = new BatchFlush();
+
+        self::assertNull($attribute->afterMessages);
+    }
+}

--- a/tests/Unit/Attribute/HandleTest.php
+++ b/tests/Unit/Attribute/HandleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\Handle;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+#[CoversClass(Handle::class)]
+final class HandleTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new Handle(stdClass::class);
+
+        self::assertSame(stdClass::class, $attribute->commandClass);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $attribute = new Handle();
+
+        self::assertNull($attribute->commandClass);
+    }
+}

--- a/tests/Unit/Attribute/InjectTest.php
+++ b/tests/Unit/Attribute/InjectTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\Inject;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Inject::class)]
+final class InjectTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new Inject('foo');
+
+        self::assertSame('foo', $attribute->service);
+    }
+}

--- a/tests/Unit/Attribute/ProcessorTest.php
+++ b/tests/Unit/Attribute/ProcessorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\Processor;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Processor::class)]
+final class ProcessorTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new Processor('foo', 'bar', RunMode::FromBeginning);
+
+        self::assertSame('foo', $attribute->id);
+        self::assertSame('bar', $attribute->group);
+        self::assertSame(RunMode::FromBeginning, $attribute->runMode);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $attribute = new Processor('foo');
+
+        self::assertSame('foo', $attribute->id);
+        self::assertSame('processor', $attribute->group);
+        self::assertSame(RunMode::FromNow, $attribute->runMode);
+    }
+}

--- a/tests/Unit/Attribute/ProjectorTest.php
+++ b/tests/Unit/Attribute/ProjectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\Projector;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Projector::class)]
+final class ProjectorTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new Projector('foo', 'bar', RunMode::Once);
+
+        self::assertSame('foo', $attribute->id);
+        self::assertSame('bar', $attribute->group);
+        self::assertSame(RunMode::Once, $attribute->runMode);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $attribute = new Projector('foo');
+
+        self::assertSame('foo', $attribute->id);
+        self::assertSame('projector', $attribute->group);
+        self::assertSame(RunMode::FromBeginning, $attribute->runMode);
+    }
+}

--- a/tests/Unit/Attribute/RetryStrategyTest.php
+++ b/tests/Unit/Attribute/RetryStrategyTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\RetryStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RetryStrategy::class)]
+final class RetryStrategyTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new RetryStrategy('foo');
+
+        self::assertSame('foo', $attribute->name);
+    }
+}

--- a/tests/Unit/Attribute/SharedApplyContextTest.php
+++ b/tests/Unit/Attribute/SharedApplyContextTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\SharedApplyContext;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SharedApplyContext::class)]
+final class SharedApplyContextTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new SharedApplyContext([Profile::class]);
+
+        self::assertSame([Profile::class], $attribute->aggregates);
+    }
+}

--- a/tests/Unit/Attribute/StreamTest.php
+++ b/tests/Unit/Attribute/StreamTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Attribute;
+
+use Patchlevel\EventSourcing\Attribute\Stream;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Stream::class)]
+final class StreamTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $attribute = new Stream('foo');
+
+        self::assertSame('foo', $attribute->name);
+    }
+}

--- a/tests/Unit/CommandBus/Handler/AggregateIdNotFoundTest.php
+++ b/tests/Unit/CommandBus/Handler/AggregateIdNotFoundTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\CommandBus\Handler;
+
+use Patchlevel\EventSourcing\CommandBus\Handler\AggregateIdNotFound;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\CreateProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(AggregateIdNotFound::class)]
+final class AggregateIdNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateIdNotFound(CreateProfile::class);
+
+        self::assertSame(
+            sprintf('Missing `Id` Attribute in command %s', CreateProfile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/CommandBus/Handler/DefaultParameterResolverTest.php
+++ b/tests/Unit/CommandBus/Handler/DefaultParameterResolverTest.php
@@ -113,6 +113,35 @@ final class DefaultParameterResolverTest extends TestCase
         self::assertSame([$command], $result);
     }
 
+    public function testMissingTypeOnParameter(): void
+    {
+        $this->expectException(ServiceNotResolvable::class);
+
+        $class = new class () {
+            // phpcs:disable
+            /** @phpstan-ignore-next-line */
+            public function handle(stdClass $command, $foo): void
+            {
+            }
+            // phpcs:enable
+        };
+
+        $container = $this->createMock(ContainerInterface::class);
+
+        $resolver = new DefaultParameterResolver($container);
+
+        $command = new stdClass();
+
+        $result = [
+            ...$resolver->resolve(
+                new ReflectionMethod($class, 'handle'),
+                $command,
+            ),
+        ];
+
+        self::assertSame([$command], $result);
+    }
+
     public function testNoClass(): void
     {
         $this->expectException(ServiceNotResolvable::class);

--- a/tests/Unit/CommandBus/Handler/ServiceNotResolvableTest.php
+++ b/tests/Unit/CommandBus/Handler/ServiceNotResolvableTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\CommandBus\Handler;
+
+use Patchlevel\EventSourcing\CommandBus\Handler\ServiceNotResolvable;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function sprintf;
+
+#[CoversClass(ServiceNotResolvable::class)]
+final class ServiceNotResolvableTest extends TestCase
+{
+    public function testMissingType(): void
+    {
+        $exception = ServiceNotResolvable::missingType(Profile::class, 'foo');
+
+        self::assertSame(
+            sprintf('Missing type for property "foo" in class "%s"', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testTypeNotObject(): void
+    {
+        $exception = ServiceNotResolvable::typeNotObject(Profile::class, 'foo');
+
+        self::assertSame(
+            sprintf('Type for property "foo" in class "%s" must be object', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testMissingContainer(): void
+    {
+        $exception = ServiceNotResolvable::missingContainer();
+
+        self::assertSame('Container is not configured', $exception->getMessage());
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testMissingService(): void
+    {
+        $previous = new RuntimeException('service error');
+
+        $exception = ServiceNotResolvable::missingService(Profile::class, 'handle', 'foo', $previous);
+
+        self::assertSame(
+            sprintf('Missing service for parameter "foo" in "%s::handle" . Exception: service error', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Unit/CommandBus/Handler/UpdateAggregateHandlerTest.php
+++ b/tests/Unit/CommandBus/Handler/UpdateAggregateHandlerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\CommandBus\Handler;
 
+use InvalidArgumentException;
+use Patchlevel\EventSourcing\Attribute\Id;
 use Patchlevel\EventSourcing\CommandBus\Handler\AggregateIdNotFound;
 use Patchlevel\EventSourcing\CommandBus\Handler\DefaultParameterResolver;
 use Patchlevel\EventSourcing\CommandBus\Handler\UpdateAggregateHandler;
@@ -67,6 +69,31 @@ final class UpdateAggregateHandlerTest extends TestCase
         );
 
         $this->expectException(AggregateIdNotFound::class);
+
+        $handler->__invoke($command);
+    }
+
+    public function testIdPropertyNotIdentifier(): void
+    {
+        $repositoryManager = $this->createMock(RepositoryManager::class);
+
+        $handler = new UpdateAggregateHandler(
+            $repositoryManager,
+            ProfileWithHandler::class,
+            'changeName',
+            new DefaultParameterResolver(),
+        );
+
+        $command = new class ('123') {
+            public function __construct(
+                #[Id]
+                public readonly string $profileId,
+            ) {
+            }
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Id property must be an instance of AggregateRootId');
 
         $handler->__invoke($command);
     }

--- a/tests/Unit/CommandBus/HandlerFinderTest.php
+++ b/tests/Unit/CommandBus/HandlerFinderTest.php
@@ -141,4 +141,52 @@ final class HandlerFinderTest extends TestCase
             new HandlerReference(ChangeProfileName::class, 'handle', false),
         ], $result);
     }
+
+    public function testSkipMethodWithoutHandleAttribute(): void
+    {
+        $class = new class () {
+            public function handle(CreateProfile $command): void
+            {
+            }
+        };
+
+        $result = [...HandlerFinder::findInClass($class::class)];
+
+        self::assertSame([], $result);
+    }
+
+    public function testMissingType(): void
+    {
+        $this->expectException(InvalidHandleMethod::class);
+
+        $class = new class () {
+            // phpcs:disable
+            /** @phpstan-ignore-next-line */
+            #[Handle]
+            public function handle($command): void
+            {
+            }
+            // phpcs:enable
+        };
+
+        $result = [...HandlerFinder::findInClass($class::class)];
+
+        self::assertSame([], $result);
+    }
+
+    public function testUnionWithNotObjectType(): void
+    {
+        $this->expectException(InvalidHandleMethod::class);
+
+        $class = new class () {
+            #[Handle]
+            public function handle(CreateProfile|string $command): void
+            {
+            }
+        };
+
+        $result = [...HandlerFinder::findInClass($class::class)];
+
+        self::assertSame([], $result);
+    }
 }

--- a/tests/Unit/CommandBus/HandlerNotFoundTest.php
+++ b/tests/Unit/CommandBus/HandlerNotFoundTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\CommandBus;
+
+use Patchlevel\EventSourcing\CommandBus\HandlerNotFound;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\CreateProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(HandlerNotFound::class)]
+final class HandlerNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new HandlerNotFound(CreateProfile::class);
+
+        self::assertSame(
+            sprintf('Handler for command "%s" not found', CreateProfile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/CommandBus/HandlerReferenceTest.php
+++ b/tests/Unit/CommandBus/HandlerReferenceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\CommandBus;
+
+use Patchlevel\EventSourcing\CommandBus\HandlerReference;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\CreateProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HandlerReference::class)]
+final class HandlerReferenceTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $reference = new HandlerReference(CreateProfile::class, 'handle', true);
+
+        self::assertSame(CreateProfile::class, $reference->commandClass);
+        self::assertSame('handle', $reference->method);
+        self::assertTrue($reference->static);
+    }
+}

--- a/tests/Unit/CommandBus/InvalidHandleMethodTest.php
+++ b/tests/Unit/CommandBus/InvalidHandleMethodTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\CommandBus;
+
+use Patchlevel\EventSourcing\CommandBus\InvalidHandleMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(InvalidHandleMethod::class)]
+final class InvalidHandleMethodTest extends TestCase
+{
+    public function testNoParameters(): void
+    {
+        $exception = InvalidHandleMethod::noParameters(Profile::class, 'handle');
+
+        self::assertSame(
+            sprintf('Method "handle" in aggregate "%s" has no parameters', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testIncompatibleType(): void
+    {
+        $exception = InvalidHandleMethod::incompatibleType(Profile::class, 'handle');
+
+        self::assertSame(
+            sprintf('Method "handle" in aggregate "%s" has no compatible type', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/CommandBus/MultipleHandlersFoundTest.php
+++ b/tests/Unit/CommandBus/MultipleHandlersFoundTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\CommandBus;
+
+use Patchlevel\EventSourcing\CommandBus\MultipleHandlersFound;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\CreateProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(MultipleHandlersFound::class)]
+final class MultipleHandlersFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MultipleHandlersFound(CreateProfile::class);
+
+        self::assertSame(
+            sprintf('Multiple handlers found for command "%s"', CreateProfile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/CommandBus/ServiceNotFoundTest.php
+++ b/tests/Unit/CommandBus/ServiceNotFoundTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\CommandBus;
+
+use Patchlevel\EventSourcing\CommandBus\ServiceNotFound;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ServiceNotFound::class)]
+final class ServiceNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new ServiceNotFound('foo');
+
+        self::assertSame('service "foo" not found', $exception->getMessage());
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/CommandBus/SyncCommandBusTest.php
+++ b/tests/Unit/CommandBus/SyncCommandBusTest.php
@@ -9,6 +9,10 @@ use Patchlevel\EventSourcing\CommandBus\HandlerNotFound;
 use Patchlevel\EventSourcing\CommandBus\HandlerProvider;
 use Patchlevel\EventSourcing\CommandBus\MultipleHandlersFound;
 use Patchlevel\EventSourcing\CommandBus\SyncCommandBus;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
+use Patchlevel\EventSourcing\Repository\RepositoryManager;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\CreateProfile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -72,5 +76,79 @@ final class SyncCommandBusTest extends TestCase
         $commandBus->dispatch($command);
 
         self::assertSame($command, $handler->command);
+    }
+
+    public function testIterableHandlerProviders(): void
+    {
+        $command = new class {
+        };
+
+        $handler = new class {
+            public object|null $command = null;
+
+            public function __invoke(object $command): void
+            {
+                $this->command = $command;
+            }
+        };
+
+        $handlerProvider = $this->createMock(HandlerProvider::class);
+        $handlerProvider
+            ->expects($this->once())
+            ->method('handlerForCommand')
+            ->with($command::class)
+            ->willReturn([
+                new HandlerDescriptor($handler),
+            ]);
+
+        $commandBus = new SyncCommandBus([$handlerProvider]);
+
+        $commandBus->dispatch($command);
+
+        self::assertSame($command, $handler->command);
+    }
+
+    public function testHandlerGenerator(): void
+    {
+        $command = new class {
+        };
+
+        $handler = new class {
+            public object|null $command = null;
+
+            public function __invoke(object $command): void
+            {
+                $this->command = $command;
+            }
+        };
+
+        $handlerProvider = $this->createMock(HandlerProvider::class);
+        $handlerProvider
+            ->expects($this->once())
+            ->method('handlerForCommand')
+            ->with($command::class)
+            ->willReturnCallback(static function () use ($handler) {
+                yield new HandlerDescriptor($handler);
+            });
+
+        $commandBus = new SyncCommandBus($handlerProvider);
+
+        $commandBus->dispatch($command);
+
+        self::assertSame($command, $handler->command);
+    }
+
+    public function testCreateForAggregateHandlers(): void
+    {
+        $repositoryManager = $this->createMock(RepositoryManager::class);
+
+        $commandBus = SyncCommandBus::createForAggregateHandlers(
+            new AggregateRootRegistry([]),
+            $repositoryManager,
+        );
+
+        $this->expectException(HandlerNotFound::class);
+
+        $commandBus->dispatch(new CreateProfile(ProfileId::fromString('1'), 'foo'));
     }
 }

--- a/tests/Unit/Console/Command/ShowCommandTest.php
+++ b/tests/Unit/Console/Command/ShowCommandTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\ShowCommand;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
+use Patchlevel\EventSourcing\Serializer\EventSerializer;
+use Patchlevel\EventSourcing\Serializer\SerializedEvent;
+use Patchlevel\EventSourcing\Store\Header\PlayheadHeader;
+use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
+use Patchlevel\EventSourcing\Store\InMemoryStore;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(ShowCommand::class)]
+final class ShowCommandTest extends TestCase
+{
+    public function testShowNoMessages(): void
+    {
+        $store = new InMemoryStore();
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer->expects($this->never())->method('serialize');
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer->expects($this->never())->method('serialize');
+
+        $commandTester = new CommandTester(new ShowCommand($store, $eventSerializer, $headersSerializer));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('No more messages (0/0)', $display);
+    }
+
+    public function testShowOneMessage(): void
+    {
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new PlayheadHeader(1));
+
+        $store = new InMemoryStore([$message]);
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturn(new SerializedEvent('profile.created', '{"id":"1"}'));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturn('[]');
+
+        $commandTester = new CommandTester(new ShowCommand($store, $eventSerializer, $headersSerializer));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('profile.created', $display);
+        self::assertStringContainsString('profile-1', $display);
+        self::assertStringContainsString('No more messages (1/1)', $display);
+    }
+
+    public function testShowWithStream(): void
+    {
+        $message1 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new PlayheadHeader(1));
+        $message2 = Message::create(new ProfileCreated(ProfileId::fromString('2'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('other-1'))
+            ->withHeader(new PlayheadHeader(1));
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturn(new SerializedEvent('profile.created', '{"id":"1"}'));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturn('[]');
+
+        $commandTester = new CommandTester(new ShowCommand($store, $eventSerializer, $headersSerializer));
+        $commandTester->execute(['--stream' => 'profile-1']);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('profile-1', $display);
+        self::assertStringNotContainsString('other-1', $display);
+        self::assertStringContainsString('No more messages (1/1)', $display);
+    }
+
+    public function testShowWithLimitZero(): void
+    {
+        $message1 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new PlayheadHeader(1));
+        $message2 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new PlayheadHeader(2));
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturn(new SerializedEvent('profile.created', '{"id":"1"}'));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturn('[]');
+
+        $commandTester = new CommandTester(new ShowCommand($store, $eventSerializer, $headersSerializer));
+        $commandTester->execute(['--limit' => 0]);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('profile.created', $display);
+        self::assertStringNotContainsString('No more messages', $display);
+    }
+
+    public function testShowNextBatchConfirmed(): void
+    {
+        $message1 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new PlayheadHeader(1));
+        $message2 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new PlayheadHeader(2));
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturn(new SerializedEvent('profile.created', '{"id":"1"}'));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->exactly(2))
+            ->method('serialize')
+            ->willReturn('[]');
+
+        $commandTester = new CommandTester(new ShowCommand($store, $eventSerializer, $headersSerializer));
+        $commandTester->setInputs(['yes']);
+        $commandTester->execute(['--limit' => 1]);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('Show next 1 messages? (1/2)', $display);
+        self::assertStringContainsString('No more messages (2/2)', $display);
+    }
+
+    public function testShowNextBatchAborted(): void
+    {
+        $message1 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new PlayheadHeader(1));
+        $message2 = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new PlayheadHeader(2));
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturn(new SerializedEvent('profile.created', '{"id":"1"}'));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->willReturn('[]');
+
+        $commandTester = new CommandTester(new ShowCommand($store, $eventSerializer, $headersSerializer));
+        $commandTester->setInputs(['no']);
+        $commandTester->execute(['--limit' => 1]);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('Show next 1 messages? (1/2)', $display);
+        self::assertStringNotContainsString('No more messages', $display);
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionBootCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionBootCommandTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use LogicException;
+use Patchlevel\EventSourcing\Console\Command\SubscriptionBootCommand;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Boot;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Setup;
+use Patchlevel\EventSourcing\Subscription\Engine\ProcessedResult;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Tests\ReturnCallback;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionBootCommand::class)]
+final class SubscriptionBootCommandTest extends TestCase
+{
+    public function testBoot(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->with(new SubscriptionEngineCriteria(null, null))
+            ->willReturn([new Subscription('foo')]);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Boot(['foo'], null, 1000))
+            ->willReturn(new ProcessedResult(0, true));
+
+        $commandTester = new CommandTester(new SubscriptionBootCommand($engine));
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testBootWithSetup(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->with(new SubscriptionEngineCriteria(null, null))
+            ->willReturn([new Subscription('foo')]);
+        $engine
+            ->expects($this->exactly(2))
+            ->method('execute')
+            ->willReturnCallback(new ReturnCallback([
+                [[new Setup(['foo'], null)], new Result()],
+                [[new Boot(['foo'], null, 1000)], new ProcessedResult(0, true)],
+            ]));
+
+        $commandTester = new CommandTester(new SubscriptionBootCommand($engine));
+        $commandTester->execute(['--setup' => true]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testBootNotFinished(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->with(new SubscriptionEngineCriteria(null, null))
+            ->willReturn([new Subscription('foo')]);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Boot(['foo'], null, 1000))
+            ->willReturn(new ProcessedResult(0, false));
+
+        $commandTester = new CommandTester(new SubscriptionBootCommand($engine));
+        $commandTester->execute(['--run-limit' => 1]);
+
+        self::assertSame(1, $commandTester->getStatusCode());
+    }
+
+    public function testBootUnexpectedResult(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->with(new SubscriptionEngineCriteria(null, null))
+            ->willReturn([new Subscription('foo')]);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Boot(['foo'], null, 1000))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionBootCommand($engine));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Expected ProcessedResult');
+
+        $commandTester->execute([]);
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionPauseCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionPauseCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\SubscriptionPauseCommand;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Pause;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionPauseCommand::class)]
+final class SubscriptionPauseCommandTest extends TestCase
+{
+    public function testPause(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Pause(null, null))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionPauseCommand($engine));
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testPauseWithFilter(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Pause(['foo'], ['bar']))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionPauseCommand($engine));
+        $commandTester->execute(['--id' => ['foo'], '--group' => ['bar']]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionReactivateCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionReactivateCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\SubscriptionReactivateCommand;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Reactivate;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionReactivateCommand::class)]
+final class SubscriptionReactivateCommandTest extends TestCase
+{
+    public function testReactivate(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Reactivate(null, null))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionReactivateCommand($engine));
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testReactivateWithFilter(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Reactivate(['foo'], ['bar']))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionReactivateCommand($engine));
+        $commandTester->execute(['--id' => ['foo'], '--group' => ['bar']]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionRefreshCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionRefreshCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\SubscriptionRefreshCommand;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Refresh;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionRefreshCommand::class)]
+final class SubscriptionRefreshCommandTest extends TestCase
+{
+    public function testRefresh(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Refresh(null, null))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionRefreshCommand($engine));
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testRefreshWithFilter(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Refresh(['foo'], ['bar']))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionRefreshCommand($engine));
+        $commandTester->execute(['--id' => ['foo'], '--group' => ['bar']]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionRemoveCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionRemoveCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\SubscriptionRemoveCommand;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Remove;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionRemoveCommand::class)]
+final class SubscriptionRemoveCommandTest extends TestCase
+{
+    public function testRemoveWithForce(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Remove(null, null))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionRemoveCommand($engine));
+        $commandTester->execute(['--force' => true]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testRemoveWithIds(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Remove(['foo'], null))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionRemoveCommand($engine));
+        $commandTester->execute(['--id' => ['foo']]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testRemoveConfirmed(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Remove(null, null))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionRemoveCommand($engine));
+        $commandTester->setInputs(['yes']);
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testRemoveAborted(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->never())
+            ->method('execute');
+
+        $commandTester = new CommandTester(new SubscriptionRemoveCommand($engine));
+        $commandTester->setInputs(['no']);
+        $commandTester->execute([]);
+
+        self::assertSame(1, $commandTester->getStatusCode());
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionRunCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionRunCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\SubscriptionRunCommand;
+use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Store\SubscriptionStore;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Boot;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Remove;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Run;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Tests\ReturnCallback;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionRunCommand::class)]
+final class SubscriptionRunCommandTest extends TestCase
+{
+    public function testRun(): void
+    {
+        $store = $this->createMock(Store::class);
+
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->with(new SubscriptionEngineCriteria(null, null))
+            ->willReturn([new Subscription('foo')]);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Run(['foo'], null, 100))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionRunCommand($engine, $store));
+        $commandTester->execute(['--run-limit' => 1, '--sleep' => 0]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testRunWithRebuild(): void
+    {
+        $store = $this->createMock(Store::class);
+
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->with(new SubscriptionEngineCriteria(null, null))
+            ->willReturn([new Subscription('foo')]);
+        $engine
+            ->expects($this->exactly(3))
+            ->method('execute')
+            ->willReturnCallback(new ReturnCallback([
+                [[new Remove(['foo'], null)], new Result()],
+                [[new Boot(['foo'], null)], new Result()],
+                [[new Run(['foo'], null, 100)], new Result()],
+            ]));
+
+        $commandTester = new CommandTester(new SubscriptionRunCommand($engine, $store));
+        $commandTester->execute(['--run-limit' => 1, '--sleep' => 0, '--rebuild' => true]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testRunWithSubscriptionStore(): void
+    {
+        $store = $this->createMockForIntersectionOfInterfaces([Store::class, SubscriptionStore::class]);
+        $store
+            ->expects($this->once())
+            ->method('setupSubscription');
+        $store
+            ->expects($this->once())
+            ->method('supportSubscription')
+            ->willReturn(true);
+        $store
+            ->expects($this->once())
+            ->method('wait')
+            ->with(0);
+
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->with(new SubscriptionEngineCriteria(null, null))
+            ->willReturn([new Subscription('foo')]);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Run(['foo'], null, 100))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionRunCommand($engine, $store));
+        $commandTester->execute(['--run-limit' => 1, '--sleep' => 0]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionSetupCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionSetupCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\SubscriptionSetupCommand;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Setup;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionSetupCommand::class)]
+final class SubscriptionSetupCommandTest extends TestCase
+{
+    public function testSetup(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Setup(null, null, false))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionSetupCommand($engine));
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testSetupWithSkipBooting(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Setup(['foo'], ['bar'], true))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionSetupCommand($engine));
+        $commandTester->execute(['--id' => ['foo'], '--group' => ['bar'], '--skip-booting' => true]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionStatusCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionStatusCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\SubscriptionStatusCommand;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Status;
+use Patchlevel\EventSourcing\Subscription\Store\SubscriptionNotFound;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Subscription\SubscriptionError;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionStatusCommand::class)]
+final class SubscriptionStatusCommandTest extends TestCase
+{
+    public function testStatusList(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->willReturn([
+                new Subscription('foo'),
+                new Subscription('bar', 'other', RunMode::Once, Status::Active, 42),
+            ]);
+
+        $commandTester = new CommandTester(new SubscriptionStatusCommand($engine));
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('foo', $display);
+        self::assertStringContainsString('bar', $display);
+        self::assertStringContainsString('active', $display);
+        self::assertStringContainsString('42', $display);
+    }
+
+    public function testStatusDetail(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->willReturn([
+                new Subscription('foo', 'default', RunMode::FromBeginning, Status::Active, 42),
+            ]);
+
+        $commandTester = new CommandTester(new SubscriptionStatusCommand($engine));
+        $commandTester->execute(['id' => 'foo']);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('foo', $display);
+        self::assertStringContainsString('active', $display);
+        self::assertStringContainsString('42', $display);
+    }
+
+    public function testStatusDetailWithError(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->willReturn([
+                new Subscription(
+                    'foo',
+                    'default',
+                    RunMode::FromBeginning,
+                    Status::Error,
+                    42,
+                    SubscriptionError::fromThrowable(
+                        Status::Active,
+                        new RuntimeException('something went wrong'),
+                    ),
+                ),
+            ]);
+
+        $commandTester = new CommandTester(new SubscriptionStatusCommand($engine));
+        $commandTester->execute(['id' => 'foo']);
+
+        $display = $commandTester->getDisplay();
+
+        self::assertSame(0, $commandTester->getStatusCode());
+        self::assertStringContainsString('foo', $display);
+        self::assertStringContainsString('error', $display);
+        self::assertStringContainsString('something went wrong', $display);
+    }
+
+    public function testStatusNotFound(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('subscriptions')
+            ->willReturn([new Subscription('foo')]);
+
+        $commandTester = new CommandTester(new SubscriptionStatusCommand($engine));
+
+        $this->expectException(SubscriptionNotFound::class);
+
+        $commandTester->execute(['id' => 'bar']);
+    }
+}

--- a/tests/Unit/Console/Command/SubscriptionTeardownCommandTest.php
+++ b/tests/Unit/Console/Command/SubscriptionTeardownCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Console\Command;
+
+use Patchlevel\EventSourcing\Console\Command\SubscriptionTeardownCommand;
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Teardown;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(SubscriptionTeardownCommand::class)]
+final class SubscriptionTeardownCommandTest extends TestCase
+{
+    public function testTeardown(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Teardown(null, null))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionTeardownCommand($engine));
+        $commandTester->execute([]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function testTeardownWithFilter(): void
+    {
+        $engine = $this->createMock(SubscriptionEngine::class);
+        $engine
+            ->expects($this->once())
+            ->method('execute')
+            ->with(new Teardown(['foo'], ['bar']))
+            ->willReturn(new Result());
+
+        $commandTester = new CommandTester(new SubscriptionTeardownCommand($engine));
+        $commandTester->execute(['--id' => ['foo'], '--group' => ['bar']]);
+
+        self::assertSame(0, $commandTester->getStatusCode());
+    }
+}

--- a/tests/Unit/Console/InputHelperTest.php
+++ b/tests/Unit/Console/InputHelperTest.php
@@ -81,4 +81,156 @@ final class InputHelperTest extends TestCase
 
         InputHelper::nullableInt('foo');
     }
+
+    public function testValidIntFromInt(): void
+    {
+        self::assertSame(1, InputHelper::int(1));
+    }
+
+    public function testValidIntFromString(): void
+    {
+        self::assertSame(2, InputHelper::int('2'));
+    }
+
+    public function testInvalidIntFromBool(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "int" got "bool"');
+
+        InputHelper::int(true);
+    }
+
+    public function testInvalidIntFromNonNumericString(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "int" got "string"');
+
+        InputHelper::int('foo');
+    }
+
+    public function testValidPositiveInt(): void
+    {
+        self::assertSame(1, InputHelper::positiveInt(1));
+        self::assertSame(2, InputHelper::positiveInt('2'));
+    }
+
+    public function testInvalidPositiveIntFromBool(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int" got "bool"');
+
+        InputHelper::positiveInt(true);
+    }
+
+    public function testInvalidPositiveIntFromNonNumericString(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int" got "string"');
+
+        InputHelper::positiveInt('foo');
+    }
+
+    public function testInvalidPositiveIntFromZero(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int" got "int"');
+
+        InputHelper::positiveInt(0);
+    }
+
+    public function testValidNullablePositiveInt(): void
+    {
+        self::assertSame(1, InputHelper::nullablePositiveInt(1));
+        self::assertSame(2, InputHelper::nullablePositiveInt('2'));
+    }
+
+    public function testValidNullablePositiveIntIsNull(): void
+    {
+        self::assertSame(null, InputHelper::nullablePositiveInt(null));
+    }
+
+    public function testInvalidNullablePositiveIntFromBool(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int|null" got "bool"');
+
+        InputHelper::nullablePositiveInt(true);
+    }
+
+    public function testInvalidNullablePositiveIntFromNonNumericString(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int|null" got "string"');
+
+        InputHelper::nullablePositiveInt('foo');
+    }
+
+    public function testInvalidNullablePositiveIntFromZero(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int|null" got "int"');
+
+        InputHelper::nullablePositiveInt(0);
+    }
+
+    public function testValidPositiveIntOrZero(): void
+    {
+        self::assertSame(0, InputHelper::positiveIntOrZero(0));
+        self::assertSame(5, InputHelper::positiveIntOrZero('5'));
+    }
+
+    public function testInvalidPositiveIntOrZeroFromBool(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int|0" got "bool"');
+
+        InputHelper::positiveIntOrZero(true);
+    }
+
+    public function testInvalidPositiveIntOrZeroFromNonNumericString(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int|0" got "string"');
+
+        InputHelper::positiveIntOrZero('foo');
+    }
+
+    public function testInvalidPositiveIntOrZeroFromNegativeInt(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "positive-int|0" got "int"');
+
+        InputHelper::positiveIntOrZero(-1);
+    }
+
+    public function testValidNullableStringList(): void
+    {
+        self::assertSame(['foo', 'bar'], InputHelper::nullableStringList(['foo', 'bar']));
+    }
+
+    public function testValidNullableStringListIsNull(): void
+    {
+        self::assertSame(null, InputHelper::nullableStringList(null));
+    }
+
+    public function testValidNullableStringListFromEmptyArray(): void
+    {
+        self::assertSame(null, InputHelper::nullableStringList([]));
+    }
+
+    public function testInvalidNullableStringList(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "list<string>|null" got "string"');
+
+        InputHelper::nullableStringList('foo');
+    }
+
+    public function testInvalidNullableStringListElement(): void
+    {
+        $this->expectException(InvalidArgumentGiven::class);
+        $this->expectExceptionMessage('Invalid argument given: need type "list<string>|null" got "array"');
+
+        InputHelper::nullableStringList([1]);
+    }
 }

--- a/tests/Unit/Console/InvalidArgumentGivenTest.php
+++ b/tests/Unit/Console/InvalidArgumentGivenTest.php
@@ -18,6 +18,7 @@ final class InvalidArgumentGivenTest extends TestCase
 
         self::assertSame('Invalid argument given: need type "int" got "string"', $exception->getMessage());
         self::assertSame($expectedValue, $exception->value());
+        self::assertSame('int', $exception->need());
         self::assertSame(0, $exception->getCode());
     }
 }

--- a/tests/Unit/Console/OutputStyleTest.php
+++ b/tests/Unit/Console/OutputStyleTest.php
@@ -20,8 +20,10 @@ use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 #[CoversClass(OutputStyle::class)]
 final class OutputStyleTest extends TestCase
@@ -111,5 +113,101 @@ final class OutputStyleTest extends TestCase
         self::assertStringContainsString('{"id":"1","email":"foo@bar.com"}', $content);
         self::assertStringContainsString('stream', $content);
         self::assertStringContainsString('profile', $content);
+    }
+
+    public function testMessageWithSerializationError(): void
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $event = new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('foo@bar.com'),
+        );
+
+        $message = Message::create($event)
+            ->withHeader(new StreamNameHeader('profile-1'));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($event, [Encoder::OPTION_PRETTY_PRINT => true])
+            ->willThrowException(new RuntimeException('boom'));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer->expects($this->never())->method('serialize');
+
+        $console = new OutputStyle($input, $output);
+
+        $console->message(
+            $eventSerializer,
+            $headersSerializer,
+            $message,
+        );
+
+        $content = $output->fetch();
+
+        self::assertStringContainsString('Error while serializing event', $content);
+        self::assertStringContainsString('boom', $content);
+        self::assertStringNotContainsString('#0', $content);
+    }
+
+    public function testMessageWithSerializationErrorVeryVerbose(): void
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+        $event = new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('foo@bar.com'),
+        );
+
+        $message = Message::create($event)
+            ->withHeader(new StreamNameHeader('profile-1'));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($event, [Encoder::OPTION_PRETTY_PRINT => true])
+            ->willThrowException(new RuntimeException('boom'));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer->expects($this->never())->method('serialize');
+
+        $console = new OutputStyle($input, $output);
+
+        $console->message(
+            $eventSerializer,
+            $headersSerializer,
+            $message,
+        );
+
+        $content = $output->fetch();
+
+        self::assertStringContainsString('Error while serializing event', $content);
+        self::assertStringContainsString('1) boom', $content);
+        self::assertStringContainsString('#0', $content);
+    }
+
+    public function testThrowable(): void
+    {
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $error = new RuntimeException(
+            'outer error',
+            0,
+            new RuntimeException('inner error'),
+        );
+
+        $console = new OutputStyle($input, $output);
+        $console->throwable($error);
+
+        $content = $output->fetch();
+
+        self::assertStringContainsString('1) outer error', $content);
+        self::assertStringContainsString('2) inner error', $content);
     }
 }

--- a/tests/Unit/Cryptography/ExtensionDoctrineCipherKeyStoreTest.php
+++ b/tests/Unit/Cryptography/ExtensionDoctrineCipherKeyStoreTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Cryptography;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use Patchlevel\EventSourcing\Cryptography\ExtensionDoctrineCipherKeyStore;
+use Patchlevel\Hydrator\Extension\Cryptography\Cipher\CipherKey;
+use Patchlevel\Hydrator\Extension\Cryptography\Store\CipherKeyNotExists;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function base64_encode;
+
+#[CoversClass(ExtensionDoctrineCipherKeyStore::class)]
+final class ExtensionDoctrineCipherKeyStoreTest extends TestCase
+{
+    public function testGet(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->with('SELECT * FROM cryptography_keys WHERE id = :id', ['id' => 'foo'])
+            ->willReturn([
+                'id' => 'foo',
+                'subject_id' => 'profile-1',
+                'crypto_key' => base64_encode('secret-key'),
+                'crypto_method' => 'aes-256-gcm',
+                'created_at' => '2024-01-01 10:00:00',
+            ]);
+        $connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        self::assertEquals(
+            new CipherKey(
+                'foo',
+                'profile-1',
+                'secret-key',
+                'aes-256-gcm',
+                new DateTimeImmutable('2024-01-01 10:00:00'),
+            ),
+            $store->get('foo'),
+        );
+    }
+
+    public function testGetNotFound(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->with('SELECT * FROM cryptography_keys WHERE id = :id', ['id' => 'foo'])
+            ->willReturn(false);
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        $this->expectException(CipherKeyNotExists::class);
+
+        $store->get('foo');
+    }
+
+    public function testCurrentKeyFor(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->with('SELECT * FROM cryptography_keys WHERE subject_id = :subject_id', ['subject_id' => 'profile-1'])
+            ->willReturn([
+                'id' => 'foo',
+                'subject_id' => 'profile-1',
+                'crypto_key' => base64_encode('secret-key'),
+                'crypto_method' => 'aes-256-gcm',
+                'created_at' => '2024-01-01 10:00:00',
+            ]);
+        $connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        self::assertEquals(
+            new CipherKey(
+                'foo',
+                'profile-1',
+                'secret-key',
+                'aes-256-gcm',
+                new DateTimeImmutable('2024-01-01 10:00:00'),
+            ),
+            $store->currentKeyFor('profile-1'),
+        );
+    }
+
+    public function testCurrentKeyForNotFound(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->with('SELECT * FROM cryptography_keys WHERE subject_id = :subject_id', ['subject_id' => 'profile-1'])
+            ->willReturn(false);
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        $this->expectException(CipherKeyNotExists::class);
+
+        $store->currentKeyFor('profile-1');
+    }
+
+    public function testStore(): void
+    {
+        $platform = new SQLitePlatform();
+        $createdAt = new DateTimeImmutable('2024-01-01 10:00:00');
+        $expectedDate = Type::getType(Types::DATETIMETZ_IMMUTABLE)->convertToDatabaseValue($createdAt, $platform);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+        $connection
+            ->expects($this->once())
+            ->method('insert')
+            ->with('cryptography_keys', [
+                'id' => 'foo',
+                'subject_id' => 'profile-1',
+                'crypto_key' => base64_encode('secret-key'),
+                'crypto_method' => 'aes-256-gcm',
+                'created_at' => $expectedDate,
+            ]);
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        $store->store(new CipherKey(
+            'foo',
+            'profile-1',
+            'secret-key',
+            'aes-256-gcm',
+            $createdAt,
+        ));
+    }
+
+    public function testRemove(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('delete')
+            ->with('cryptography_keys', ['id' => 'foo']);
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        $store->remove('foo');
+    }
+
+    public function testRemoveWithSubjectId(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('delete')
+            ->with('cryptography_keys', ['subject_id' => 'profile-1']);
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        $store->removeWithSubjectId('profile-1');
+    }
+
+    public function testCustomTableName(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('delete')
+            ->with('my_keys', ['id' => 'foo']);
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection, 'my_keys');
+
+        $store->remove('foo');
+    }
+
+    public function testConfigureSchema(): void
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        $expectedSchema = new Schema();
+        $table = $expectedSchema->createTable('cryptography_keys');
+        $table->addColumn('id', 'string')
+            ->setNotnull(true)
+            ->setLength(255);
+        $table->addColumn('subject_id', 'string')
+            ->setNotnull(true)
+            ->setLength(255);
+        $table->addColumn('crypto_key', 'string')
+            ->setNotnull(true)
+            ->setLength(255);
+        $table->addColumn('crypto_method', 'string')
+            ->setNotnull(true)
+            ->setLength(255);
+        $table->addColumn('created_at', 'datetimetz_immutable')
+            ->setNotnull(true);
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['subject_id']);
+
+        $schema = new Schema();
+        $store->configureSchema($schema, $connection);
+
+        self::assertEquals($expectedSchema, $schema);
+    }
+
+    public function testConfigureSchemaWithDifferentDatabase(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db']);
+
+        $differentConnection = $this->createMock(Connection::class);
+        $differentConnection
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db2']);
+
+        $store = new ExtensionDoctrineCipherKeyStore($connection);
+
+        $schema = new Schema();
+        $store->configureSchema($schema, $differentConnection);
+
+        self::assertEquals(new Schema(), $schema);
+    }
+}

--- a/tests/Unit/Fixture/BrokenAutoInitializableProfile.php
+++ b/tests/Unit/Fixture/BrokenAutoInitializableProfile.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\AutoInitialize;
+use Patchlevel\EventSourcing\Attribute\Id;
+use stdClass;
+
+#[Aggregate('broken_auto_initializable_profile')]
+final class BrokenAutoInitializableProfile extends BasicAggregateRoot
+{
+    #[Id]
+    private ProfileId $id;
+
+    #[AutoInitialize]
+    public static function initialize(ProfileId $id): object
+    {
+        return new stdClass();
+    }
+}

--- a/tests/Unit/Fixture/ProfileWithAggregateStream.php
+++ b/tests/Unit/Fixture/ProfileWithAggregateStream.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Id;
+use Patchlevel\EventSourcing\Attribute\Stream;
+
+#[Aggregate('profile_with_aggregate_stream')]
+#[Stream(Profile::class)]
+final class ProfileWithAggregateStream extends BasicAggregateRoot
+{
+    #[Id]
+    private ProfileId $id;
+}

--- a/tests/Unit/Fixture/ProfileWithBrokenApplyStringType.php
+++ b/tests/Unit/Fixture/ProfileWithBrokenApplyStringType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Apply;
+use Patchlevel\EventSourcing\Attribute\Id;
+
+#[Aggregate('profile_with_broken_apply_string_type')]
+final class ProfileWithBrokenApplyStringType extends BasicAggregateRoot
+{
+    #[Id]
+    private ProfileId $id;
+
+    #[Apply]
+    protected function applyEvent(string $event): void
+    {
+    }
+}

--- a/tests/Unit/Fixture/ProfileWithBrokenApplyUnionIntersection.php
+++ b/tests/Unit/Fixture/ProfileWithBrokenApplyUnionIntersection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Countable;
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Apply;
+use Patchlevel\EventSourcing\Attribute\Id;
+use Stringable;
+
+#[Aggregate('profile_with_broken_apply_union_intersection')]
+final class ProfileWithBrokenApplyUnionIntersection extends BasicAggregateRoot
+{
+    #[Id]
+    private ProfileId $id;
+
+    #[Apply]
+    protected function applyEvent(ProfileCreated|(Countable&Stringable) $event): void
+    {
+    }
+}

--- a/tests/Unit/Fixture/ProfileWithBrokenPlayhead.php
+++ b/tests/Unit/Fixture/ProfileWithBrokenPlayhead.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Apply;
+use Patchlevel\EventSourcing\Attribute\Id;
+
+#[Aggregate('profile_with_broken_playhead')]
+final class ProfileWithBrokenPlayhead extends BasicAggregateRoot
+{
+    #[Id]
+    private ProfileId $id;
+
+    public function visit(): void
+    {
+        $this->recordThat(new ProfileVisited($this->id));
+    }
+
+    #[Apply]
+    protected function applyProfileCreated(ProfileCreated $event): void
+    {
+        $this->id = $event->profileId;
+    }
+
+    #[Apply]
+    protected function applyProfileVisited(ProfileVisited $event): void
+    {
+    }
+
+    public function playhead(): int
+    {
+        return parent::playhead() - 2;
+    }
+}

--- a/tests/Unit/Fixture/ProfileWithDuplicateApply.php
+++ b/tests/Unit/Fixture/ProfileWithDuplicateApply.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+use Patchlevel\EventSourcing\Attribute\Apply;
+use Patchlevel\EventSourcing\Attribute\Id;
+
+#[Aggregate('profile_with_duplicate_apply')]
+final class ProfileWithDuplicateApply extends BasicAggregateRoot
+{
+    #[Id]
+    private ProfileId $id;
+
+    #[Apply]
+    protected function applyA(ProfileCreated $event): void
+    {
+    }
+
+    #[Apply]
+    protected function applyB(ProfileCreated $event): void
+    {
+    }
+}

--- a/tests/Unit/Fixture/ProfileWithoutAggregateAttribute.php
+++ b/tests/Unit/Fixture/ProfileWithoutAggregateAttribute.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Id;
+
+final class ProfileWithoutAggregateAttribute extends BasicAggregateRoot
+{
+    #[Id]
+    private ProfileId $id;
+}

--- a/tests/Unit/Fixture/ProfileWithoutId.php
+++ b/tests/Unit/Fixture/ProfileWithoutId.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Fixture;
+
+use Patchlevel\EventSourcing\Aggregate\BasicAggregateRoot;
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+
+#[Aggregate('profile_without_id')]
+final class ProfileWithoutId extends BasicAggregateRoot
+{
+}

--- a/tests/Unit/Message/MissingHeadersTest.php
+++ b/tests/Unit/Message/MissingHeadersTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Message;
+
+use Patchlevel\EventSourcing\Message\MissingHeaders;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MissingHeaders::class)]
+final class MissingHeadersTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $headers = ['foo' => ['bar' => 'baz']];
+
+        $missingHeaders = new MissingHeaders($headers);
+
+        self::assertSame($headers, $missingHeaders->headers);
+    }
+}

--- a/tests/Unit/Message/Serializer/DefaultHeadersSerializerTest.php
+++ b/tests/Unit/Message/Serializer/DefaultHeadersSerializerTest.php
@@ -7,6 +7,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Message\Serializer;
 use DateTimeImmutable;
 use Patchlevel\EventSourcing\Message\MissingHeaders;
 use Patchlevel\EventSourcing\Message\Serializer\DefaultHeadersSerializer;
+use Patchlevel\EventSourcing\Message\Serializer\InvalidArgument;
 use Patchlevel\EventSourcing\Metadata\Message\AttributeMessageHeaderRegistryFactory;
 use Patchlevel\EventSourcing\Metadata\Message\HeaderNameNotRegistered;
 use Patchlevel\EventSourcing\Serializer\Encoder\JsonEncoder;
@@ -151,5 +152,31 @@ final class DefaultHeadersSerializerTest extends TestCase
             '{"streamName":{"streamName":"profile-1"},"removed":{"foo":"bar"},"alsoRemoved":{"baz":1}}',
             $content,
         );
+    }
+
+    public function testDeserializeWithInvalidHeaderPayload(): void
+    {
+        $serializer = new DefaultHeadersSerializer(
+            (new AttributeMessageHeaderRegistryFactory())->create([
+                __DIR__ . '/../../Fixture',
+            ]),
+            new MetadataHydrator(),
+            new JsonEncoder(),
+        );
+
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage('header payload must be an array');
+
+        $serializer->deserialize('{"streamName":"profile-1"}');
+    }
+
+    public function testCreateDefault(): void
+    {
+        $serializer = DefaultHeadersSerializer::createDefault();
+
+        $content = $serializer->serialize([new StreamNameHeader('profile-1')]);
+
+        self::assertEquals('{"streamName":{"streamName":"profile-1"}}', $content);
+        self::assertEquals([new StreamNameHeader('profile-1')], $serializer->deserialize($content));
     }
 }

--- a/tests/Unit/Message/StreamClosedTest.php
+++ b/tests/Unit/Message/StreamClosedTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Message;
+
+use Patchlevel\EventSourcing\Message\StreamClosed;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StreamClosed::class)]
+final class StreamClosedTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new StreamClosed();
+
+        self::assertSame('Stream is already closed.', $exception->getMessage());
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Message/StreamNotRewindableTest.php
+++ b/tests/Unit/Message/StreamNotRewindableTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Message;
+
+use Patchlevel\EventSourcing\Message\StreamNotRewindable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StreamNotRewindable::class)]
+final class StreamNotRewindableTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new StreamNotRewindable();
+
+        self::assertSame(
+            'Stream cannot be rewound because the underlying iterator is single-pass.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Message/StreamTest.php
+++ b/tests/Unit/Message/StreamTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Unit\Message;
 
 use DateTimeImmutable;
+use IteratorAggregate;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Message\Stream;
 use Patchlevel\EventSourcing\Message\StreamClosed;
@@ -20,6 +21,7 @@ use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Traversable;
 
 #[CoversClass(Stream::class)]
 final class StreamTest extends TestCase
@@ -150,6 +152,73 @@ final class StreamTest extends TestCase
         self::assertInstanceOf(ProfileVisited::class, $resultMessages[2]->event());
         self::assertSame('profile-2', $resultMessages[2]->header(StreamNameHeader::class)->streamName);
         self::assertSame(1, $resultMessages[2]->header(PlayheadHeader::class)->playhead);
+    }
+
+    public function testTraversable(): void
+    {
+        $message = Message::create(
+            new ProfileCreated(
+                ProfileId::fromString('foo'),
+                Email::fromString('info@patchlevel.de'),
+            ),
+        );
+
+        $messages = new class ([$message]) implements IteratorAggregate {
+            /** @param list<Message> $messages */
+            public function __construct(
+                private readonly array $messages,
+            ) {
+            }
+
+            public function getIterator(): Traversable
+            {
+                yield from $this->messages;
+            }
+        };
+
+        $stream = new Stream($messages);
+
+        self::assertSame([$message], $stream->toList());
+    }
+
+    public function testToArray(): void
+    {
+        $message = Message::create(
+            new ProfileCreated(
+                ProfileId::fromString('foo'),
+                Email::fromString('info@patchlevel.de'),
+            ),
+        );
+
+        $stream = new Stream([5 => $message]);
+
+        self::assertSame([5 => $message], $stream->toArray());
+    }
+
+    public function testChunk(): void
+    {
+        $messages = $this->messages();
+
+        $stream = new Stream($messages);
+
+        $chunks = [...$stream->chunk(2)];
+
+        self::assertCount(3, $chunks);
+        self::assertCount(2, $chunks[0]->toList());
+        self::assertCount(2, $chunks[1]->toList());
+        self::assertCount(1, $chunks[2]->toList());
+    }
+
+    public function testChunkWithExactMultiple(): void
+    {
+        $messages = $this->messages();
+
+        $stream = new Stream([$messages[0], $messages[1]]);
+
+        $chunks = [...$stream->chunk(2)];
+
+        self::assertCount(1, $chunks);
+        self::assertCount(2, $chunks[0]->toList());
     }
 
     public function testTransformIsSinglePass(): void

--- a/tests/Unit/Message/StreamTest.php
+++ b/tests/Unit/Message/StreamTest.php
@@ -170,6 +170,7 @@ final class StreamTest extends TestCase
             ) {
             }
 
+            /** @return Traversable<int, Message> */
             public function getIterator(): Traversable
             {
                 yield from $this->messages;

--- a/tests/Unit/Message/Translator/ExtractEventTagTranslatorTest.php
+++ b/tests/Unit/Message/Translator/ExtractEventTagTranslatorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Message\Translator;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Translator\ExtractEventTagTranslator;
+use Patchlevel\EventSourcing\Serializer\EventTagExtractor;
+use Patchlevel\EventSourcing\Store\Header\TagsHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExtractEventTagTranslator::class)]
+final class ExtractEventTagTranslatorTest extends TestCase
+{
+    public function testExtractTags(): void
+    {
+        $event = new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $message = Message::create($event);
+
+        $extractor = $this->createMock(EventTagExtractor::class);
+        $extractor
+            ->expects($this->once())
+            ->method('extract')
+            ->with($event)
+            ->willReturn(['profile-1']);
+
+        $translator = new ExtractEventTagTranslator($extractor);
+
+        $result = $translator($message);
+
+        self::assertCount(1, $result);
+        self::assertSame(['profile-1'], $result[0]->header(TagsHeader::class)->tags);
+    }
+
+    public function testOverwriteAlreadyTagged(): void
+    {
+        $event = new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $message = Message::create($event)
+            ->withHeader(new TagsHeader(['old']));
+
+        $extractor = $this->createMock(EventTagExtractor::class);
+        $extractor
+            ->expects($this->once())
+            ->method('extract')
+            ->with($event)
+            ->willReturn(['profile-1']);
+
+        $translator = new ExtractEventTagTranslator($extractor);
+
+        $result = $translator($message);
+
+        self::assertCount(1, $result);
+        self::assertSame(['profile-1'], $result[0]->header(TagsHeader::class)->tags);
+    }
+
+    public function testSkipAlreadyTagged(): void
+    {
+        $event = new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('info@patchlevel.de'),
+        );
+
+        $message = Message::create($event)
+            ->withHeader(new TagsHeader(['old']));
+
+        $extractor = $this->createMock(EventTagExtractor::class);
+        $extractor
+            ->expects($this->never())
+            ->method('extract');
+
+        $translator = new ExtractEventTagTranslator($extractor, skipAlreadyTagged: true);
+
+        $result = $translator($message);
+
+        self::assertSame([$message], $result);
+        self::assertSame(['old'], $result[0]->header(TagsHeader::class)->tags);
+    }
+}

--- a/tests/Unit/Message/Translator/RecalculatePlayheadTranslatorTest.php
+++ b/tests/Unit/Message/Translator/RecalculatePlayheadTranslatorTest.php
@@ -115,4 +115,20 @@ final class RecalculatePlayheadTranslatorTest extends TestCase
         self::assertSame('profile', $result[0]->header(StreamNameHeader::class)->streamName);
         self::assertSame(1, $result[0]->header(PlayheadHeader::class)->playhead);
     }
+
+    public function testPassthroughWithoutHeaders(): void
+    {
+        $translator = new RecalculatePlayheadTranslator();
+
+        $message = Message::create(
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('hallo@patchlevel.de'),
+            ),
+        );
+
+        $result = $translator($message);
+
+        self::assertSame([$message], $result);
+    }
 }

--- a/tests/Unit/Message/Translator/UntilEventTranslatorTest.php
+++ b/tests/Unit/Message/Translator/UntilEventTranslatorTest.php
@@ -52,4 +52,20 @@ final class UntilEventTranslatorTest extends TestCase
 
         self::assertSame([], $result);
     }
+
+    public function testPassthroughWithoutRecordedOnHeader(): void
+    {
+        $translator = new UntilEventTranslator(new DateTimeImmutable('2020-01-01 00:00:00'));
+
+        $message = Message::create(
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('info@patchlevel.de'),
+            ),
+        );
+
+        $result = $translator($message);
+
+        self::assertSame([$message], $result);
+    }
 }

--- a/tests/Unit/Metadata/Aggregate/AggregateRootAlreadyInRegistryTest.php
+++ b/tests/Unit/Metadata/Aggregate/AggregateRootAlreadyInRegistryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootAlreadyInRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AggregateRootAlreadyInRegistry::class)]
+final class AggregateRootAlreadyInRegistryTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateRootAlreadyInRegistry('profile');
+
+        self::assertSame(
+            'The aggregate name "profile" is already used in the registry. Maybe you defined 2 aggregates with the same name.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AggregateRootClassNotRegisteredTest.php
+++ b/tests/Unit/Metadata/Aggregate/AggregateRootClassNotRegisteredTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootClassNotRegistered;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(AggregateRootClassNotRegistered::class)]
+final class AggregateRootClassNotRegisteredTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateRootClassNotRegistered(Profile::class);
+
+        self::assertSame(
+            sprintf('Aggregate root class "%s" is not registered', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AggregateRootIdNotFoundTest.php
+++ b/tests/Unit/Metadata/Aggregate/AggregateRootIdNotFoundTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootIdNotFound;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(AggregateRootIdNotFound::class)]
+final class AggregateRootIdNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateRootIdNotFound(Profile::class);
+
+        self::assertSame(
+            sprintf('class %s has no property marked as aggregate root id', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AggregateRootMetadataAwareMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/AggregateRootMetadataAwareMetadataFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Aggregate\AggregateRoot;
+use Patchlevel\EventSourcing\Identifier\Identifier;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadataAwareMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateWithoutMetadataAware;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(AggregateRootMetadataAwareMetadataFactory::class)]
+final class AggregateRootMetadataAwareMetadataFactoryTest extends TestCase
+{
+    public function testMetadata(): void
+    {
+        $factory = new AggregateRootMetadataAwareMetadataFactory();
+
+        $metadata = $factory->metadata(Profile::class);
+
+        self::assertSame(Profile::class, $metadata->className);
+        self::assertSame('profile', $metadata->name);
+    }
+
+    public function testMetadataWithoutMetadataAware(): void
+    {
+        $aggregate = new class implements AggregateRoot {
+            public function aggregateRootId(): Identifier
+            {
+                throw new RuntimeException('not implemented');
+            }
+
+            /** @param iterable<object> $events */
+            public function catchUp(iterable $events): void
+            {
+            }
+
+            /** @return list<object> */
+            public function releaseEvents(): array
+            {
+                return [];
+            }
+
+            /**
+             * @param iterable<object> $events
+             * @param 0|positive-int   $startPlayhead
+             */
+            public static function createFromEvents(iterable $events, int $startPlayhead = 0): static
+            {
+                throw new RuntimeException('not implemented');
+            }
+
+            public function playhead(): int
+            {
+                return 0;
+            }
+        };
+
+        $factory = new AggregateRootMetadataAwareMetadataFactory();
+
+        $this->expectException(AggregateWithoutMetadataAware::class);
+
+        $factory->metadata($aggregate::class);
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AggregateRootMetadataTest.php
+++ b/tests/Unit/Metadata/Aggregate/AggregateRootMetadataTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadata;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\MissingAggregateIdForStreamName;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\Snapshot;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AggregateRootMetadata::class)]
+final class AggregateRootMetadataTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $snapshot = new Snapshot('default');
+
+        $metadata = new AggregateRootMetadata(
+            Profile::class,
+            'profile',
+            'id',
+            [ProfileCreated::class => 'applyProfileCreated'],
+            [ProfileCreated::class => true],
+            false,
+            $snapshot,
+        );
+
+        self::assertSame(Profile::class, $metadata->className);
+        self::assertSame('profile', $metadata->name);
+        self::assertSame('id', $metadata->idProperty);
+        self::assertSame([ProfileCreated::class => 'applyProfileCreated'], $metadata->applyMethods);
+        self::assertSame([ProfileCreated::class => true], $metadata->suppressEvents);
+        self::assertFalse($metadata->suppressAll);
+        self::assertSame($snapshot, $metadata->snapshot);
+        self::assertSame('profile-{id}', $metadata->streamName);
+        self::assertNull($metadata->autoInitializeMethod);
+    }
+
+    public function testStreamNameWithAggregateId(): void
+    {
+        $metadata = new AggregateRootMetadata(
+            Profile::class,
+            'profile',
+            'id',
+            [],
+            [],
+            false,
+            null,
+        );
+
+        self::assertSame('profile-1', $metadata->streamName('1'));
+    }
+
+    public function testStreamNameWithoutAggregateId(): void
+    {
+        $metadata = new AggregateRootMetadata(
+            Profile::class,
+            'profile',
+            'id',
+            [],
+            [],
+            false,
+            null,
+            'profile',
+        );
+
+        self::assertSame('profile', $metadata->streamName());
+    }
+
+    public function testStreamNameMissingAggregateId(): void
+    {
+        $metadata = new AggregateRootMetadata(
+            Profile::class,
+            'profile',
+            'id',
+            [],
+            [],
+            false,
+            null,
+        );
+
+        $this->expectException(MissingAggregateIdForStreamName::class);
+
+        $metadata->streamName();
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AggregateRootNameNotRegisteredTest.php
+++ b/tests/Unit/Metadata/Aggregate/AggregateRootNameNotRegisteredTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootNameNotRegistered;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AggregateRootNameNotRegistered::class)]
+final class AggregateRootNameNotRegisteredTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateRootNameNotRegistered('profile');
+
+        self::assertSame(
+            'Aggregate root name "profile" is not registered',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AggregateWithoutMetadataAwareTest.php
+++ b/tests/Unit/Metadata/Aggregate/AggregateWithoutMetadataAwareTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateWithoutMetadataAware;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(AggregateWithoutMetadataAware::class)]
+final class AggregateWithoutMetadataAwareTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateWithoutMetadataAware(Profile::class);
+
+        self::assertSame(
+            sprintf('The class "%s" does not implements AggregateRootMetadataAware', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/ArgumentTypeIsMissingTest.php
+++ b/tests/Unit/Metadata/Aggregate/ArgumentTypeIsMissingTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\ArgumentTypeIsMissing;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ArgumentTypeIsMissing::class)]
+final class ArgumentTypeIsMissingTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new ArgumentTypeIsMissing('applyProfileCreated');
+
+        self::assertSame(
+            'The method [applyProfileCreated] is no type specified.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/ArgumentTypeIsNotAClassTest.php
+++ b/tests/Unit/Metadata/Aggregate/ArgumentTypeIsNotAClassTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\ArgumentTypeIsNotAClass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ArgumentTypeIsNotAClass::class)]
+final class ArgumentTypeIsNotAClassTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new ArgumentTypeIsNotAClass('applyProfileCreated', 'string');
+
+        self::assertSame(
+            'The type [string] is not a valid class for method [applyProfileCreated].',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/AttributeAggregateMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/AttributeAggregateMetadataFactoryTest.php
@@ -4,21 +4,34 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
 
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootIdNotFound;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\ArgumentTypeIsMissing;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\ArgumentTypeIsNotAClass;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\ClassIsNotAnAggregate;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\DuplicateApplyMethod;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\DuplicateEmptyApplyAttribute;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\MixedApplyAttributeUsage;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\Snapshot;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\AutoInitializableProfile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\MessageDeleted;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\NameChanged;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithAggregateStream;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyBothUsage;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyIntersection;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyMultipleApply;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyNoType;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyStringType;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenApplyUnionIntersection;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithDuplicateApply;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithEmptyApply;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithoutAggregateAttribute;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithoutId;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithSharedApplyContext;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithSnapshot;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithStream;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithSuppressAll;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\SplittingEvent;
@@ -69,7 +82,7 @@ final class AttributeAggregateMetadataFactoryTest extends TestCase
         self::assertSame([], $metadata->suppressEvents);
     }
 
-    public function streamName(): void
+    public function testStreamName(): void
     {
         $metadataFactory = new AttributeAggregateRootMetadataFactory();
         $metadata = $metadataFactory->metadata(ProfileWithStream::class);
@@ -92,6 +105,14 @@ final class AttributeAggregateMetadataFactoryTest extends TestCase
         $this->expectException(ArgumentTypeIsMissing::class);
 
         $metadataFactory->metadata(ProfileWithBrokenApplyIntersection::class);
+    }
+
+    public function testBrokenApplyWithUnionIntersectionType(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+        $this->expectException(ArgumentTypeIsMissing::class);
+
+        $metadataFactory->metadata(ProfileWithBrokenApplyUnionIntersection::class);
     }
 
     public function testBrokenApplyWithMultipleApply(): void
@@ -126,5 +147,83 @@ final class AttributeAggregateMetadataFactoryTest extends TestCase
 
         self::assertFalse($metadata->suppressAll);
         self::assertSame([ProfileCreated::class => true], $metadata->suppressEvents);
+    }
+
+    public function testMetadataCache(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+
+        self::assertSame(
+            $metadataFactory->metadata(Profile::class),
+            $metadataFactory->metadata(Profile::class),
+        );
+    }
+
+    public function testNotAnAggregate(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+
+        $this->expectException(ClassIsNotAnAggregate::class);
+
+        $metadataFactory->metadata(ProfileWithoutAggregateAttribute::class);
+    }
+
+    public function testAggregateRootIdNotFound(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+
+        $this->expectException(AggregateRootIdNotFound::class);
+
+        $metadataFactory->metadata(ProfileWithoutId::class);
+    }
+
+    public function testSnapshot(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+        $metadata = $metadataFactory->metadata(ProfileWithSnapshot::class);
+
+        self::assertEquals(new Snapshot('memory', 2, '1'), $metadata->snapshot);
+    }
+
+    public function testStreamNameFromString(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+        $metadata = $metadataFactory->metadata(ProfileWithStream::class);
+
+        self::assertSame('other-{id}', $metadata->streamName);
+    }
+
+    public function testStreamNameFromAggregateClass(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+        $metadata = $metadataFactory->metadata(ProfileWithAggregateStream::class);
+
+        self::assertSame('profile-{id}', $metadata->streamName);
+    }
+
+    public function testAutoInitializeMethod(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+        $metadata = $metadataFactory->metadata(AutoInitializableProfile::class);
+
+        self::assertSame('initialize', $metadata->autoInitializeMethod);
+    }
+
+    public function testApplyWithNotAClassType(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+
+        $this->expectException(ArgumentTypeIsNotAClass::class);
+
+        $metadataFactory->metadata(ProfileWithBrokenApplyStringType::class);
+    }
+
+    public function testDuplicateApplyMethod(): void
+    {
+        $metadataFactory = new AttributeAggregateRootMetadataFactory();
+
+        $this->expectException(DuplicateApplyMethod::class);
+
+        $metadataFactory->metadata(ProfileWithDuplicateApply::class);
     }
 }

--- a/tests/Unit/Metadata/Aggregate/AttributeAggregateRootRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/AttributeAggregateRootRegistryFactoryTest.php
@@ -6,6 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
 
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootAlreadyInRegistry;
 use Patchlevel\EventSourcing\Metadata\AggregateRoot\AttributeAggregateRootRegistryFactory;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\NoAggregateRoot;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Message;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -32,5 +33,13 @@ final class AttributeAggregateRootRegistryFactoryTest extends TestCase
 
         $factory = new AttributeAggregateRootRegistryFactory();
         $factory->create([__DIR__ . '/Fixture']);
+    }
+
+    public function testCreateRegistryWithNonAggregateClass(): void
+    {
+        $this->expectException(NoAggregateRoot::class);
+
+        $factory = new AttributeAggregateRootRegistryFactory();
+        $factory->create([__DIR__ . '/InvalidFixture']);
     }
 }

--- a/tests/Unit/Metadata/Aggregate/ClassIsNotAnAggregateTest.php
+++ b/tests/Unit/Metadata/Aggregate/ClassIsNotAnAggregateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\ClassIsNotAnAggregate;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(ClassIsNotAnAggregate::class)]
+final class ClassIsNotAnAggregateTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new ClassIsNotAnAggregate(Profile::class);
+
+        self::assertSame(
+            sprintf('class %s is not an aggregate root', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/DuplicateApplyMethodTest.php
+++ b/tests/Unit/Metadata/Aggregate/DuplicateApplyMethodTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\DuplicateApplyMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateApplyMethod::class)]
+final class DuplicateApplyMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateApplyMethod(Profile::class, ProfileCreated::class, 'applyA', 'applyB');
+
+        self::assertSame(
+            sprintf('Two methods "applyA" and "applyB" on the aggregate "%s" want to apply the same event "%s". Only one method can apply an event.', Profile::class, ProfileCreated::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/DuplicateEmptyApplyAttributeTest.php
+++ b/tests/Unit/Metadata/Aggregate/DuplicateEmptyApplyAttributeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\DuplicateEmptyApplyAttribute;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DuplicateEmptyApplyAttribute::class)]
+final class DuplicateEmptyApplyAttributeTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateEmptyApplyAttribute('apply');
+
+        self::assertSame(
+            'The method [apply] has multiple apply attributes given without an event name which is not allowed.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/InvalidFixture/NotAggregate.php
+++ b/tests/Unit/Metadata/Aggregate/InvalidFixture/NotAggregate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate\InvalidFixture;
+
+use Patchlevel\EventSourcing\Attribute\Aggregate;
+
+#[Aggregate('not_aggregate')]
+final class NotAggregate
+{
+}

--- a/tests/Unit/Metadata/Aggregate/MissingAggregateIdForStreamNameTest.php
+++ b/tests/Unit/Metadata/Aggregate/MissingAggregateIdForStreamNameTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\MissingAggregateIdForStreamName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MissingAggregateIdForStreamName::class)]
+final class MissingAggregateIdForStreamNameTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MissingAggregateIdForStreamName('profile-{id}');
+
+        self::assertSame(
+            'Missing aggregate id for stream name "profile-{id}"',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/MissingDataSubjectIdTest.php
+++ b/tests/Unit/Metadata/Aggregate/MissingDataSubjectIdTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\MissingDataSubjectId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(MissingDataSubjectId::class)]
+final class MissingDataSubjectIdTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MissingDataSubjectId(Profile::class);
+
+        self::assertSame(
+            sprintf('Personal data cannot used without a subject id. Please provide a subject id for %s.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/MixedApplyAttributeUsageTest.php
+++ b/tests/Unit/Metadata/Aggregate/MixedApplyAttributeUsageTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\MixedApplyAttributeUsage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MixedApplyAttributeUsage::class)]
+final class MixedApplyAttributeUsageTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MixedApplyAttributeUsage('apply');
+
+        self::assertSame(
+            'The method [apply] has at least one apply attribute with an event name and one without which is not allowed.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/MultipleDataSubjectIdTest.php
+++ b/tests/Unit/Metadata/Aggregate/MultipleDataSubjectIdTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\MultipleDataSubjectId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MultipleDataSubjectId::class)]
+final class MultipleDataSubjectIdTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MultipleDataSubjectId('foo', 'bar');
+
+        self::assertSame(
+            'Multiple data subject id found: foo and bar.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/NoAggregateRootTest.php
+++ b/tests/Unit/Metadata/Aggregate/NoAggregateRootTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\NoAggregateRoot;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(NoAggregateRoot::class)]
+final class NoAggregateRootTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new NoAggregateRoot(Profile::class);
+
+        self::assertSame(
+            sprintf('The class "%s" does not implement AggregateRoot', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/Psr16AggregateRootMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/Psr16AggregateRootMetadataFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadata;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\Psr16AggregateRootMetadataFactory;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+#[CoversClass(Psr16AggregateRootMetadataFactory::class)]
+final class Psr16AggregateRootMetadataFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new AggregateRootMetadata(Profile::class, 'profile', 'id', [], [], false, null);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with(Profile::class)
+            ->willReturn($value);
+        $cache
+            ->expects($this->never())
+            ->method('set');
+
+        $innerFactory = $this->createMock(AggregateRootMetadataFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('metadata');
+
+        $factory = new Psr16AggregateRootMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(Profile::class));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new AggregateRootMetadata(Profile::class, 'profile', 'id', [], [], false, null);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with(Profile::class)
+            ->willReturn(null);
+        $cache
+            ->expects($this->once())
+            ->method('set')
+            ->with(Profile::class, $value)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(AggregateRootMetadataFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('metadata')
+            ->with(Profile::class)
+            ->willReturn($value);
+
+        $factory = new Psr16AggregateRootMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(Profile::class));
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/Psr16AggregateRootRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/Psr16AggregateRootRegistryFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistryFactory;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\Psr16AggregateRootRegistryFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+#[CoversClass(Psr16AggregateRootRegistryFactory::class)]
+final class Psr16AggregateRootRegistryFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new AggregateRootRegistry([]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with('aggregate_root_registry')
+            ->willReturn($value);
+        $cache
+            ->expects($this->never())
+            ->method('set');
+
+        $innerFactory = $this->createMock(AggregateRootRegistryFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('create');
+
+        $factory = new Psr16AggregateRootRegistryFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->create(['/foo']));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new AggregateRootRegistry([]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with('aggregate_root_registry')
+            ->willReturn(null);
+        $cache
+            ->expects($this->once())
+            ->method('set')
+            ->with('aggregate_root_registry', $value)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(AggregateRootRegistryFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with(['/foo'])
+            ->willReturn($value);
+
+        $factory = new Psr16AggregateRootRegistryFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->create(['/foo']));
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/Psr6AggregateRootMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/Psr6AggregateRootMetadataFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadata;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\Psr6AggregateRootMetadataFactory;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+#[CoversClass(Psr6AggregateRootMetadataFactory::class)]
+final class Psr6AggregateRootMetadataFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new AggregateRootMetadata(Profile::class, 'profile', 'id', [], [], false, null);
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($value);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with(Profile::class)
+            ->willReturn($item);
+        $cache
+            ->expects($this->never())
+            ->method('save');
+
+        $innerFactory = $this->createMock(AggregateRootMetadataFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('metadata');
+
+        $factory = new Psr6AggregateRootMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(Profile::class));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new AggregateRootMetadata(Profile::class, 'profile', 'id', [], [], false, null);
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(false);
+        $item
+            ->expects($this->once())
+            ->method('set')
+            ->with($value)
+            ->willReturnSelf();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with(Profile::class)
+            ->willReturn($item);
+        $cache
+            ->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(AggregateRootMetadataFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('metadata')
+            ->with(Profile::class)
+            ->willReturn($value);
+
+        $factory = new Psr6AggregateRootMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(Profile::class));
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/Psr6AggregateRootRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Aggregate/Psr6AggregateRootRegistryFactoryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistry;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\AggregateRootRegistryFactory;
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\Psr6AggregateRootRegistryFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+#[CoversClass(Psr6AggregateRootRegistryFactory::class)]
+final class Psr6AggregateRootRegistryFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new AggregateRootRegistry([]);
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($value);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('aggregate_root_registry')
+            ->willReturn($item);
+        $cache
+            ->expects($this->never())
+            ->method('save');
+
+        $innerFactory = $this->createMock(AggregateRootRegistryFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('create');
+
+        $factory = new Psr6AggregateRootRegistryFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->create(['/foo']));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new AggregateRootRegistry([]);
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(false);
+        $item
+            ->expects($this->once())
+            ->method('set')
+            ->with($value)
+            ->willReturnSelf();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('aggregate_root_registry')
+            ->willReturn($item);
+        $cache
+            ->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(AggregateRootRegistryFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with(['/foo'])
+            ->willReturn($value);
+
+        $factory = new Psr6AggregateRootRegistryFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->create(['/foo']));
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/SnapshotTest.php
+++ b/tests/Unit/Metadata/Aggregate/SnapshotTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\Snapshot;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Snapshot::class)]
+final class SnapshotTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $snapshot = new Snapshot('default', 10, '1');
+
+        self::assertSame('default', $snapshot->store);
+        self::assertSame(10, $snapshot->batch);
+        self::assertSame('1', $snapshot->version);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $snapshot = new Snapshot('default');
+
+        self::assertSame('default', $snapshot->store);
+        self::assertNull($snapshot->batch);
+        self::assertNull($snapshot->version);
+    }
+}

--- a/tests/Unit/Metadata/Aggregate/SubjectIdAndPersonalDataConflictTest.php
+++ b/tests/Unit/Metadata/Aggregate/SubjectIdAndPersonalDataConflictTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Aggregate;
+
+use Patchlevel\EventSourcing\Metadata\AggregateRoot\SubjectIdAndPersonalDataConflict;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(SubjectIdAndPersonalDataConflict::class)]
+final class SubjectIdAndPersonalDataConflictTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new SubjectIdAndPersonalDataConflict(Profile::class, 'email');
+
+        self::assertSame(
+            sprintf('Personal data cannot be used as a subject id. Fix subject id for %s::email.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/ClassFinderTest.php
+++ b/tests/Unit/Metadata/ClassFinderTest.php
@@ -8,6 +8,13 @@ use Patchlevel\EventSourcing\Metadata\ClassFinder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function symlink;
+use function sys_get_temp_dir;
+use function unlink;
+
 #[CoversClass(ClassFinder::class)]
 final class ClassFinderTest extends TestCase
 {
@@ -17,6 +24,35 @@ final class ClassFinderTest extends TestCase
         $classes = $finder->findClassNames([__DIR__ . '/../../../docs']);
 
         self::assertCount(0, $classes);
+    }
+
+    public function testNoPaths(): void
+    {
+        $finder = new ClassFinder();
+        $classes = $finder->findClassNames([]);
+
+        self::assertCount(0, $classes);
+    }
+
+    public function testBrokenSymlink(): void
+    {
+        $dir = sys_get_temp_dir() . '/class-finder-broken-symlink';
+
+        if (!is_dir($dir)) {
+            mkdir($dir);
+        }
+
+        symlink($dir . '/missing-target.php', $dir . '/broken.php');
+
+        try {
+            $finder = new ClassFinder();
+            $classes = $finder->findClassNames([$dir]);
+
+            self::assertCount(0, $classes);
+        } finally {
+            unlink($dir . '/broken.php');
+            rmdir($dir);
+        }
     }
 
     public function testLoadDirectory(): void

--- a/tests/Unit/Metadata/ClassFinderTest.php
+++ b/tests/Unit/Metadata/ClassFinderTest.php
@@ -5,15 +5,9 @@ declare(strict_types=1);
 namespace Patchlevel\EventSourcing\Tests\Unit\Metadata;
 
 use Patchlevel\EventSourcing\Metadata\ClassFinder;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-
-use function is_dir;
-use function mkdir;
-use function rmdir;
-use function symlink;
-use function sys_get_temp_dir;
-use function unlink;
 
 #[CoversClass(ClassFinder::class)]
 final class ClassFinderTest extends TestCase
@@ -34,32 +28,11 @@ final class ClassFinderTest extends TestCase
         self::assertCount(0, $classes);
     }
 
-    public function testBrokenSymlink(): void
-    {
-        $dir = sys_get_temp_dir() . '/class-finder-broken-symlink';
-
-        if (!is_dir($dir)) {
-            mkdir($dir);
-        }
-
-        symlink($dir . '/missing-target.php', $dir . '/broken.php');
-
-        try {
-            $finder = new ClassFinder();
-            $classes = $finder->findClassNames([$dir]);
-
-            self::assertCount(0, $classes);
-        } finally {
-            unlink($dir . '/broken.php');
-            rmdir($dir);
-        }
-    }
-
     public function testLoadDirectory(): void
     {
         $finder = new ClassFinder();
         $classes = $finder->findClassNames([__DIR__ . '/../Fixture']);
 
-        self::assertContains('Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile', $classes);
+        self::assertContains(Profile::class, $classes);
     }
 }

--- a/tests/Unit/Metadata/Event/AliasFixture/EventWithAlias.php
+++ b/tests/Unit/Metadata/Event/AliasFixture/EventWithAlias.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event\AliasFixture;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+
+#[Event('event_with_alias', aliases: ['event_alias'])]
+final class EventWithAlias
+{
+}

--- a/tests/Unit/Metadata/Event/AttributeEventMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Event/AttributeEventMetadataFactoryTest.php
@@ -51,4 +51,18 @@ final class AttributeEventMetadataFactoryTest extends TestCase
         self::assertSame('profile_created', $metadata->name);
         self::assertSame(true, $metadata->splitStream);
     }
+
+    public function testMetadataCache(): void
+    {
+        $event = new #[Event('profile_created')]
+        class {
+        };
+
+        $metadataFactory = new AttributeEventMetadataFactory();
+
+        self::assertSame(
+            $metadataFactory->metadata($event::class),
+            $metadataFactory->metadata($event::class),
+        );
+    }
 }

--- a/tests/Unit/Metadata/Event/AttributeEventRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Event/AttributeEventRegistryFactoryTest.php
@@ -8,6 +8,7 @@ use Patchlevel\EventSourcing\Metadata\Event\AttributeEventRegistryFactory;
 use Patchlevel\EventSourcing\Metadata\Event\EventAlreadyInRegistry;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Message;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Metadata\Event\AliasFixture\EventWithAlias;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -30,5 +31,24 @@ final class AttributeEventRegistryFactoryTest extends TestCase
 
         $factory = new AttributeEventRegistryFactory();
         $factory->create([__DIR__ . '/Fixture']);
+    }
+
+    public function testCreateRegistryWithAliases(): void
+    {
+        $factory = new AttributeEventRegistryFactory();
+        $registry = $factory->create([__DIR__ . '/AliasFixture']);
+
+        self::assertTrue($registry->hasEventName('event_with_alias'));
+        self::assertTrue($registry->hasEventName('event_alias'));
+        self::assertSame(EventWithAlias::class, $registry->eventClass('event_alias'));
+    }
+
+    public function testCreateRegistryWithDuplicateAlias(): void
+    {
+        $this->expectException(EventAlreadyInRegistry::class);
+        $this->expectExceptionMessage('The event name "duplicate_alias" is already used in the registry. Maybe you defined 2 events with the same name.');
+
+        $factory = new AttributeEventRegistryFactory();
+        $factory->create([__DIR__ . '/DuplicateAliasFixture']);
     }
 }

--- a/tests/Unit/Metadata/Event/ClassIsNotAnEventTest.php
+++ b/tests/Unit/Metadata/Event/ClassIsNotAnEventTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\ClassIsNotAnEvent;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(ClassIsNotAnEvent::class)]
+final class ClassIsNotAnEventTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new ClassIsNotAnEvent(ProfileCreated::class);
+
+        self::assertSame(
+            sprintf('class %s is not an event', ProfileCreated::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Event/DuplicateAliasFixture/AliasedEvent.php
+++ b/tests/Unit/Metadata/Event/DuplicateAliasFixture/AliasedEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event\DuplicateAliasFixture;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+
+#[Event('aliased_event', aliases: ['duplicate_alias'])]
+final class AliasedEvent
+{
+}

--- a/tests/Unit/Metadata/Event/DuplicateAliasFixture/AliasedEvent2.php
+++ b/tests/Unit/Metadata/Event/DuplicateAliasFixture/AliasedEvent2.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event\DuplicateAliasFixture;
+
+use Patchlevel\EventSourcing\Attribute\Event;
+
+#[Event('aliased_event_2', aliases: ['duplicate_alias'])]
+final class AliasedEvent2
+{
+}

--- a/tests/Unit/Metadata/Event/EventAlreadyInRegistryTest.php
+++ b/tests/Unit/Metadata/Event/EventAlreadyInRegistryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventAlreadyInRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventAlreadyInRegistry::class)]
+final class EventAlreadyInRegistryTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new EventAlreadyInRegistry('profile.created');
+
+        self::assertSame(
+            'The event name "profile.created" is already used in the registry. Maybe you defined 2 events with the same name.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Event/EventClassNotRegisteredTest.php
+++ b/tests/Unit/Metadata/Event/EventClassNotRegisteredTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventClassNotRegistered;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(EventClassNotRegistered::class)]
+final class EventClassNotRegisteredTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new EventClassNotRegistered(ProfileCreated::class);
+
+        self::assertSame(
+            sprintf('Event class "%s" is not registered', ProfileCreated::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Event/EventMetadataTest.php
+++ b/tests/Unit/Metadata/Event/EventMetadataTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventMetadata;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventMetadata::class)]
+final class EventMetadataTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $metadata = new EventMetadata('profile.created', true, ['profile_created']);
+
+        self::assertSame('profile.created', $metadata->name);
+        self::assertTrue($metadata->splitStream);
+        self::assertSame(['profile_created'], $metadata->aliases);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $metadata = new EventMetadata('profile.created');
+
+        self::assertSame('profile.created', $metadata->name);
+        self::assertFalse($metadata->splitStream);
+        self::assertSame([], $metadata->aliases);
+    }
+}

--- a/tests/Unit/Metadata/Event/EventNameNotRegisteredTest.php
+++ b/tests/Unit/Metadata/Event/EventNameNotRegisteredTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventNameNotRegistered;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventNameNotRegistered::class)]
+final class EventNameNotRegisteredTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new EventNameNotRegistered('profile.created');
+
+        self::assertSame(
+            'Event name "profile.created" is not registered',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Event/MissingDataSubjectIdTest.php
+++ b/tests/Unit/Metadata/Event/MissingDataSubjectIdTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\MissingDataSubjectId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(MissingDataSubjectId::class)]
+final class MissingDataSubjectIdTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MissingDataSubjectId(ProfileCreated::class);
+
+        self::assertSame(
+            sprintf('Personal data cannot used without a subject id. Please provide a subject id for %s.', ProfileCreated::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Event/MultipleDataSubjectIdTest.php
+++ b/tests/Unit/Metadata/Event/MultipleDataSubjectIdTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\MultipleDataSubjectId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MultipleDataSubjectId::class)]
+final class MultipleDataSubjectIdTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MultipleDataSubjectId('foo', 'bar');
+
+        self::assertSame(
+            'Multiple data subject id found: foo and bar.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Event/Psr16EventMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Event/Psr16EventMetadataFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventMetadata;
+use Patchlevel\EventSourcing\Metadata\Event\EventMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\Event\Psr16EventMetadataFactory;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+#[CoversClass(Psr16EventMetadataFactory::class)]
+final class Psr16EventMetadataFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new EventMetadata('profile.created');
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with(ProfileCreated::class)
+            ->willReturn($value);
+        $cache
+            ->expects($this->never())
+            ->method('set');
+
+        $innerFactory = $this->createMock(EventMetadataFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('metadata');
+
+        $factory = new Psr16EventMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(ProfileCreated::class));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new EventMetadata('profile.created');
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with(ProfileCreated::class)
+            ->willReturn(null);
+        $cache
+            ->expects($this->once())
+            ->method('set')
+            ->with(ProfileCreated::class, $value)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(EventMetadataFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('metadata')
+            ->with(ProfileCreated::class)
+            ->willReturn($value);
+
+        $factory = new Psr16EventMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(ProfileCreated::class));
+    }
+}

--- a/tests/Unit/Metadata/Event/Psr16EventRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Event/Psr16EventRegistryFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventRegistry;
+use Patchlevel\EventSourcing\Metadata\Event\EventRegistryFactory;
+use Patchlevel\EventSourcing\Metadata\Event\Psr16EventRegistryFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+#[CoversClass(Psr16EventRegistryFactory::class)]
+final class Psr16EventRegistryFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new EventRegistry([]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with('event_registry')
+            ->willReturn($value);
+        $cache
+            ->expects($this->never())
+            ->method('set');
+
+        $innerFactory = $this->createMock(EventRegistryFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('create');
+
+        $factory = new Psr16EventRegistryFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->create(['/foo']));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new EventRegistry([]);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with('event_registry')
+            ->willReturn(null);
+        $cache
+            ->expects($this->once())
+            ->method('set')
+            ->with('event_registry', $value)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(EventRegistryFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with(['/foo'])
+            ->willReturn($value);
+
+        $factory = new Psr16EventRegistryFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->create(['/foo']));
+    }
+}

--- a/tests/Unit/Metadata/Event/Psr6EventMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Event/Psr6EventMetadataFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventMetadata;
+use Patchlevel\EventSourcing\Metadata\Event\EventMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\Event\Psr6EventMetadataFactory;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+#[CoversClass(Psr6EventMetadataFactory::class)]
+final class Psr6EventMetadataFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new EventMetadata('profile.created');
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($value);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with(ProfileCreated::class)
+            ->willReturn($item);
+        $cache
+            ->expects($this->never())
+            ->method('save');
+
+        $innerFactory = $this->createMock(EventMetadataFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('metadata');
+
+        $factory = new Psr6EventMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(ProfileCreated::class));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new EventMetadata('profile.created');
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(false);
+        $item
+            ->expects($this->once())
+            ->method('set')
+            ->with($value)
+            ->willReturnSelf();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with(ProfileCreated::class)
+            ->willReturn($item);
+        $cache
+            ->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(EventMetadataFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('metadata')
+            ->with(ProfileCreated::class)
+            ->willReturn($value);
+
+        $factory = new Psr6EventMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(ProfileCreated::class));
+    }
+}

--- a/tests/Unit/Metadata/Event/Psr6EventRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Event/Psr6EventRegistryFactoryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventRegistry;
+use Patchlevel\EventSourcing\Metadata\Event\EventRegistryFactory;
+use Patchlevel\EventSourcing\Metadata\Event\Psr6EventRegistryFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+#[CoversClass(Psr6EventRegistryFactory::class)]
+final class Psr6EventRegistryFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new EventRegistry([]);
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($value);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('event_registry')
+            ->willReturn($item);
+        $cache
+            ->expects($this->never())
+            ->method('save');
+
+        $innerFactory = $this->createMock(EventRegistryFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('create');
+
+        $factory = new Psr6EventRegistryFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->create(['/foo']));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new EventRegistry([]);
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(false);
+        $item
+            ->expects($this->once())
+            ->method('set')
+            ->with($value)
+            ->willReturnSelf();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('event_registry')
+            ->willReturn($item);
+        $cache
+            ->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(EventRegistryFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with(['/foo'])
+            ->willReturn($value);
+
+        $factory = new Psr6EventRegistryFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->create(['/foo']));
+    }
+}

--- a/tests/Unit/Metadata/Event/SubjectIdAndPersonalDataConflictTest.php
+++ b/tests/Unit/Metadata/Event/SubjectIdAndPersonalDataConflictTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Event;
+
+use Patchlevel\EventSourcing\Metadata\Event\SubjectIdAndPersonalDataConflict;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(SubjectIdAndPersonalDataConflict::class)]
+final class SubjectIdAndPersonalDataConflictTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new SubjectIdAndPersonalDataConflict(ProfileCreated::class, 'email');
+
+        self::assertSame(
+            sprintf('Personal data cannot be used as a subject id. Fix subject id for %s::email.', ProfileCreated::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Message/AttributeMessageHeaderRegistryFactoryTest.php
+++ b/tests/Unit/Metadata/Message/AttributeMessageHeaderRegistryFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Message;
+
+use Patchlevel\EventSourcing\Metadata\Message\AttributeMessageHeaderRegistryFactory;
+use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Header\BazHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Header\FooHeader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AttributeMessageHeaderRegistryFactory::class)]
+final class AttributeMessageHeaderRegistryFactoryTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $registry = (new AttributeMessageHeaderRegistryFactory())->create([
+            __DIR__ . '/../../Fixture',
+        ]);
+
+        self::assertSame(FooHeader::class, $registry->headerClass('foo'));
+        self::assertSame(BazHeader::class, $registry->headerClass('baz'));
+        self::assertSame(StreamNameHeader::class, $registry->headerClass('streamName'));
+    }
+}

--- a/tests/Unit/Metadata/Message/HeaderClassNotRegisteredTest.php
+++ b/tests/Unit/Metadata/Message/HeaderClassNotRegisteredTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Message;
+
+use Patchlevel\EventSourcing\Metadata\Message\HeaderClassNotRegistered;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Header\FooHeader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(HeaderClassNotRegistered::class)]
+final class HeaderClassNotRegisteredTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new HeaderClassNotRegistered(FooHeader::class);
+
+        self::assertSame(
+            sprintf('Header class "%s" is not registered', FooHeader::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Message/HeaderNameNotRegisteredTest.php
+++ b/tests/Unit/Metadata/Message/HeaderNameNotRegisteredTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Message;
+
+use Patchlevel\EventSourcing\Metadata\Message\HeaderNameNotRegistered;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HeaderNameNotRegistered::class)]
+final class HeaderNameNotRegisteredTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new HeaderNameNotRegistered('foo');
+
+        self::assertSame(
+            'Header name "foo" is not registered',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Message/MessageHeaderRegistryTest.php
+++ b/tests/Unit/Metadata/Message/MessageHeaderRegistryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Message;
+
+use Patchlevel\EventSourcing\Metadata\Message\HeaderClassNotRegistered;
+use Patchlevel\EventSourcing\Metadata\Message\HeaderNameNotRegistered;
+use Patchlevel\EventSourcing\Metadata\Message\MessageHeaderRegistry;
+use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Header\BazHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Header\FooHeader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MessageHeaderRegistry::class)]
+final class MessageHeaderRegistryTest extends TestCase
+{
+    public function testHeaderName(): void
+    {
+        $registry = new MessageHeaderRegistry(['foo' => FooHeader::class]);
+
+        self::assertSame('foo', $registry->headerName(FooHeader::class));
+    }
+
+    public function testHeaderNameNotRegistered(): void
+    {
+        $registry = new MessageHeaderRegistry(['foo' => FooHeader::class]);
+
+        $this->expectException(HeaderClassNotRegistered::class);
+
+        $registry->headerName(BazHeader::class);
+    }
+
+    public function testHeaderClass(): void
+    {
+        $registry = new MessageHeaderRegistry(['foo' => FooHeader::class]);
+
+        self::assertSame(FooHeader::class, $registry->headerClass('foo'));
+    }
+
+    public function testHeaderClassNotRegistered(): void
+    {
+        $registry = new MessageHeaderRegistry(['foo' => FooHeader::class]);
+
+        $this->expectException(HeaderNameNotRegistered::class);
+
+        $registry->headerClass('baz');
+    }
+
+    public function testHasHeaderClass(): void
+    {
+        $registry = new MessageHeaderRegistry(['foo' => FooHeader::class]);
+
+        self::assertTrue($registry->hasHeaderClass(FooHeader::class));
+        self::assertFalse($registry->hasHeaderClass(BazHeader::class));
+    }
+
+    public function testHasHeaderName(): void
+    {
+        $registry = new MessageHeaderRegistry(['foo' => FooHeader::class]);
+
+        self::assertTrue($registry->hasHeaderName('foo'));
+        self::assertFalse($registry->hasHeaderName('baz'));
+    }
+
+    public function testHeaderClassesAndNames(): void
+    {
+        $registry = new MessageHeaderRegistry(['foo' => FooHeader::class]);
+
+        self::assertSame(['foo' => FooHeader::class], $registry->headerClasses());
+        self::assertSame([FooHeader::class => 'foo'], $registry->headerNames());
+    }
+
+    public function testCreateWithInternalHeaders(): void
+    {
+        $registry = MessageHeaderRegistry::createWithInternalHeaders(['foo' => FooHeader::class]);
+
+        self::assertSame(FooHeader::class, $registry->headerClass('foo'));
+        self::assertSame(StreamNameHeader::class, $registry->headerClass('streamName'));
+        self::assertTrue($registry->hasHeaderName('playhead'));
+        self::assertTrue($registry->hasHeaderName('recordedOn'));
+        self::assertTrue($registry->hasHeaderName('archived'));
+        self::assertTrue($registry->hasHeaderName('newStreamStart'));
+        self::assertTrue($registry->hasHeaderName('eventId'));
+        self::assertTrue($registry->hasHeaderName('index'));
+        self::assertTrue($registry->hasHeaderName('tags'));
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/ArgumentTypeNotSupportedTest.php
+++ b/tests/Unit/Metadata/Subscriber/ArgumentTypeNotSupportedTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentTypeNotSupported;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(ArgumentTypeNotSupported::class)]
+final class ArgumentTypeNotSupportedTest extends TestCase
+{
+    public function testMissingType(): void
+    {
+        $exception = ArgumentTypeNotSupported::missingType(Profile::class, 'onProfileCreated', 'event');
+
+        self::assertSame(
+            sprintf('Argument type for method "onProfileCreated" in class "%s" is not supported. Argument "event" must have a type.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/AttributeSubscriberMetadataFactoryTest.php
@@ -9,10 +9,13 @@ use Patchlevel\EventSourcing\Attribute\BatchFlush;
 use Patchlevel\EventSourcing\Attribute\BatchRollback;
 use Patchlevel\EventSourcing\Attribute\BatchShouldFlush;
 use Patchlevel\EventSourcing\Attribute\BatchState;
+use Patchlevel\EventSourcing\Attribute\Cleanup;
 use Patchlevel\EventSourcing\Attribute\DisableEventEmitting;
 use Patchlevel\EventSourcing\Attribute\EnableEventEmittingDuringBoot;
+use Patchlevel\EventSourcing\Attribute\OnFailed;
 use Patchlevel\EventSourcing\Attribute\Processor;
 use Patchlevel\EventSourcing\Attribute\Projector;
+use Patchlevel\EventSourcing\Attribute\RetryStrategy;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Subscriber;
@@ -24,6 +27,8 @@ use Patchlevel\EventSourcing\Metadata\Subscriber\AttributeSubscriberMetadataFact
 use Patchlevel\EventSourcing\Metadata\Subscriber\BatchMetadata;
 use Patchlevel\EventSourcing\Metadata\Subscriber\ClassIsNotASubscriber;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateBeginBatchMethod;
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateCleanupMethod;
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateFailedMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateFlushMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateRollbackBatchMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateSetupMethod;
@@ -31,6 +36,7 @@ use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateShouldFlushMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateSubscribeMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateTeardownMethod;
 use Patchlevel\EventSourcing\Metadata\Subscriber\IncompleteBatchMethods;
+use Patchlevel\EventSourcing\Metadata\Subscriber\MixedTeardownAndCleanupMethods;
 use Patchlevel\EventSourcing\Metadata\Subscriber\SubscribeMethodMetadata;
 use Patchlevel\EventSourcing\Subscription\RunMode;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
@@ -648,5 +654,151 @@ final class AttributeSubscriberMetadataFactoryTest extends TestCase
 
         $metadataFactory = new AttributeSubscriberMetadataFactory();
         $metadataFactory->metadata($subscriber::class);
+    }
+
+    public function testMetadataCache(): void
+    {
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+
+        self::assertSame(
+            $metadataFactory->metadata($subscriber::class),
+            $metadataFactory->metadata($subscriber::class),
+        );
+    }
+
+    public function testOnFailedMethod(): void
+    {
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[OnFailed]
+            public function onFailed(): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadata = $metadataFactory->metadata($subscriber::class);
+
+        self::assertSame('onFailed', $metadata->failedMethod);
+    }
+
+    public function testDuplicateFailedException(): void
+    {
+        $this->expectException(DuplicateFailedMethod::class);
+        $this->expectExceptionMessage('have been marked as "OnFailed" methods');
+
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[OnFailed]
+            public function onFailed1(): void
+            {
+            }
+
+            #[OnFailed]
+            public function onFailed2(): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadataFactory->metadata($subscriber::class);
+    }
+
+    public function testCleanupMethod(): void
+    {
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[Cleanup]
+            public function cleanup(): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadata = $metadataFactory->metadata($subscriber::class);
+
+        self::assertSame('cleanup', $metadata->cleanupMethod);
+        self::assertNull($metadata->teardownMethod);
+    }
+
+    public function testDuplicateCleanupException(): void
+    {
+        $this->expectException(DuplicateCleanupMethod::class);
+        $this->expectExceptionMessage('have been marked as "cleanup" methods');
+
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[Cleanup]
+            public function cleanup1(): void
+            {
+            }
+
+            #[Cleanup]
+            public function cleanup2(): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadataFactory->metadata($subscriber::class);
+    }
+
+    public function testCleanupAfterTeardownException(): void
+    {
+        $this->expectException(MixedTeardownAndCleanupMethods::class);
+
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[Teardown]
+            public function teardown(): void
+            {
+            }
+
+            #[Cleanup]
+            public function cleanup(): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadataFactory->metadata($subscriber::class);
+    }
+
+    public function testTeardownAfterCleanupException(): void
+    {
+        $this->expectException(MixedTeardownAndCleanupMethods::class);
+
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        class {
+            #[Cleanup]
+            public function cleanup(): void
+            {
+            }
+
+            #[Teardown]
+            public function teardown(): void
+            {
+            }
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadataFactory->metadata($subscriber::class);
+    }
+
+    public function testRetryStrategy(): void
+    {
+        $subscriber = new #[Subscriber('foo', RunMode::FromBeginning)]
+        #[RetryStrategy('custom_strategy')]
+        class {
+        };
+
+        $metadataFactory = new AttributeSubscriberMetadataFactory();
+        $metadata = $metadataFactory->metadata($subscriber::class);
+
+        self::assertSame('custom_strategy', $metadata->retryStrategy);
     }
 }

--- a/tests/Unit/Metadata/Subscriber/BatchMetadataTest.php
+++ b/tests/Unit/Metadata/Subscriber/BatchMetadataTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\BatchMetadata;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BatchMetadata::class)]
+final class BatchMetadataTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $metadata = new BatchMetadata('flush', 'begin', 'shouldFlush', 'rollback', 100);
+
+        self::assertSame('flush', $metadata->flushMethod);
+        self::assertSame('begin', $metadata->beginMethod);
+        self::assertSame('shouldFlush', $metadata->shouldFlushMethod);
+        self::assertSame('rollback', $metadata->rollbackMethod);
+        self::assertSame(100, $metadata->afterMessages);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $metadata = new BatchMetadata('flush');
+
+        self::assertSame('flush', $metadata->flushMethod);
+        self::assertNull($metadata->beginMethod);
+        self::assertNull($metadata->shouldFlushMethod);
+        self::assertNull($metadata->rollbackMethod);
+        self::assertNull($metadata->afterMessages);
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/ClassIsNotASubscriberTest.php
+++ b/tests/Unit/Metadata/Subscriber/ClassIsNotASubscriberTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\ClassIsNotASubscriber;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(ClassIsNotASubscriber::class)]
+final class ClassIsNotASubscriberTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new ClassIsNotASubscriber(Profile::class);
+
+        self::assertSame(
+            sprintf('Class "%s" is not a subscriber', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateBeginBatchMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateBeginBatchMethodTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateBeginBatchMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateBeginBatchMethod::class)]
+final class DuplicateBeginBatchMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateBeginBatchMethod(Profile::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" have been marked as "begin batch" methods. Only one method can be defined like this.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateCleanupMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateCleanupMethodTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateCleanupMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateCleanupMethod::class)]
+final class DuplicateCleanupMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateCleanupMethod(Profile::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" have been marked as "cleanup" methods. Only one method can be defined like this.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateFailedMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateFailedMethodTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateFailedMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateFailedMethod::class)]
+final class DuplicateFailedMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateFailedMethod(Profile::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" have been marked as "OnFailed" methods. Only one method can be defined like this.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateFlushMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateFlushMethodTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateFlushMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateFlushMethod::class)]
+final class DuplicateFlushMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateFlushMethod(Profile::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" have been marked as "flush" methods. Only one method can be defined like this.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateRollbackBatchMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateRollbackBatchMethodTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateRollbackBatchMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateRollbackBatchMethod::class)]
+final class DuplicateRollbackBatchMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateRollbackBatchMethod(Profile::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" have been marked as "rollback batch" methods. Only one method can be defined like this.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateSetupMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateSetupMethodTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateSetupMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateSetupMethod::class)]
+final class DuplicateSetupMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateSetupMethod(Profile::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" have been marked as "setup" methods. Only one method can be defined like this.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateShouldFlushMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateShouldFlushMethodTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateShouldFlushMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateShouldFlushMethod::class)]
+final class DuplicateShouldFlushMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateShouldFlushMethod(Profile::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" have been marked as "should flush" methods. Only one method can be defined like this.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateSubscribeMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateSubscribeMethodTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateSubscribeMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateSubscribeMethod::class)]
+final class DuplicateSubscribeMethodTest extends TestCase
+{
+    public function testDuplicateEvent(): void
+    {
+        $exception = DuplicateSubscribeMethod::duplicateEvent(Profile::class, ProfileCreated::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" are subscribing the event "%s". A subscriber can only listen once to a event, thus this is not allowed.', Profile::class, ProfileCreated::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testMixedWithAll(): void
+    {
+        $exception = DuplicateSubscribeMethod::mixedWithAll(Profile::class);
+
+        self::assertSame(
+            sprintf('The subscriber "%s" is subscribing explicit events and all events. A subscriber can only listen once to a event, thus this is not allowed.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/DuplicateTeardownMethodTest.php
+++ b/tests/Unit/Metadata/Subscriber/DuplicateTeardownMethodTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\DuplicateTeardownMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(DuplicateTeardownMethod::class)]
+final class DuplicateTeardownMethodTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateTeardownMethod(Profile::class, 'methodA', 'methodB');
+
+        self::assertSame(
+            sprintf('Two methods "methodA" and "methodB" on the subscriber "%s" have been marked as "teardown" methods. Only one method can be defined like this.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/IncompleteBatchMethodsTest.php
+++ b/tests/Unit/Metadata/Subscriber/IncompleteBatchMethodsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\IncompleteBatchMethods;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(IncompleteBatchMethods::class)]
+final class IncompleteBatchMethodsTest extends TestCase
+{
+    public function testMissingFlushMethod(): void
+    {
+        $exception = IncompleteBatchMethods::missingFlushMethod(Profile::class);
+
+        self::assertSame(
+            sprintf('The subscriber "%s" uses batching but does not define a method marked with the #[BatchFlush] attribute.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/MixedTeardownAndCleanupMethodsTest.php
+++ b/tests/Unit/Metadata/Subscriber/MixedTeardownAndCleanupMethodsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\MixedTeardownAndCleanupMethods;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(MixedTeardownAndCleanupMethods::class)]
+final class MixedTeardownAndCleanupMethodsTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MixedTeardownAndCleanupMethods(Profile::class, 'teardownA', 'cleanupB');
+
+        self::assertSame(
+            sprintf('The subscriber "%s" has a "teardown" method "%s" and a "cleanup" method "%s". Only one of them can be defined.', Profile::class, 'teardownA', 'cleanupB'),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/Psr16SubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/Psr16SubscriberMetadataFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\Psr16SubscriberMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadata;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadataFactory;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+#[CoversClass(Psr16SubscriberMetadataFactory::class)]
+final class Psr16SubscriberMetadataFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new SubscriberMetadata('foo');
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with(Profile::class)
+            ->willReturn($value);
+        $cache
+            ->expects($this->never())
+            ->method('set');
+
+        $innerFactory = $this->createMock(SubscriberMetadataFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('metadata');
+
+        $factory = new Psr16SubscriberMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(Profile::class));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new SubscriberMetadata('foo');
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with(Profile::class)
+            ->willReturn(null);
+        $cache
+            ->expects($this->once())
+            ->method('set')
+            ->with(Profile::class, $value)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(SubscriberMetadataFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('metadata')
+            ->with(Profile::class)
+            ->willReturn($value);
+
+        $factory = new Psr16SubscriberMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(Profile::class));
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/Psr6SubscriberMetadataFactoryTest.php
+++ b/tests/Unit/Metadata/Subscriber/Psr6SubscriberMetadataFactoryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\Psr6SubscriberMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadata;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadataFactory;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+#[CoversClass(Psr6SubscriberMetadataFactory::class)]
+final class Psr6SubscriberMetadataFactoryTest extends TestCase
+{
+    public function testCacheHit(): void
+    {
+        $value = new SubscriberMetadata('foo');
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($value);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with(Profile::class)
+            ->willReturn($item);
+        $cache
+            ->expects($this->never())
+            ->method('save');
+
+        $innerFactory = $this->createMock(SubscriberMetadataFactory::class);
+        $innerFactory
+            ->expects($this->never())
+            ->method('metadata');
+
+        $factory = new Psr6SubscriberMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(Profile::class));
+    }
+
+    public function testCacheMiss(): void
+    {
+        $value = new SubscriberMetadata('foo');
+
+        $item = $this->createMock(CacheItemInterface::class);
+        $item
+            ->expects($this->once())
+            ->method('isHit')
+            ->willReturn(false);
+        $item
+            ->expects($this->once())
+            ->method('set')
+            ->with($value)
+            ->willReturnSelf();
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with(Profile::class)
+            ->willReturn($item);
+        $cache
+            ->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $innerFactory = $this->createMock(SubscriberMetadataFactory::class);
+        $innerFactory
+            ->expects($this->once())
+            ->method('metadata')
+            ->with(Profile::class)
+            ->willReturn($value);
+
+        $factory = new Psr6SubscriberMetadataFactory($innerFactory, $cache);
+
+        self::assertSame($value, $factory->metadata(Profile::class));
+    }
+}

--- a/tests/Unit/Metadata/Subscriber/SubscribeMethodMetadataTest.php
+++ b/tests/Unit/Metadata/Subscriber/SubscribeMethodMetadataTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Metadata\Subscriber;
+
+use Patchlevel\EventSourcing\Metadata\Subscriber\ArgumentMetadata;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscribeMethodMetadata;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type;
+
+#[CoversClass(SubscribeMethodMetadata::class)]
+final class SubscribeMethodMetadataTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $argument = new ArgumentMetadata('message', Type::string());
+
+        $metadata = new SubscribeMethodMetadata('onProfileCreated', [$argument]);
+
+        self::assertSame('onProfileCreated', $metadata->name);
+        self::assertSame([$argument], $metadata->arguments);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $metadata = new SubscribeMethodMetadata('onProfileCreated');
+
+        self::assertSame('onProfileCreated', $metadata->name);
+        self::assertSame([], $metadata->arguments);
+    }
+}

--- a/tests/Unit/Projection/ApplyMethodDetectionErrorTest.php
+++ b/tests/Unit/Projection/ApplyMethodDetectionErrorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Projection;
+
+use Patchlevel\EventSourcing\Projection\ApplyMethodDetectionError;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\IncrementProjection;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(ApplyMethodDetectionError::class)]
+final class ApplyMethodDetectionErrorTest extends TestCase
+{
+    public function testDuplicateEmptyApplyAttribute(): void
+    {
+        $exception = ApplyMethodDetectionError::duplicateEmptyApplyAttribute('applyEvent');
+
+        self::assertSame(
+            'The method "applyEvent" has multiple #[Apply] attributes with an empty "event" argument. Only one is allowed.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testMixedApplyAttributeUsage(): void
+    {
+        $exception = ApplyMethodDetectionError::mixedApplyAttributeUsage('applyEvent');
+
+        self::assertSame(
+            'The method "applyEvent" has an #[Apply] attribute with an empty "event" argument, but also has a non-empty "event" argument in another #[Apply] attribute. This is not allowed.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testArgumentTypeIsNotAClass(): void
+    {
+        $exception = ApplyMethodDetectionError::argumentTypeIsNotAClass('applyEvent', 'foo');
+
+        self::assertSame(
+            'The method "applyEvent" has an #[Apply] attribute with an "event" argument that is not a class: string.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testDuplicateApplyMethod(): void
+    {
+        $exception = ApplyMethodDetectionError::duplicateApplyMethod(
+            IncrementProjection::class,
+            ProfileCreated::class,
+            'applyA',
+            'applyB',
+        );
+
+        self::assertSame(
+            sprintf(
+                'Two methods "applyA" and "applyB" on the class "%s" want to apply the same event "%s". Only one method can apply an event.',
+                IncrementProjection::class,
+                ProfileCreated::class,
+            ),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testParameterIsMissing(): void
+    {
+        $exception = ApplyMethodDetectionError::parameterIsMissing('applyEvent', 1);
+
+        self::assertSame(
+            'The method "applyEvent" has an #[Apply] attribute with an "event" argument, but the parameter #1 is missing.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testArgumentTypeIsMissing(): void
+    {
+        $exception = ApplyMethodDetectionError::argumentTypeIsMissing('applyEvent');
+
+        self::assertSame(
+            'The method "applyEvent" has an #[Apply] attribute with an empty "event" argument. This is not allowed.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Projection/BasicProjectionTest.php
+++ b/tests/Unit/Projection/BasicProjectionTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Projection;
+
+use Countable;
+use Patchlevel\EventSourcing\Attribute\Apply;
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Projection\ApplyMethodDetectionError;
+use Patchlevel\EventSourcing\Projection\BasicProjection;
+use Patchlevel\EventSourcing\Store\Header\TagsHeader;
+use Patchlevel\EventSourcing\Store\SubQuery;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Stringable;
+
+#[CoversClass(BasicProjection::class)]
+final class BasicProjectionTest extends TestCase
+{
+    public function testApplyWithMatchingEvent(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return ['match'];
+            }
+
+            #[Apply]
+            public function applyProfileCreated(int $state, ProfileCreated $event): int
+            {
+                return $state + 1;
+            }
+        };
+
+        $state = $projection->apply(0, $this->message(['match']));
+
+        self::assertSame(1, $state);
+        self::assertEquals(
+            new SubQuery(['match'], [ProfileCreated::class]),
+            $projection->subQuery(),
+        );
+        self::assertSame($projection->subQuery(), $projection->subQuery());
+    }
+
+    public function testApplyWithNonMatchingMessage(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return ['match'];
+            }
+
+            #[Apply]
+            public function applyProfileCreated(int $state, ProfileCreated $event): int
+            {
+                return $state + 1;
+            }
+        };
+
+        self::assertSame(0, $projection->apply(0, $this->message(['other'])));
+    }
+
+    public function testApplyWithUnhandledEvent(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            /** @return list<class-string> */
+            protected function eventTypeFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            public function applyProfileVisited(int $state, ProfileVisited $event): int
+            {
+                return $state + 1;
+            }
+        };
+
+        self::assertSame(0, $projection->apply(0, $this->message([])));
+    }
+
+    public function testApplyWithExplicitEventClass(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply(ProfileCreated::class)]
+            public function applyProfileCreated(int $state, object $event): int
+            {
+                return $state + 1;
+            }
+        };
+
+        self::assertSame(1, $projection->apply(0, $this->message([])));
+    }
+
+    public function testApplyWithUnionType(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            public function applyEvent(int $state, ProfileCreated|ProfileVisited $event): int
+            {
+                return $state + 1;
+            }
+        };
+
+        self::assertEquals(
+            new SubQuery([], [ProfileCreated::class, ProfileVisited::class]),
+            $projection->subQuery(),
+        );
+        self::assertSame(1, $projection->apply(0, $this->message([])));
+    }
+
+    public function testDuplicateEmptyApplyAttribute(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            #[Apply]
+            public function applyEvent(int $state, ProfileCreated $event): int
+            {
+                return $state;
+            }
+        };
+
+        $this->expectException(ApplyMethodDetectionError::class);
+
+        $projection->subQuery();
+    }
+
+    public function testMixedApplyAttributeUsage(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            #[Apply(ProfileVisited::class)]
+            public function applyEvent(int $state, ProfileCreated $event): int
+            {
+                return $state;
+            }
+        };
+
+        $this->expectException(ApplyMethodDetectionError::class);
+
+        $projection->subQuery();
+    }
+
+    public function testApplyTypeIsNotAClass(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            public function applyEvent(int $state, string $event): int
+            {
+                return $state;
+            }
+        };
+
+        $this->expectException(ApplyMethodDetectionError::class);
+
+        $projection->subQuery();
+    }
+
+    public function testDuplicateApplyMethod(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            public function applyA(int $state, ProfileCreated $event): int
+            {
+                return $state;
+            }
+
+            #[Apply]
+            public function applyB(int $state, ProfileCreated $event): int
+            {
+                return $state;
+            }
+        };
+
+        $this->expectException(ApplyMethodDetectionError::class);
+
+        $projection->subQuery();
+    }
+
+    public function testParameterIsMissing(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            public function applyEvent(int $state): int
+            {
+                return $state;
+            }
+        };
+
+        $this->expectException(ApplyMethodDetectionError::class);
+
+        $projection->subQuery();
+    }
+
+    public function testUntypedParameter(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            // phpcs:disable
+            /** @phpstan-ignore-next-line */
+            #[Apply]
+            public function applyEvent(int $state, $event): int
+            {
+                return $state;
+            }
+            // phpcs:enable
+        };
+
+        $this->expectException(ApplyMethodDetectionError::class);
+
+        $projection->subQuery();
+    }
+
+    public function testIntersectionType(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            public function applyEvent(int $state, Countable&Stringable $event): int
+            {
+                return $state;
+            }
+        };
+
+        $this->expectException(ApplyMethodDetectionError::class);
+
+        $projection->subQuery();
+    }
+
+    public function testUnionWithIntersectionType(): void
+    {
+        $projection = new class extends BasicProjection {
+            public function initialState(): int
+            {
+                return 0;
+            }
+
+            /** @return list<string> */
+            protected function tagFilter(): array
+            {
+                return [];
+            }
+
+            #[Apply]
+            public function applyEvent(int $state, ProfileCreated|(Countable&Stringable) $event): int
+            {
+                return $state;
+            }
+        };
+
+        $this->expectException(ApplyMethodDetectionError::class);
+
+        $projection->subQuery();
+    }
+
+    /** @param list<string> $tags */
+    private function message(array $tags): Message
+    {
+        return Message::create(new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('foo@bar.com'),
+        ))->withHeader(new TagsHeader($tags));
+    }
+}

--- a/tests/Unit/Projection/CompositeProjectionTest.php
+++ b/tests/Unit/Projection/CompositeProjectionTest.php
@@ -6,6 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Projection;
 
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Projection\CompositeProjection;
+use Patchlevel\EventSourcing\Projection\Projection;
 use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
 use Patchlevel\EventSourcing\Store\Header\TagsHeader;
 use Patchlevel\EventSourcing\Store\Query;
@@ -97,5 +98,17 @@ final class CompositeProjectionTest extends TestCase
         // 'm' matches and increments; 'n' does not match and stays the same
         self::assertSame(3, $newState['m']);
         self::assertSame(3, $newState['n']);
+    }
+
+    public function testQueryWithoutSubQueryProvider(): void
+    {
+        $projection = $this->createMock(Projection::class);
+
+        $composite = new CompositeProjection([
+            'a' => $projection,
+            'b' => new IncrementProjection(0, ['tag:b']),
+        ]);
+
+        self::assertEquals(new Query(), $composite->query());
     }
 }

--- a/tests/Unit/Projection/StoreProjectionBuilderTest.php
+++ b/tests/Unit/Projection/StoreProjectionBuilderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Projection;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Stream;
+use Patchlevel\EventSourcing\Projection\CompositeProjection;
+use Patchlevel\EventSourcing\Projection\StoreProjectionBuilder;
+use Patchlevel\EventSourcing\Store\AppendStore;
+use Patchlevel\EventSourcing\Store\Header\TagsHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\IncrementProjection;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StoreProjectionBuilder::class)]
+final class StoreProjectionBuilderTest extends TestCase
+{
+    public function testBuild(): void
+    {
+        $projections = ['count' => new IncrementProjection(0, ['match'])];
+
+        $expectedQuery = (new CompositeProjection($projections))->query();
+
+        $message = Message::create(new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('foo@bar.com'),
+        ))->withHeader(new TagsHeader(['match']));
+
+        $store = $this->createMock(AppendStore::class);
+        $store
+            ->expects($this->once())
+            ->method('query')
+            ->with($expectedQuery)
+            ->willReturn(new Stream([$message, $message]));
+
+        $builder = new StoreProjectionBuilder($store);
+
+        self::assertSame(['count' => 2], $builder->build($projections));
+    }
+}

--- a/tests/Unit/QueryBus/ChainHandlerProviderTest.php
+++ b/tests/Unit/QueryBus/ChainHandlerProviderTest.php
@@ -8,9 +8,10 @@ use Patchlevel\EventSourcing\QueryBus\ChainHandlerProvider;
 use Patchlevel\EventSourcing\QueryBus\HandlerDescriptor;
 use Patchlevel\EventSourcing\QueryBus\HandlerProvider;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Patchlevel\EventSourcing\QueryBus\ChainHandlerProvider */
+#[CoversClass(ChainHandlerProvider::class)]
 final class ChainHandlerProviderTest extends TestCase
 {
     public function testEmpty(): void

--- a/tests/Unit/QueryBus/HandlerDescriptorTest.php
+++ b/tests/Unit/QueryBus/HandlerDescriptorTest.php
@@ -9,10 +9,11 @@ use Patchlevel\EventSourcing\QueryBus\HandlerDescriptor;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryAnsweringProjection;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryAnsweringStaticProjection;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Patchlevel\EventSourcing\QueryBus\HandlerDescriptor */
+#[CoversClass(HandlerDescriptor::class)]
 final class HandlerDescriptorTest extends TestCase
 {
     public function testObjectMethod(): void

--- a/tests/Unit/QueryBus/HandlerFinderTest.php
+++ b/tests/Unit/QueryBus/HandlerFinderTest.php
@@ -10,9 +10,10 @@ use Patchlevel\EventSourcing\QueryBus\HandlerReference;
 use Patchlevel\EventSourcing\QueryBus\InvalidHandleMethod;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\OtherQueryProfile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Patchlevel\EventSourcing\QueryBus\HandlerFinder */
+#[CoversClass(HandlerFinder::class)]
 final class HandlerFinderTest extends TestCase
 {
     public function testNoParameters(): void
@@ -38,6 +39,38 @@ final class HandlerFinderTest extends TestCase
             // phpcs:disable
             #[Answer]
             public function handle(mixed $query): void
+            {
+            }
+            // phpcs:enable
+        };
+
+        $result = [...HandlerFinder::findInClass($class::class)];
+
+        self::assertSame([], $result);
+    }
+
+    public function testSkipMethodWithoutAnswerAttribute(): void
+    {
+        $class = new class () {
+            public function handle(QueryProfile $query): void
+            {
+            }
+        };
+
+        $result = [...HandlerFinder::findInClass($class::class)];
+
+        self::assertSame([], $result);
+    }
+
+    public function testMissingType(): void
+    {
+        $this->expectException(InvalidHandleMethod::class);
+
+        $class = new class () {
+            // phpcs:disable
+            /** @phpstan-ignore-next-line */
+            #[Answer]
+            public function handle($query): void
             {
             }
             // phpcs:enable

--- a/tests/Unit/QueryBus/HandlerReferenceTest.php
+++ b/tests/Unit/QueryBus/HandlerReferenceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\QueryBus;
+
+use Patchlevel\EventSourcing\QueryBus\HandlerReference;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HandlerReference::class)]
+final class HandlerReferenceTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $reference = new HandlerReference(QueryProfile::class, 'handle', true);
+
+        self::assertSame(QueryProfile::class, $reference->queryClass);
+        self::assertSame('handle', $reference->method);
+        self::assertTrue($reference->static);
+    }
+}

--- a/tests/Unit/QueryBus/InvalidHandleMethodTest.php
+++ b/tests/Unit/QueryBus/InvalidHandleMethodTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\QueryBus;
+
+use Patchlevel\EventSourcing\QueryBus\InvalidHandleMethod;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(InvalidHandleMethod::class)]
+final class InvalidHandleMethodTest extends TestCase
+{
+    public function testNoParameters(): void
+    {
+        $exception = InvalidHandleMethod::noParameters(QueryProfile::class, 'handle');
+
+        self::assertSame(
+            sprintf('Query handling method "handle" in class "%s" has no parameters', QueryProfile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testIncompatibleType(): void
+    {
+        $exception = InvalidHandleMethod::incompatibleType(QueryProfile::class, 'handle');
+
+        self::assertSame(
+            sprintf('Query handling method "handle" in class "%s" has no compatible type', QueryProfile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/QueryBus/InvalidQueryHandlerTest.php
+++ b/tests/Unit/QueryBus/InvalidQueryHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\QueryBus;
+
+use Patchlevel\EventSourcing\QueryBus\InvalidQueryHandler;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(InvalidQueryHandler::class)]
+final class InvalidQueryHandlerTest extends TestCase
+{
+    public function testNoHandler(): void
+    {
+        $exception = InvalidQueryHandler::noHandler(QueryProfile::class);
+
+        self::assertSame(
+            sprintf('No handler found for query %s', QueryProfile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testMultipleHandler(): void
+    {
+        $exception = InvalidQueryHandler::multipleHandler(QueryProfile::class);
+
+        self::assertSame(
+            sprintf('Multiple handlers found for query %s', QueryProfile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/QueryBus/ServiceHandlerProviderTest.php
+++ b/tests/Unit/QueryBus/ServiceHandlerProviderTest.php
@@ -7,9 +7,10 @@ namespace Patchlevel\EventSourcing\Tests\Unit\QueryBus;
 use Patchlevel\EventSourcing\Attribute\Answer;
 use Patchlevel\EventSourcing\QueryBus\ServiceHandlerProvider;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\QueryProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Patchlevel\EventSourcing\QueryBus\ServiceHandlerProvider */
+#[CoversClass(ServiceHandlerProvider::class)]
 final class ServiceHandlerProviderTest extends TestCase
 {
     public function testEmpty(): void

--- a/tests/Unit/QueryBus/SyncQueryBusTest.php
+++ b/tests/Unit/QueryBus/SyncQueryBusTest.php
@@ -8,10 +8,11 @@ use Patchlevel\EventSourcing\QueryBus\HandlerDescriptor;
 use Patchlevel\EventSourcing\QueryBus\HandlerProvider;
 use Patchlevel\EventSourcing\QueryBus\InvalidQueryHandler;
 use Patchlevel\EventSourcing\QueryBus\SyncQueryBus;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-/** @covers \Patchlevel\EventSourcing\QueryBus\SyncQueryBus */
+#[CoversClass(SyncQueryBus::class)]
 final class SyncQueryBusTest extends TestCase
 {
     public function testHandlerNotFound(): void
@@ -72,6 +73,64 @@ final class SyncQueryBusTest extends TestCase
         $logger->expects($this->once())->method('debug')->with('QueryBus: dispatch query', ['query' => $query::class]);
 
         $queryBus = new SyncQueryBus($handlerProvider, $logger);
+        $queryBus->dispatch($query);
+
+        self::assertSame($query, $handler->query);
+    }
+
+    public function testIterableHandlerProviders(): void
+    {
+        $query = new class {
+        };
+
+        $handler = new class {
+            public object|null $query = null;
+
+            public function __invoke(object $query): void
+            {
+                $this->query = $query;
+            }
+        };
+
+        $handlerProvider = $this->createMock(HandlerProvider::class);
+        $handlerProvider
+            ->expects($this->once())
+            ->method('handlerForQuery')
+            ->with($query::class)
+            ->willReturn([
+                new HandlerDescriptor($handler),
+            ]);
+
+        $queryBus = new SyncQueryBus([$handlerProvider]);
+        $queryBus->dispatch($query);
+
+        self::assertSame($query, $handler->query);
+    }
+
+    public function testHandlerGenerator(): void
+    {
+        $query = new class {
+        };
+
+        $handler = new class {
+            public object|null $query = null;
+
+            public function __invoke(object $query): void
+            {
+                $this->query = $query;
+            }
+        };
+
+        $handlerProvider = $this->createMock(HandlerProvider::class);
+        $handlerProvider
+            ->expects($this->once())
+            ->method('handlerForQuery')
+            ->with($query::class)
+            ->willReturnCallback(static function () use ($handler) {
+                yield new HandlerDescriptor($handler);
+            });
+
+        $queryBus = new SyncQueryBus($handlerProvider);
         $queryBus->dispatch($query);
 
         self::assertSame($query, $handler->query);

--- a/tests/Unit/Repository/AggregateAlreadyExistsTest.php
+++ b/tests/Unit/Repository/AggregateAlreadyExistsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository;
+
+use Patchlevel\EventSourcing\Repository\AggregateAlreadyExists;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(AggregateAlreadyExists::class)]
+final class AggregateAlreadyExistsTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateAlreadyExists(Profile::class, ProfileId::fromString('1'));
+
+        self::assertSame(
+            sprintf('aggregate %s with id 1 already exists', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Repository/AggregateDetachedTest.php
+++ b/tests/Unit/Repository/AggregateDetachedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository;
+
+use Patchlevel\EventSourcing\Repository\AggregateDetached;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(AggregateDetached::class)]
+final class AggregateDetachedTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateDetached(Profile::class, ProfileId::fromString('1'));
+
+        self::assertSame(
+            sprintf('An error occurred while saving the aggregate "%s" with the ID "1", causing the uncommitted events to be lost. Please reload the aggregate.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Repository/AggregateNotFoundTest.php
+++ b/tests/Unit/Repository/AggregateNotFoundTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository;
+
+use Patchlevel\EventSourcing\Repository\AggregateNotFound;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(AggregateNotFound::class)]
+final class AggregateNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateNotFound(Profile::class, ProfileId::fromString('1'));
+
+        self::assertSame(
+            sprintf('aggregate "%s::1" not found', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Repository/AggregateUnknownTest.php
+++ b/tests/Unit/Repository/AggregateUnknownTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository;
+
+use Patchlevel\EventSourcing\Repository\AggregateUnknown;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(AggregateUnknown::class)]
+final class AggregateUnknownTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AggregateUnknown(Profile::class, ProfileId::fromString('1'));
+
+        self::assertSame(
+            sprintf('The aggregate %s with the ID "1" was not loaded from this repository. Please reload the aggregate.', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Repository/DefaultRepositoryTest.php
+++ b/tests/Unit/Repository/DefaultRepositoryTest.php
@@ -15,11 +15,14 @@ use Patchlevel\EventSourcing\Repository\AggregateNotFound;
 use Patchlevel\EventSourcing\Repository\AggregateOutdated;
 use Patchlevel\EventSourcing\Repository\AggregateUnknown;
 use Patchlevel\EventSourcing\Repository\DefaultRepository;
+use Patchlevel\EventSourcing\Repository\InvalidAggregate;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\MessageDecorator;
 use Patchlevel\EventSourcing\Repository\MessageDecorator\SplitStreamDecorator;
+use Patchlevel\EventSourcing\Repository\PlayheadMismatch;
 use Patchlevel\EventSourcing\Repository\WrongAggregate;
 use Patchlevel\EventSourcing\Snapshot\SnapshotNotFound;
 use Patchlevel\EventSourcing\Snapshot\SnapshotStore;
+use Patchlevel\EventSourcing\Snapshot\SnapshotVersionInvalid;
 use Patchlevel\EventSourcing\Store\ArchivedHeader;
 use Patchlevel\EventSourcing\Store\Criteria\ArchivedCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\Criteria;
@@ -30,12 +33,16 @@ use Patchlevel\EventSourcing\Store\Header\RecordedOnHeader;
 use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
 use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
+use Patchlevel\EventSourcing\Tests\ReturnCallback;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\AutoInitializableProfile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\BrokenAutoInitializableProfile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\NameChanged;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithBrokenPlayhead;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithSnapshot;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithStream;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -763,5 +770,204 @@ final class DefaultRepositoryTest extends TestCase
         self::assertInstanceOf(AutoInitializableProfile::class, $aggregate);
         self::assertSame(1, $aggregate->playhead());
         self::assertEquals(ProfileId::fromString('1'), $aggregate->id());
+    }
+
+    public function testLoadInitializableAggregateWithInvalidReturn(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn(new Stream([]));
+
+        $repository = new DefaultRepository($store, BrokenAutoInitializableProfile::metadata());
+
+        $this->expectException(InvalidAggregate::class);
+
+        $repository->load(ProfileId::fromString('1'));
+    }
+
+    public function testLoadAggregateWithSnapshotRebuildFailed(): void
+    {
+        $id = ProfileId::fromString('1');
+
+        $profile = ProfileWithSnapshot::createProfile(
+            $id,
+            Email::fromString('hallo@patchlevel.de'),
+        );
+
+        $badMessage = Message::create(new NameChanged('foo'))
+            ->withHeader(new StreamNameHeader('profile_with_snapshot-1'))
+            ->withHeader(new PlayheadHeader(2))
+            ->withHeader(new RecordedOnHeader(new DateTimeImmutable()));
+
+        $goodMessage = Message::create(
+            new ProfileCreated(
+                ProfileId::fromString('1'),
+                Email::fromString('hallo@patchlevel.de'),
+            ),
+        )
+            ->withHeader(new StreamNameHeader('profile_with_snapshot-1'))
+            ->withHeader(new PlayheadHeader(1))
+            ->withHeader(new RecordedOnHeader(new DateTimeImmutable()));
+
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->exactly(2))
+            ->method('load')
+            ->willReturnCallback(new ReturnCallback([
+                [
+                    [
+                        new Criteria(
+                            new StreamCriterion('profile_with_snapshot-1'),
+                            new FromPlayheadCriterion(1),
+                        ),
+                        null,
+                        null,
+                        false,
+                    ],
+                    new Stream([$badMessage]),
+                ],
+                [
+                    [
+                        new Criteria(
+                            new StreamCriterion('profile_with_snapshot-1'),
+                            new ArchivedCriterion(false),
+                        ),
+                        null,
+                        null,
+                        false,
+                    ],
+                    new Stream([$goodMessage]),
+                ],
+            ]));
+
+        $snapshotStore = $this->createMock(SnapshotStore::class);
+        $snapshotStore
+            ->expects($this->once())
+            ->method('load')
+            ->with(ProfileWithSnapshot::class, $id)
+            ->willReturn($profile);
+        $snapshotStore
+            ->expects($this->never())
+            ->method('save');
+
+        $repository = new DefaultRepository(
+            $store,
+            ProfileWithSnapshot::metadata(),
+            null,
+            $snapshotStore,
+        );
+
+        $aggregate = $repository->load($id);
+
+        self::assertInstanceOf(ProfileWithSnapshot::class, $aggregate);
+        self::assertSame(1, $aggregate->playhead());
+        self::assertEquals(Email::fromString('hallo@patchlevel.de'), $aggregate->email());
+    }
+
+    public function testLoadAggregateWithSnapshotVersionInvalid(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(new Criteria(
+                new StreamCriterion('profile_with_snapshot-1'),
+                new ArchivedCriterion(false),
+            ))
+            ->willReturn(
+                new Stream([
+                    Message::create(
+                        new ProfileCreated(
+                            ProfileId::fromString('1'),
+                            Email::fromString('hallo@patchlevel.de'),
+                        ),
+                    )
+                        ->withHeader(new StreamNameHeader('profile_with_snapshot-1'))
+                        ->withHeader(new PlayheadHeader(1))
+                        ->withHeader(new RecordedOnHeader(new DateTimeImmutable())),
+                    Message::create(
+                        new ProfileVisited(
+                            ProfileId::fromString('1'),
+                        ),
+                    )
+                        ->withHeader(new StreamNameHeader('profile_with_snapshot-1'))
+                        ->withHeader(new PlayheadHeader(2))
+                        ->withHeader(new RecordedOnHeader(new DateTimeImmutable())),
+                    Message::create(
+                        new ProfileVisited(
+                            ProfileId::fromString('1'),
+                        ),
+                    )
+                        ->withHeader(new StreamNameHeader('profile_with_snapshot-1'))
+                        ->withHeader(new PlayheadHeader(3))
+                        ->withHeader(new RecordedOnHeader(new DateTimeImmutable())),
+                ]),
+            );
+
+        $snapshotStore = $this->createMock(SnapshotStore::class);
+        $snapshotStore
+            ->expects($this->once())
+            ->method('load')
+            ->with(
+                ProfileWithSnapshot::class,
+                ProfileId::fromString('1'),
+            )
+            ->willThrowException(new SnapshotVersionInvalid('profile_with_snapshot-1'));
+
+        $snapshotStore
+            ->expects($this->once())
+            ->method('save')
+            ->with($this->isInstanceOf(ProfileWithSnapshot::class));
+
+        $repository = new DefaultRepository(
+            $store,
+            ProfileWithSnapshot::metadata(),
+            null,
+            $snapshotStore,
+        );
+
+        $aggregate = $repository->load(ProfileId::fromString('1'));
+
+        self::assertInstanceOf(ProfileWithSnapshot::class, $aggregate);
+        self::assertSame(3, $aggregate->playhead());
+        self::assertEquals(ProfileId::fromString('1'), $aggregate->id());
+    }
+
+    public function testSavePlayheadMismatch(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn(
+                new Stream([
+                    Message::create(
+                        new ProfileCreated(
+                            ProfileId::fromString('1'),
+                            Email::fromString('hallo@patchlevel.de'),
+                        ),
+                    )
+                        ->withHeader(new StreamNameHeader('profile_with_broken_playhead-1'))
+                        ->withHeader(new PlayheadHeader(1))
+                        ->withHeader(new RecordedOnHeader(new DateTimeImmutable())),
+                ]),
+            );
+        $store
+            ->expects($this->never())
+            ->method('save');
+
+        $repository = new DefaultRepository($store, ProfileWithBrokenPlayhead::metadata());
+
+        $aggregate = $repository->load(ProfileId::fromString('1'));
+
+        self::assertInstanceOf(ProfileWithBrokenPlayhead::class, $aggregate);
+
+        $aggregate->visit();
+
+        $this->expectException(PlayheadMismatch::class);
+
+        $repository->save($aggregate);
     }
 }

--- a/tests/Unit/Repository/InvalidAggregateTest.php
+++ b/tests/Unit/Repository/InvalidAggregateTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository;
+
+use Patchlevel\EventSourcing\Repository\InvalidAggregate;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+use function sprintf;
+
+#[CoversClass(InvalidAggregate::class)]
+final class InvalidAggregateTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new InvalidAggregate('initialize', Profile::class, new stdClass());
+
+        self::assertSame(
+            sprintf('The method "initialize" in "%s" returned "stdClass". Expected an instance of "%s".', Profile::class, Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Repository/MessageDecorator/EventTagDecoratorTest.php
+++ b/tests/Unit/Repository/MessageDecorator/EventTagDecoratorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository\MessageDecorator;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Repository\MessageDecorator\EventTagDecorator;
+use Patchlevel\EventSourcing\Serializer\EventTagExtractor;
+use Patchlevel\EventSourcing\Store\Header\TagsHeader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventTagDecorator::class)]
+final class EventTagDecoratorTest extends TestCase
+{
+    public function testAddTagsHeader(): void
+    {
+        $event = new ProfileCreated(
+            ProfileId::fromString('1'),
+            Email::fromString('foo@bar.com'),
+        );
+
+        $message = Message::create($event);
+
+        $extractor = $this->createMock(EventTagExtractor::class);
+        $extractor
+            ->expects($this->once())
+            ->method('extract')
+            ->with($event)
+            ->willReturn(['profile-1']);
+
+        $decorator = new EventTagDecorator($extractor);
+
+        $decoratedMessage = $decorator($message);
+
+        self::assertSame(['profile-1'], $decoratedMessage->header(TagsHeader::class)->tags);
+    }
+}

--- a/tests/Unit/Repository/PlayheadMismatchTest.php
+++ b/tests/Unit/Repository/PlayheadMismatchTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository;
+
+use Patchlevel\EventSourcing\Repository\PlayheadMismatch;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(PlayheadMismatch::class)]
+final class PlayheadMismatchTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new PlayheadMismatch(Profile::class, ProfileId::fromString('1'), 1, 2);
+
+        self::assertSame(
+            sprintf('There is a mismatch between the playhead [1] and the event count [2] for the aggregate [%s] with the id [1]', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Repository/SnapshotRebuildFailedTest.php
+++ b/tests/Unit/Repository/SnapshotRebuildFailedTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository;
+
+use Patchlevel\EventSourcing\Repository\SnapshotRebuildFailed;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function sprintf;
+
+#[CoversClass(SnapshotRebuildFailed::class)]
+final class SnapshotRebuildFailedTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $id = ProfileId::fromString('1');
+        $previous = new RuntimeException('rebuild error');
+
+        $exception = new SnapshotRebuildFailed(Profile::class, $id, $previous);
+
+        self::assertSame(
+            sprintf('Rebuild from snapshot of aggregate "%s" with the id "1" failed', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
+        self::assertSame(Profile::class, $exception->aggregateClass());
+        self::assertSame($id, $exception->aggregateRootId());
+    }
+}

--- a/tests/Unit/Repository/WrongAggregateTest.php
+++ b/tests/Unit/Repository/WrongAggregateTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Repository;
+
+use Patchlevel\EventSourcing\Repository\WrongAggregate;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileWithSnapshot;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(WrongAggregate::class)]
+final class WrongAggregateTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new WrongAggregate(Profile::class, ProfileWithSnapshot::class);
+
+        self::assertSame(
+            sprintf('Wrong aggregate given: got "%s" but expected "%s"', Profile::class, ProfileWithSnapshot::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Schema/DoctrineHelperTest.php
+++ b/tests/Unit/Schema/DoctrineHelperTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Schema;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Patchlevel\EventSourcing\Schema\DoctrineHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function str_starts_with;
+
+#[CoversClass(DoctrineHelper::class)]
+final class DoctrineHelperTest extends TestCase
+{
+    public function testSameConnection(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->never())
+            ->method('getParams');
+
+        self::assertTrue(DoctrineHelper::sameDatabase($connection, $connection));
+    }
+
+    public function testSameParams(): void
+    {
+        $connectionA = $this->createMock(Connection::class);
+        $connectionA
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db']);
+        $connectionA
+            ->expects($this->never())
+            ->method('executeStatement');
+
+        $connectionB = $this->createMock(Connection::class);
+        $connectionB
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db']);
+        $connectionB
+            ->expects($this->never())
+            ->method('executeStatement');
+
+        self::assertTrue(DoctrineHelper::sameDatabase($connectionA, $connectionB));
+    }
+
+    public function testDifferentDatabase(): void
+    {
+        $connectionA = $this->createMock(Connection::class);
+        $connectionA
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db']);
+        $connectionA
+            ->expects($this->exactly(2))
+            ->method('executeStatement')
+            ->with($this->matchesRegularExpression('/^(CREATE|DROP) TABLE same_db_check_[0-9a-f]{14}/'))
+            ->willReturn(1);
+
+        $connectionB = $this->createMock(Connection::class);
+        $connectionB
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db2']);
+        $connectionB
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with($this->matchesRegularExpression('/^DROP TABLE same_db_check_[0-9a-f]{14}/'))
+            ->willThrowException(new TableNotFoundException(new Exception('table not found'), null));
+
+        self::assertFalse(DoctrineHelper::sameDatabase($connectionA, $connectionB));
+    }
+
+    public function testSameDatabaseDetectedViaCheckTable(): void
+    {
+        $connectionA = $this->createMock(Connection::class);
+        $connectionA
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db', 'host' => 'a']);
+        $connectionA
+            ->expects($this->exactly(2))
+            ->method('executeStatement')
+            ->willReturnCallback(static function (string $sql): int {
+                if (str_starts_with($sql, 'CREATE TABLE same_db_check_')) {
+                    return 1;
+                }
+
+                throw new TableNotFoundException(new Exception('table not found'), null);
+            });
+
+        $connectionB = $this->createMock(Connection::class);
+        $connectionB
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db', 'host' => 'b']);
+        $connectionB
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with($this->matchesRegularExpression('/^DROP TABLE same_db_check_[0-9a-f]{14}/'))
+            ->willReturn(1);
+
+        self::assertTrue(DoctrineHelper::sameDatabase($connectionA, $connectionB));
+    }
+
+    public function testIgnoresErrorOnSecondConnectionDrop(): void
+    {
+        $connectionA = $this->createMock(Connection::class);
+        $connectionA
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db']);
+        $connectionA
+            ->expects($this->exactly(2))
+            ->method('executeStatement')
+            ->with($this->matchesRegularExpression('/^(CREATE|DROP) TABLE same_db_check_[0-9a-f]{14}/'))
+            ->willReturn(1);
+
+        $connectionB = $this->createMock(Connection::class);
+        $connectionB
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db2']);
+        $connectionB
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->willThrowException(new RuntimeException('connection error'));
+
+        self::assertFalse(DoctrineHelper::sameDatabase($connectionA, $connectionB));
+    }
+}

--- a/tests/Unit/Serializer/AttributeEventTagExtractorTest.php
+++ b/tests/Unit/Serializer/AttributeEventTagExtractorTest.php
@@ -7,8 +7,14 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Serializer;
 use Patchlevel\EventSourcing\Attribute\EventTag;
 use Patchlevel\EventSourcing\Identifier\CustomId;
 use Patchlevel\EventSourcing\Serializer\AttributeEventTagExtractor;
+use Patchlevel\EventSourcing\Serializer\EventTagExtractorError;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Stringable;
 
+use function sprintf;
+
+#[CoversClass(AttributeEventTagExtractor::class)]
 final class AttributeEventTagExtractorTest extends TestCase
 {
     public function testExtractEmpty(): void
@@ -90,5 +96,70 @@ final class AttributeEventTagExtractorTest extends TestCase
         $tags = $extractor->extract($event);
 
         self::assertSame(['name:0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'], $tags);
+    }
+
+    public function testExtractInt(): void
+    {
+        $extractor = new AttributeEventTagExtractor();
+
+        $event = new class (42) {
+            public function __construct(
+                #[EventTag]
+                public int $number,
+            ) {
+            }
+        };
+
+        $tags = $extractor->extract($event);
+
+        self::assertSame(['42'], $tags);
+    }
+
+    public function testExtractRealStringable(): void
+    {
+        $extractor = new AttributeEventTagExtractor();
+
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'foo';
+            }
+        };
+
+        $event = new class ($stringable) {
+            public function __construct(
+                #[EventTag]
+                public Stringable $id,
+            ) {
+            }
+        };
+
+        $tags = $extractor->extract($event);
+
+        self::assertSame(['foo'], $tags);
+    }
+
+    public function testExtractInvalidValueType(): void
+    {
+        $extractor = new AttributeEventTagExtractor();
+
+        $event = new class ([]) {
+            /** @param list<string> $items */
+            public function __construct(
+                #[EventTag]
+                public array $items,
+            ) {
+            }
+        };
+
+        $this->expectException(EventTagExtractorError::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Event tag value for property "items" in class "%s" must be stringable, array given',
+                $event::class,
+            ),
+        );
+
+        $extractor->extract($event);
     }
 }

--- a/tests/Unit/Serializer/EventTagExtractorErrorTest.php
+++ b/tests/Unit/Serializer/EventTagExtractorErrorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Serializer;
+
+use Patchlevel\EventSourcing\Serializer\EventTagExtractorError;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(EventTagExtractorError::class)]
+final class EventTagExtractorErrorTest extends TestCase
+{
+    public function testInvalidValueType(): void
+    {
+        $exception = EventTagExtractorError::invalidValueType(ProfileCreated::class, 'profileId', 1.5);
+
+        self::assertSame(
+            sprintf(
+                'Event tag value for property "profileId" in class "%s" must be stringable, float given',
+                ProfileCreated::class,
+            ),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Serializer/Normalizer/IdNormalizerTest.php
+++ b/tests/Unit/Serializer/Normalizer/IdNormalizerTest.php
@@ -94,4 +94,22 @@ final class IdNormalizerTest extends TestCase
 
         $normalizer->identifierClass();
     }
+
+    public function testAutoDetectNullableType(): void
+    {
+        $normalizer = new IdNormalizer();
+        $normalizer->handleType(Type::nullable(Type::object(ProfileId::class)));
+
+        self::assertEquals(ProfileId::class, $normalizer->identifierClass());
+    }
+
+    public function testAutoDetectNotObjectType(): void
+    {
+        $this->expectException(InvalidType::class);
+
+        $normalizer = new IdNormalizer();
+        $normalizer->handleType(Type::string());
+
+        $normalizer->identifierClass();
+    }
 }

--- a/tests/Unit/Snapshot/DefaultSnapshotStoreTest.php
+++ b/tests/Unit/Snapshot/DefaultSnapshotStoreTest.php
@@ -6,6 +6,7 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Snapshot;
 
 use Patchlevel\EventSourcing\Snapshot\Adapter\SnapshotAdapter;
 use Patchlevel\EventSourcing\Snapshot\AdapterNotFound;
+use Patchlevel\EventSourcing\Snapshot\AdapterRepository;
 use Patchlevel\EventSourcing\Snapshot\DefaultSnapshotStore;
 use Patchlevel\EventSourcing\Snapshot\SnapshotNotConfigured;
 use Patchlevel\EventSourcing\Snapshot\SnapshotNotFound;
@@ -124,6 +125,31 @@ final class DefaultSnapshotStoreTest extends TestCase
     {
         $adapter = $this->createMock(SnapshotAdapter::class);
         $store = new DefaultSnapshotStore(['memory' => $adapter]);
+
+        self::assertSame($adapter, $store->adapter(ProfileWithSnapshot::class));
+    }
+
+    public function testAdapterRepositoryInstance(): void
+    {
+        $adapter = $this->createMock(SnapshotAdapter::class);
+
+        $adapterRepository = $this->createMock(AdapterRepository::class);
+        $adapterRepository
+            ->expects($this->once())
+            ->method('get')
+            ->with('memory')
+            ->willReturn($adapter);
+
+        $store = new DefaultSnapshotStore($adapterRepository);
+
+        self::assertSame($adapter, $store->adapter(ProfileWithSnapshot::class));
+    }
+
+    public function testCreateDefault(): void
+    {
+        $adapter = $this->createMock(SnapshotAdapter::class);
+
+        $store = DefaultSnapshotStore::createDefault(['memory' => $adapter]);
 
         self::assertSame($adapter, $store->adapter(ProfileWithSnapshot::class));
     }

--- a/tests/Unit/Store/AppendConditionNotMetTest.php
+++ b/tests/Unit/Store/AppendConditionNotMetTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\AppendCondition;
+use Patchlevel\EventSourcing\Store\AppendConditionNotMet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AppendConditionNotMet::class)]
+final class AppendConditionNotMetTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AppendConditionNotMet($condition = new AppendCondition());
+
+        self::assertSame(
+            'Append condition not met',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+        self::assertSame($condition, $exception->appendCondition);
+    }
+}

--- a/tests/Unit/Store/AppendConditionTest.php
+++ b/tests/Unit/Store/AppendConditionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\AppendCondition;
+use Patchlevel\EventSourcing\Store\Query;
+use Patchlevel\EventSourcing\Store\SubQuery;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AppendCondition::class)]
+final class AppendConditionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $query = new Query(new SubQuery(['foo']));
+
+        $condition = new AppendCondition($query, 42);
+
+        self::assertSame($query, $condition->query);
+        self::assertSame(42, $condition->highestSequenceNumber);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $condition = new AppendCondition();
+
+        self::assertEquals(new Query(), $condition->query);
+        self::assertNull($condition->highestSequenceNumber);
+    }
+}

--- a/tests/Unit/Store/Criteria/ArchivedCriterionTest.php
+++ b/tests/Unit/Store/Criteria/ArchivedCriterionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\ArchivedCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ArchivedCriterion::class)]
+final class ArchivedCriterionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new ArchivedCriterion(true);
+
+        self::assertSame(true, $object->archived);
+    }
+}

--- a/tests/Unit/Store/Criteria/CriteriaBuilderTest.php
+++ b/tests/Unit/Store/Criteria/CriteriaBuilderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Patchlevel\EventSourcing\Tests\Unit\Store\Crtieria;
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
 
 use Patchlevel\EventSourcing\Store\Criteria\ArchivedCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\Criteria;
@@ -11,6 +11,7 @@ use Patchlevel\EventSourcing\Store\Criteria\EventsCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\FromIndexCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\FromPlayheadCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\ToPlayheadCriterion;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -44,6 +45,43 @@ final class CriteriaBuilderTest extends TestCase
                 new ArchivedCriterion(true),
                 new EventsCriterion(['foo', 'bar']),
             ),
+            $criteria,
+        );
+    }
+
+    public function testStreamNames(): void
+    {
+        $builder = new CriteriaBuilder();
+        $criteria = $builder
+            ->streamName(['profile-1', 'profile-2'])
+            ->build();
+
+        self::assertEquals(
+            new Criteria(new StreamCriterion('profile-1', 'profile-2')),
+            $criteria,
+        );
+    }
+
+    public function testResetStreamName(): void
+    {
+        $builder = new CriteriaBuilder();
+        $criteria = $builder
+            ->streamName('profile-1')
+            ->streamName(null)
+            ->build();
+
+        self::assertEquals(new Criteria(), $criteria);
+    }
+
+    public function testToPlayhead(): void
+    {
+        $builder = new CriteriaBuilder();
+        $criteria = $builder
+            ->toPlayhead(10)
+            ->build();
+
+        self::assertEquals(
+            new Criteria(new ToPlayheadCriterion(10)),
             $criteria,
         );
     }

--- a/tests/Unit/Store/Criteria/CriteriaTest.php
+++ b/tests/Unit/Store/Criteria/CriteriaTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Patchlevel\EventSourcing\Tests\Unit\Store\Crtieria;
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
 
 use Patchlevel\EventSourcing\Store\Criteria\Criteria;
 use Patchlevel\EventSourcing\Store\Criteria\CriterionNotFound;

--- a/tests/Unit/Store/Criteria/CriterionNotFoundTest.php
+++ b/tests/Unit/Store/Criteria/CriterionNotFoundTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\CriterionNotFound;
+use Patchlevel\EventSourcing\Store\Criteria\TagCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(CriterionNotFound::class)]
+final class CriterionNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new CriterionNotFound(TagCriterion::class);
+
+        self::assertSame(
+            sprintf('criterion %s not found', TagCriterion::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Store/Criteria/EventIdCriterionTest.php
+++ b/tests/Unit/Store/Criteria/EventIdCriterionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\EventIdCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventIdCriterion::class)]
+final class EventIdCriterionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new EventIdCriterion('foo');
+
+        self::assertSame('foo', $object->eventId);
+    }
+}

--- a/tests/Unit/Store/Criteria/EventsCriterionTest.php
+++ b/tests/Unit/Store/Criteria/EventsCriterionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\EventsCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventsCriterion::class)]
+final class EventsCriterionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new EventsCriterion(['foo', 'bar']);
+
+        self::assertSame(['foo', 'bar'], $object->events);
+    }
+}

--- a/tests/Unit/Store/Criteria/FromPlayheadCriterionTest.php
+++ b/tests/Unit/Store/Criteria/FromPlayheadCriterionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\FromPlayheadCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FromPlayheadCriterion::class)]
+final class FromPlayheadCriterionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new FromPlayheadCriterion(1);
+
+        self::assertSame(1, $object->fromPlayhead);
+    }
+}

--- a/tests/Unit/Store/Criteria/StreamCriterionTest.php
+++ b/tests/Unit/Store/Criteria/StreamCriterionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StreamCriterion::class)]
+final class StreamCriterionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $criterion = new StreamCriterion('profile-1', 'foo-1');
+
+        self::assertSame(['profile-1', 'foo-1'], $criterion->streamName);
+    }
+
+    public function testStartWith(): void
+    {
+        $criterion = StreamCriterion::startWith('profile');
+
+        self::assertSame(['profile*'], $criterion->streamName);
+    }
+
+    public function testAll(): void
+    {
+        self::assertTrue((new StreamCriterion('*'))->all());
+        self::assertTrue((new StreamCriterion('profile-1', '*'))->all());
+        self::assertFalse((new StreamCriterion('profile-1'))->all());
+        self::assertFalse((new StreamCriterion())->all());
+    }
+}

--- a/tests/Unit/Store/Criteria/TagCriterionTest.php
+++ b/tests/Unit/Store/Criteria/TagCriterionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\TagCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TagCriterion::class)]
+final class TagCriterionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new TagCriterion(['foo', 'bar']);
+
+        self::assertSame(['foo', 'bar'], $object->tags);
+    }
+}

--- a/tests/Unit/Store/Criteria/ToIndexCriterionTest.php
+++ b/tests/Unit/Store/Criteria/ToIndexCriterionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\ToIndexCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToIndexCriterion::class)]
+final class ToIndexCriterionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new ToIndexCriterion(100);
+
+        self::assertSame(100, $object->toIndex);
+    }
+}

--- a/tests/Unit/Store/Criteria/ToPlayheadCriterionTest.php
+++ b/tests/Unit/Store/Criteria/ToPlayheadCriterionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Criteria;
+
+use Patchlevel\EventSourcing\Store\Criteria\ToPlayheadCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ToPlayheadCriterion::class)]
+final class ToPlayheadCriterionTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new ToPlayheadCriterion(10);
+
+        self::assertSame(10, $object->toPlayhead);
+    }
+}

--- a/tests/Unit/Store/Header/EventIdHeaderTest.php
+++ b/tests/Unit/Store/Header/EventIdHeaderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Header;
+
+use Patchlevel\EventSourcing\Store\Header\EventIdHeader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventIdHeader::class)]
+final class EventIdHeaderTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new EventIdHeader('foo');
+
+        self::assertSame('foo', $object->eventId);
+    }
+}

--- a/tests/Unit/Store/Header/IndexHeaderTest.php
+++ b/tests/Unit/Store/Header/IndexHeaderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Header;
+
+use Patchlevel\EventSourcing\Store\Header\IndexHeader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(IndexHeader::class)]
+final class IndexHeaderTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new IndexHeader(42);
+
+        self::assertSame(42, $object->index);
+    }
+}

--- a/tests/Unit/Store/Header/PlayheadHeaderTest.php
+++ b/tests/Unit/Store/Header/PlayheadHeaderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store\Header;
+
+use Patchlevel\EventSourcing\Store\Header\PlayheadHeader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PlayheadHeader::class)]
+final class PlayheadHeaderTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new PlayheadHeader(1);
+
+        self::assertSame(1, $object->playhead);
+    }
+}

--- a/tests/Unit/Store/InMemoryStoreTest.php
+++ b/tests/Unit/Store/InMemoryStoreTest.php
@@ -554,6 +554,35 @@ final class InMemoryStoreTest extends TestCase
         self::assertSame([$message1, $message4], $stream->toList());
     }
 
+    public function testArchive(): void
+    {
+        $message1 = (new Message(new ProfileVisited(ProfileId::fromString('1'))))
+            ->withHeader(new StreamNameHeader('foo'))
+            ->withHeader(new EventIdHeader('019aa600-56ef-7ca3-b92a-37c53851e2c2'))
+            ->withHeader(new RecordedOnHeader(new DateTimeImmutable()))
+            ->withHeader(new IndexHeader(1));
+        $message2 = (new Message(new ProfileVisited(ProfileId::fromString('2'))))
+            ->withHeader(new StreamNameHeader('bar'))
+            ->withHeader(new EventIdHeader('019aa600-8834-752a-ae2e-d8650e84f403'))
+            ->withHeader(new RecordedOnHeader(new DateTimeImmutable()))
+            ->withHeader(new IndexHeader(2));
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $store->archive(new Criteria(new StreamCriterion('bar')));
+
+        $messages = $store->load()->toList();
+
+        self::assertCount(2, $messages);
+        self::assertFalse($messages[0]->hasHeader(ArchivedHeader::class));
+        self::assertTrue($messages[1]->hasHeader(ArchivedHeader::class));
+
+        $archivedMessages = $store->load(new Criteria(new ArchivedCriterion(true)))->toList();
+
+        self::assertCount(1, $archivedMessages);
+        self::assertSame('bar', $archivedMessages[0]->header(StreamNameHeader::class)->streamName);
+    }
+
     public function testTransactional(): void
     {
         $called = false;

--- a/tests/Unit/Store/InvalidStreamNameTest.php
+++ b/tests/Unit/Store/InvalidStreamNameTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\InvalidStreamName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InvalidStreamName::class)]
+final class InvalidStreamNameTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new InvalidStreamName('foo');
+
+        self::assertSame(
+            'Invalid stream name "foo"',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Store/InvalidTypeTest.php
+++ b/tests/Unit/Store/InvalidTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\InvalidType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InvalidType::class)]
+final class InvalidTypeTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new InvalidType('limit', 'int');
+
+        self::assertSame(
+            '"limit" should be a "int" type',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Store/LockingNotImplementedTest.php
+++ b/tests/Unit/Store/LockingNotImplementedTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Patchlevel\EventSourcing\Store\LockingNotImplemented;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(LockingNotImplemented::class)]
+final class LockingNotImplementedTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new LockingNotImplemented(SQLitePlatform::class);
+
+        self::assertSame(
+            sprintf('Locking is not implemented on platform %s. Disable locking in the store options.', SQLitePlatform::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Store/MissingDataForStorageTest.php
+++ b/tests/Unit/Store/MissingDataForStorageTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\MissingDataForStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(MissingDataForStorage::class)]
+final class MissingDataForStorageTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MissingDataForStorage('streamName', $previous = new RuntimeException('foo'));
+
+        self::assertSame(
+            'Cannot save because the following information is missing: "streamName"',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Unit/Store/MissingEventRegistryTest.php
+++ b/tests/Unit/Store/MissingEventRegistryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Metadata\Event\EventRegistry;
+use Patchlevel\EventSourcing\Store\Criteria\EventsCriterion;
+use Patchlevel\EventSourcing\Store\MissingEventRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(MissingEventRegistry::class)]
+final class MissingEventRegistryTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MissingEventRegistry(EventsCriterion::class);
+
+        self::assertSame(
+            sprintf('criterion %s not supported without an %s given', EventsCriterion::class, EventRegistry::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Store/StoreIsReadOnlyTest.php
+++ b/tests/Unit/Store/StoreIsReadOnlyTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\StoreIsReadOnly;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StoreIsReadOnly::class)]
+final class StoreIsReadOnlyTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new StoreIsReadOnly();
+
+        self::assertSame(
+            'Store is in read only mode',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
@@ -27,16 +27,24 @@ use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Message\Serializer\HeadersSerializer;
 use Patchlevel\EventSourcing\Serializer\EventSerializer;
 use Patchlevel\EventSourcing\Serializer\SerializedEvent;
+use Patchlevel\EventSourcing\Store\ArchivedHeader;
+use Patchlevel\EventSourcing\Store\Criteria\Criteria;
 use Patchlevel\EventSourcing\Store\Criteria\CriteriaBuilder;
+use Patchlevel\EventSourcing\Store\Criteria\EventIdCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\StreamCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\ToIndexCriterion;
 use Patchlevel\EventSourcing\Store\Header\EventIdHeader;
+use Patchlevel\EventSourcing\Store\Header\IndexHeader;
 use Patchlevel\EventSourcing\Store\Header\PlayheadHeader;
 use Patchlevel\EventSourcing\Store\Header\RecordedOnHeader;
 use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
 use Patchlevel\EventSourcing\Store\LockCouldNotBeAcquired;
 use Patchlevel\EventSourcing\Store\LockCouldNotBeFreed;
+use Patchlevel\EventSourcing\Store\LockingNotImplemented;
 use Patchlevel\EventSourcing\Store\MissingDataForStorage;
 use Patchlevel\EventSourcing\Store\StreamDoctrineDbalStore;
 use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
+use Patchlevel\EventSourcing\Store\UnsupportedCriterion;
 use Patchlevel\EventSourcing\Store\WrongQueryResult;
 use Patchlevel\EventSourcing\Tests\ReturnCallback;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
@@ -51,8 +59,11 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
+use Ramsey\Uuid\Uuid;
 use RuntimeException;
+use stdClass;
 
+use function is_string;
 use function iterator_to_array;
 use function method_exists;
 
@@ -1781,5 +1792,1217 @@ final class StreamDoctrineDbalStoreTest extends TestCase
         $doctrineDbalStore->configureSchema($schema, $connection);
 
         self::assertEquals($expectedSchema, $schema);
+    }
+
+    public function testLoadBackwards(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('iterateAssociative')
+            ->willReturn(new EmptyIterator());
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT * FROM event_store ORDER BY id DESC', [], $this->isArray())
+            ->willReturn($result);
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $stream = $doctrineDbalStore->load(backwards: true);
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithEmptyStreamCriterion(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('iterateAssociative')
+            ->willReturn(new EmptyIterator());
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT * FROM event_store ORDER BY id ASC', [], $this->isArray())
+            ->willReturn($result);
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $stream = $doctrineDbalStore->load(new Criteria(new StreamCriterion()));
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithToPlayhead(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('iterateAssociative')
+            ->willReturn(new EmptyIterator());
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT * FROM event_store WHERE playhead < :to_playhead ORDER BY id ASC', ['to_playhead' => 10], $this->isArray())
+            ->willReturn($result);
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $stream = $doctrineDbalStore->load(
+            (new CriteriaBuilder())
+                ->toPlayhead(10)
+                ->build(),
+        );
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithToIndex(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('iterateAssociative')
+            ->willReturn(new EmptyIterator());
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT * FROM event_store WHERE id < :to_index ORDER BY id ASC', ['to_index' => 100], $this->isArray())
+            ->willReturn($result);
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $stream = $doctrineDbalStore->load(new Criteria(new ToIndexCriterion(100)));
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithEvents(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('iterateAssociative')
+            ->willReturn(new EmptyIterator());
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT * FROM event_store WHERE event_name IN (:events) ORDER BY id ASC', [
+                'events' => ['profile.created'],
+            ], $this->isArray())
+            ->willReturn($result);
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $stream = $doctrineDbalStore->load(
+            (new CriteriaBuilder())
+                ->events(['profile.created'])
+                ->build(),
+        );
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithEventId(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('iterateAssociative')
+            ->willReturn(new EmptyIterator());
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT * FROM event_store WHERE event_id = :event_id ORDER BY id ASC', ['event_id' => '1'], $this->isArray())
+            ->willReturn($result);
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $stream = $doctrineDbalStore->load(new Criteria(new EventIdCriterion('1')));
+
+        self::assertSame(null, $stream->index());
+        self::assertSame(null, $stream->position());
+    }
+
+    public function testLoadWithUnsupportedCriterion(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->never())
+            ->method('executeQuery');
+
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $this->expectException(UnsupportedCriterion::class);
+        $doctrineDbalStore->load(new Criteria(new stdClass()));
+    }
+
+    public function testLoadWithArchivedMessageAndCustomHeaders(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('iterateAssociative')
+            ->willReturn(new ArrayIterator(
+                [
+                    [
+                        'id' => 1,
+                        'stream' => 'profile-1',
+                        'playhead' => null,
+                        'event_id' => '1',
+                        'event_name' => 'profile.created',
+                        'event_payload' => '{"profileId": "1", "email": "s"}',
+                        'recorded_on' => '2021-02-17 10:00:00',
+                        'archived' => '1',
+                        'custom_headers' => '{"foo": "bar"}',
+                    ],
+                ],
+            ));
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT * FROM event_store ORDER BY id ASC', [], $this->isArray())
+            ->willReturn($result);
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('deserialize')
+            ->with(new SerializedEvent('profile.created', '{"profileId": "1", "email": "s"}'))
+            ->willReturn(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('deserialize')
+            ->with('{"foo": "bar"}')
+            ->willReturn([new FooHeader('bar')]);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $stream = $doctrineDbalStore->load();
+        $message = $stream->current();
+
+        self::assertInstanceOf(Message::class, $message);
+        self::assertFalse($message->hasHeader(PlayheadHeader::class));
+        self::assertTrue($message->hasHeader(ArchivedHeader::class));
+        self::assertEquals(new FooHeader('bar'), $message->header(FooHeader::class));
+    }
+
+    public function testStreams(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('fetchFirstColumn')
+            ->willReturn(['foo', 'profile-1']);
+
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT DISTINCT stream FROM event_store ORDER BY stream', [], [])
+            ->willReturn($result);
+
+        $connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        self::assertSame(['foo', 'profile-1'], $doctrineDbalStore->streams());
+    }
+
+    public function testRemove(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with('DELETE FROM event_store', [], [])
+            ->willReturn(1);
+
+        $connection
+            ->expects($this->never())
+            ->method('getDatabasePlatform');
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $doctrineDbalStore->remove();
+    }
+
+    public function testRemoveWithCriteria(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with('DELETE FROM event_store WHERE stream = :stream_0', ['stream_0' => 'profile-1'], $this->isArray())
+            ->willReturn(1);
+
+        $connection
+            ->expects($this->never())
+            ->method('getDatabasePlatform');
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $connection
+            ->expects($this->once())
+            ->method('createExpressionBuilder')
+            ->willReturn(new ExpressionBuilder($connection));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $doctrineDbalStore->remove(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->build(),
+        );
+    }
+
+    public function testArchive(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with('UPDATE event_store SET archived = :value', ['value' => true], $this->isArray())
+            ->willReturn(1);
+
+        $connection
+            ->expects($this->never())
+            ->method('getDatabasePlatform');
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $doctrineDbalStore->archive();
+    }
+
+    public function testArchiveWithCriteria(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with('UPDATE event_store SET archived = :value WHERE stream = :stream_0', [
+                'stream_0' => 'profile-1',
+                'value' => true,
+            ], $this->isArray())
+            ->willReturn(1);
+
+        $connection
+            ->expects($this->never())
+            ->method('getDatabasePlatform');
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $connection
+            ->expects($this->once())
+            ->method('createExpressionBuilder')
+            ->willReturn(new ExpressionBuilder($connection));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $doctrineDbalStore->archive(
+            (new CriteriaBuilder())
+                ->streamName('profile-1')
+                ->build(),
+        );
+    }
+
+    public function testSaveWithNoMessages(): void
+    {
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $mockedConnection = $this->createMock(Connection::class);
+        $mockedConnection
+            ->expects($this->never())
+            ->method('transactional');
+        $mockedConnection
+            ->expects($this->never())
+            ->method('executeStatement');
+
+        $store = new StreamDoctrineDbalStore(
+            $mockedConnection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+        $store->save();
+    }
+
+    public function testSaveWithHeaderFallbacks(): void
+    {
+        $now = new DateTimeImmutable('2025-01-01 10:00:00');
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamNameHeader('profile-1'));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($message->event())
+            ->willReturn(new SerializedEvent(
+                'profile_created',
+                '',
+            ));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with([])
+            ->willReturn('[]');
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn($now);
+
+        $mockedConnection = $this->createMock(Connection::class);
+        $mockedConnection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $mockedConnection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(
+                static fn (Closure $closure): mixed => $closure(),
+            );
+
+        $mockedConnection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with(
+                "INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, recorded_on, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?)",
+                $this->callback(static function (array $parameters) use ($now): bool {
+                    return $parameters[0] === 'profile-1'
+                        && $parameters[1] === null
+                        && is_string($parameters[2])
+                        && Uuid::isValid($parameters[2])
+                        && $parameters[3] === 'profile_created'
+                        && $parameters[4] === ''
+                        && $parameters[5] === $now
+                        && $parameters[6] === false
+                        && $parameters[7] === '[]';
+                }),
+                [
+                    5 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                    6 => Type::getType(Types::BOOLEAN),
+                ],
+            );
+
+        $store = new StreamDoctrineDbalStore(
+            $mockedConnection,
+            $eventSerializer,
+            $headersSerializer,
+            $clock,
+        );
+        $store->save($message);
+    }
+
+    public function testSaveWithArchivedHeader(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new EventIdHeader('1'))
+            ->withHeader(new PlayheadHeader(1))
+            ->withHeader(new RecordedOnHeader($recordedOn))
+            ->withHeader(new ArchivedHeader());
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($message->event())
+            ->willReturn(new SerializedEvent(
+                'profile_created',
+                '',
+            ));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with([])
+            ->willReturn('[]');
+
+        $mockedConnection = $this->createMock(Connection::class);
+        $mockedConnection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $mockedConnection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(
+                static fn (Closure $closure): mixed => $closure(),
+            );
+
+        $mockedConnection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with("INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, recorded_on, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?)", ['profile-1', 1, '1', 'profile_created', '', $recordedOn, true, '[]'], [
+                5 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                6 => Type::getType(Types::BOOLEAN),
+            ]);
+
+        $store = new StreamDoctrineDbalStore(
+            $mockedConnection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+        $store->save($message);
+    }
+
+    public function testSaveWithCustomTableName(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new EventIdHeader('1'))
+            ->withHeader(new PlayheadHeader(1))
+            ->withHeader(new RecordedOnHeader($recordedOn));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($message->event())
+            ->willReturn(new SerializedEvent(
+                'profile_created',
+                '',
+            ));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with([])
+            ->willReturn('[]');
+
+        $mockedConnection = $this->createMock(Connection::class);
+        $mockedConnection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $mockedConnection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(
+                static fn (Closure $closure): mixed => $closure(),
+            );
+
+        $mockedConnection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with("INSERT INTO my_event_store (stream, playhead, event_id, event_name, event_payload, recorded_on, archived, custom_headers) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?)", ['profile-1', 1, '1', 'profile_created', '', $recordedOn, false, '[]'], [
+                5 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                6 => Type::getType(Types::BOOLEAN),
+            ]);
+
+        $store = new StreamDoctrineDbalStore(
+            $mockedConnection,
+            $eventSerializer,
+            $headersSerializer,
+            config: ['table_name' => 'my_event_store'],
+        );
+        $store->save($message);
+    }
+
+    public function testSaveWithExactBatchSize(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+
+        $messages = [];
+        for ($i = 1; $i <= 8191; $i++) {
+            $messages[] = Message::create(new ProfileEmailChanged(ProfileId::fromString('1'), Email::fromString('s')))
+                ->withHeader(new StreamNameHeader('profile-1'))
+                ->withHeader(new PlayheadHeader($i))
+                ->withHeader(new RecordedOnHeader($recordedOn));
+        }
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->exactly(8191))
+            ->method('serialize')
+            ->with($messages[0]->event())
+            ->willReturn(new SerializedEvent(
+                'profile_email_changed',
+                '',
+            ));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->exactly(8191))
+            ->method('serialize')
+            ->with([])
+            ->willReturn('[]');
+
+        $mockedConnection = $this->createMock(Connection::class);
+        $mockedConnection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $mockedConnection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(
+                static fn (Closure $closure): mixed => $closure(),
+            );
+
+        $mockedConnection
+            ->expects($this->once())
+            ->method('executeStatement');
+
+        $store = new StreamDoctrineDbalStore(
+            $mockedConnection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+        $store->save(...$messages);
+    }
+
+    public function testSaveWithKeepIndex(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new EventIdHeader('1'))
+            ->withHeader(new PlayheadHeader(1))
+            ->withHeader(new RecordedOnHeader($recordedOn))
+            ->withHeader(new IndexHeader(42));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($message->event())
+            ->willReturn(new SerializedEvent(
+                'profile_created',
+                '',
+            ));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with([])
+            ->willReturn('[]');
+
+        $mockedConnection = $this->createMock(Connection::class);
+        $mockedConnection
+            ->expects($this->exactly(3))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $mockedConnection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(
+                static fn (Closure $closure): mixed => $closure(),
+            );
+
+        $mockedConnection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with("INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, recorded_on, archived, custom_headers, id) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?, ?)", ['profile-1', 1, '1', 'profile_created', '', $recordedOn, false, '[]', 42], [
+                5 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                6 => Type::getType(Types::BOOLEAN),
+            ]);
+
+        $store = new StreamDoctrineDbalStore(
+            $mockedConnection,
+            $eventSerializer,
+            $headersSerializer,
+            config: ['keep_index' => true],
+        );
+        $store->save($message);
+    }
+
+    public function testSaveWithKeepIndexMissingHeader(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new EventIdHeader('1'))
+            ->withHeader(new PlayheadHeader(1))
+            ->withHeader(new RecordedOnHeader($recordedOn));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($message->event())
+            ->willReturn(new SerializedEvent(
+                'profile_created',
+                '',
+            ));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with([])
+            ->willReturn('[]');
+
+        $mockedConnection = $this->createMock(Connection::class);
+        $mockedConnection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $mockedConnection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(
+                static fn (Closure $closure): mixed => $closure(),
+            );
+
+        $mockedConnection
+            ->expects($this->never())
+            ->method('executeStatement');
+
+        $store = new StreamDoctrineDbalStore(
+            $mockedConnection,
+            $eventSerializer,
+            $headersSerializer,
+            config: ['keep_index' => true],
+        );
+
+        $this->expectException(MissingDataForStorage::class);
+        $store->save($message);
+    }
+
+    public function testSaveWithKeepIndexOnPostgres(): void
+    {
+        $recordedOn = new DateTimeImmutable();
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('s')))
+            ->withHeader(new StreamNameHeader('profile-1'))
+            ->withHeader(new EventIdHeader('1'))
+            ->withHeader(new PlayheadHeader(1))
+            ->withHeader(new RecordedOnHeader($recordedOn))
+            ->withHeader(new IndexHeader(42));
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $eventSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with($message->event())
+            ->willReturn(new SerializedEvent(
+                'profile_created',
+                '',
+            ));
+
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+        $headersSerializer
+            ->expects($this->once())
+            ->method('serialize')
+            ->with([])
+            ->willReturn('[]');
+
+        $mockedConnection = $this->createMock(Connection::class);
+        $mockedConnection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn(new PostgreSQLPlatform());
+        $mockedConnection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(
+                static fn (Closure $closure): mixed => $closure(),
+            );
+
+        $mockedConnection
+            ->expects($this->exactly(2))
+            ->method('executeStatement')
+            ->willReturnCallback(new ReturnCallback([
+                [
+                    [
+                        "INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, recorded_on, archived, custom_headers, id) VALUES\n(?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        ['profile-1', 1, '1', 'profile_created', '', $recordedOn, false, '[]', 42],
+                        [
+                            5 => Type::getType(Types::DATETIMETZ_IMMUTABLE),
+                            6 => Type::getType(Types::BOOLEAN),
+                        ],
+                    ],
+                    1,
+                ],
+                [
+                    ["SELECT setval('event_store_id_seq', (SELECT MAX(id) FROM event_store));", [], []],
+                    1,
+                ],
+            ]));
+
+        $store = new StreamDoctrineDbalStore(
+            $mockedConnection,
+            $eventSerializer,
+            $headersSerializer,
+            config: ['keep_index' => true, 'locking' => false],
+        );
+        $store->save($message);
+    }
+
+    public function testTransactionalWithoutLocking(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->never())
+            ->method('getDatabasePlatform');
+        $connection
+            ->expects($this->never())
+            ->method('fetchOne');
+        $connection
+            ->expects($this->never())
+            ->method('executeStatement');
+
+        $connection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(static fn (Closure $closure): mixed => $closure());
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+            config: ['locking' => false],
+        );
+
+        $store->transactional($callback(...));
+
+        self::assertTrue($callback->called);
+    }
+
+    public function testTransactionalWithCustomLockId(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new MySQLPlatform());
+
+        $connection
+            ->expects($this->exactly(2))
+            ->method('fetchOne')
+            ->willReturnMap([
+                ['SELECT GET_LOCK("42", -1)', 1],
+                ['SELECT RELEASE_LOCK("42")', 1],
+            ]);
+
+        $connection
+            ->expects($this->once())
+            ->method('transactional')
+            ->willReturnCallback(static fn (Closure $closure): mixed => $closure());
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+            config: ['lock_id' => 42],
+        );
+
+        $store->transactional($callback(...));
+
+        self::assertTrue($callback->called);
+    }
+
+    public function testTransactionalWithPostgreSQLCustomLockId(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->exactly(2))
+            ->method('getDatabasePlatform')
+            ->willReturn(new PostgreSQLPlatform());
+
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with('SELECT pg_advisory_xact_lock(42)');
+
+        $connection
+            ->expects($this->once())
+            ->method('transactional')
+            ->willReturnCallback(static fn (Closure $closure): mixed => $closure());
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+            config: ['lock_id' => 42],
+        );
+
+        $store->transactional($callback(...));
+
+        self::assertTrue($callback->called);
+    }
+
+    public function testTransactionalLockingNotImplemented(): void
+    {
+        $callback = new class () {
+            public bool $called = false;
+
+            public function __invoke(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $abstractPlatform = $this->createMock(AbstractPlatform::class);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($abstractPlatform);
+        $connection
+            ->expects($this->never())
+            ->method('fetchOne');
+        $connection
+            ->expects($this->never())
+            ->method('executeStatement');
+        $connection
+            ->expects($this->once())
+            ->method('transactional')
+            ->with($this->isInstanceOf(Closure::class))
+            ->willReturnCallback(static fn (Closure $closure): mixed => $closure());
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $store = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        $this->expectException(LockingNotImplemented::class);
+        $store->transactional($callback(...));
+    }
+
+    public function testSupportSubscription(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn(new PostgreSQLPlatform());
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        self::assertTrue($doctrineDbalStore->supportSubscription());
+    }
+
+    public function testSupportSubscriptionNotPostgres(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        self::assertFalse($doctrineDbalStore->supportSubscription());
+    }
+
+    public function testWaitNotPostgres(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->never())
+            ->method('executeStatement');
+        $connection
+            ->expects($this->never())
+            ->method('getNativeConnection');
+
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+        $doctrineDbalStore->wait(100);
     }
 }

--- a/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/StreamDoctrineDbalStoreTest.php
@@ -3005,4 +3005,19 @@ final class StreamDoctrineDbalStoreTest extends TestCase
         );
         $doctrineDbalStore->wait(100);
     }
+
+    public function testConnection(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $eventSerializer = $this->createMock(EventSerializer::class);
+        $headersSerializer = $this->createMock(HeadersSerializer::class);
+
+        $doctrineDbalStore = new StreamDoctrineDbalStore(
+            $connection,
+            $eventSerializer,
+            $headersSerializer,
+        );
+
+        self::assertSame($connection, $doctrineDbalStore->connection());
+    }
 }

--- a/tests/Unit/Store/UniqueConstraintViolationTest.php
+++ b/tests/Unit/Store/UniqueConstraintViolationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\UniqueConstraintViolation;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(UniqueConstraintViolation::class)]
+final class UniqueConstraintViolationTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new UniqueConstraintViolation($previous = new RuntimeException('foo'));
+
+        self::assertSame(
+            'unique constraint violation',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Unit/Store/UnsupportedCriterionTest.php
+++ b/tests/Unit/Store/UnsupportedCriterionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\Criteria\TagCriterion;
+use Patchlevel\EventSourcing\Store\UnsupportedCriterion;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(UnsupportedCriterion::class)]
+final class UnsupportedCriterionTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new UnsupportedCriterion(TagCriterion::class);
+
+        self::assertSame(
+            sprintf('criterion %s not supported', TagCriterion::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Store/WrongQueryResultTest.php
+++ b/tests/Unit/Store/WrongQueryResultTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Store;
+
+use Patchlevel\EventSourcing\Store\WrongQueryResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(WrongQueryResult::class)]
+final class WrongQueryResultTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new WrongQueryResult();
+
+        self::assertSame(
+            'the type of the query result is wrong',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Cleanup/CleanupFailedTest.php
+++ b/tests/Unit/Subscription/Cleanup/CleanupFailedTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Cleanup;
+
+use Patchlevel\EventSourcing\Subscription\Cleanup\CleanupFailed;
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DbalCleanupTaskHandler;
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DropTableTask;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function sprintf;
+
+#[CoversClass(CleanupFailed::class)]
+final class CleanupFailedTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new CleanupFailed('foo', $task = new DropTableTask('projection_table'), DbalCleanupTaskHandler::class, $previous = new RuntimeException('error'));
+
+        self::assertSame(
+            sprintf('Cleanup of subscription "foo" failed for task "%s" in handler "%s"', DropTableTask::class, DbalCleanupTaskHandler::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+        self::assertSame($task, $exception->task);
+        self::assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Unit/Subscription/Cleanup/CleanupTaskNotSupportedTest.php
+++ b/tests/Unit/Subscription/Cleanup/CleanupTaskNotSupportedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Cleanup;
+
+use Patchlevel\EventSourcing\Subscription\Cleanup\CleanupTaskNotSupported;
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DbalCleanupTaskHandler;
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DropTableTask;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(CleanupTaskNotSupported::class)]
+final class CleanupTaskNotSupportedTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new CleanupTaskNotSupported(new DropTableTask('projection_table'), DbalCleanupTaskHandler::class);
+
+        self::assertSame(
+            sprintf('Task "%s" is not supported by handler "%s"', DropTableTask::class, DbalCleanupTaskHandler::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Cleanup/Dbal/ConnectionNameNotSupportedTest.php
+++ b/tests/Unit/Subscription/Cleanup/Dbal/ConnectionNameNotSupportedTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Cleanup\Dbal;
+
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\ConnectionNameNotSupported;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConnectionNameNotSupported::class)]
+final class ConnectionNameNotSupportedTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new ConnectionNameNotSupported('foo');
+
+        self::assertSame(
+            'Connection name "foo" is not supported. Only a single connection is available. Please use the connection registry.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Cleanup/Dbal/DropIndexTaskTest.php
+++ b/tests/Unit/Subscription/Cleanup/Dbal/DropIndexTaskTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Cleanup\Dbal;
+
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DropIndexTask;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DropIndexTask::class)]
+final class DropIndexTaskTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new DropIndexTask('idx_foo', 'projection_table', 'foo');
+
+        self::assertSame('idx_foo', $object->index);
+        self::assertSame('projection_table', $object->table);
+        self::assertSame('foo', $object->connectionName);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $object = new DropIndexTask('idx_foo', 'projection_table');
+
+        self::assertSame('idx_foo', $object->index);
+        self::assertNull($object->connectionName);
+    }
+}

--- a/tests/Unit/Subscription/Cleanup/Dbal/DropTableTaskTest.php
+++ b/tests/Unit/Subscription/Cleanup/Dbal/DropTableTaskTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Cleanup\Dbal;
+
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DropTableTask;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DropTableTask::class)]
+final class DropTableTaskTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new DropTableTask('projection_table', 'foo');
+
+        self::assertSame('projection_table', $object->table);
+        self::assertSame('foo', $object->connectionName);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $object = new DropTableTask('projection_table');
+
+        self::assertSame('projection_table', $object->table);
+        self::assertNull($object->connectionName);
+    }
+}

--- a/tests/Unit/Subscription/Cleanup/Dbal/UnexpectedConnectionTypeTest.php
+++ b/tests/Unit/Subscription/Cleanup/Dbal/UnexpectedConnectionTypeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Cleanup\Dbal;
+
+use Doctrine\DBAL\Connection;
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\UnexpectedConnectionType;
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(UnexpectedConnectionType::class)]
+final class UnexpectedConnectionTypeTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new UnexpectedConnectionType('foo', Connection::class, PDO::class);
+
+        self::assertSame(
+            sprintf('Expected connection "foo" to be of type "%s", got "%s"', Connection::class, PDO::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+
+    public function testCreateWithNullConnectionName(): void
+    {
+        $exception = new UnexpectedConnectionType(null, Connection::class, PDO::class);
+
+        self::assertSame(
+            sprintf('Expected connection "default (null)" to be of type "%s", got "%s"', Connection::class, PDO::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Cleanup/DefaultCleanerTest.php
+++ b/tests/Unit/Subscription/Cleanup/DefaultCleanerTest.php
@@ -93,4 +93,44 @@ final class DefaultCleanerTest extends TestCase
             new Subscription('test', cleanupTasks: [new DropTableTask('test')]),
         );
     }
+
+    public function testSkipsUnsupportedHandler(): void
+    {
+        $unsupportedHandler = new class implements CleanupTaskHandler {
+            public bool $called = false;
+
+            public function __invoke(object $task): void
+            {
+                $this->called = true;
+            }
+
+            public function supports(object $task): bool
+            {
+                return false;
+            }
+        };
+
+        $supportedHandler = new class implements CleanupTaskHandler {
+            public bool $called = false;
+
+            public function __invoke(object $task): void
+            {
+                $this->called = true;
+            }
+
+            public function supports(object $task): bool
+            {
+                return true;
+            }
+        };
+
+        $cleaner = new DefaultCleaner([$unsupportedHandler, $supportedHandler]);
+        $cleaner->cleanup(
+            new Subscription('test', cleanupTasks: [new DropTableTask('test')]),
+        );
+
+        self::assertFalse($unsupportedHandler->called);
+        self::assertTrue($supportedHandler->called);
+    }
+
 }

--- a/tests/Unit/Subscription/Cleanup/DefaultCleanerTest.php
+++ b/tests/Unit/Subscription/Cleanup/DefaultCleanerTest.php
@@ -132,5 +132,4 @@ final class DefaultCleanerTest extends TestCase
         self::assertFalse($unsupportedHandler->called);
         self::assertTrue($supportedHandler->called);
     }
-
 }

--- a/tests/Unit/Subscription/Cleanup/NoHandlerForCleanupTaskTest.php
+++ b/tests/Unit/Subscription/Cleanup/NoHandlerForCleanupTaskTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Cleanup;
+
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DropTableTask;
+use Patchlevel\EventSourcing\Subscription\Cleanup\NoHandlerForCleanupTask;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(NoHandlerForCleanupTask::class)]
+final class NoHandlerForCleanupTaskTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new NoHandlerForCleanupTask($task = new DropTableTask('projection_table'));
+
+        self::assertSame(
+            sprintf('No cleanup handler for task %s', DropTableTask::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+        self::assertSame($task, $exception->task);
+    }
+}

--- a/tests/Unit/Subscription/Engine/AlreadyProcessingTest.php
+++ b/tests/Unit/Subscription/Engine/AlreadyProcessingTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Subscription\Engine\AlreadyProcessing;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AlreadyProcessing::class)]
+final class AlreadyProcessingTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new AlreadyProcessing();
+
+        self::assertSame(
+            'Subscription engine is already processing',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Engine/CatchUpSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/CatchUpSubscriptionEngineTest.php
@@ -101,5 +101,4 @@ final class CatchUpSubscriptionEngineTest extends TestCase
 
         self::assertSame($expectedResult, $engine->execute($command));
     }
-
 }

--- a/tests/Unit/Subscription/Engine/CatchUpSubscriptionEngineTest.php
+++ b/tests/Unit/Subscription/Engine/CatchUpSubscriptionEngineTest.php
@@ -8,6 +8,7 @@ use Patchlevel\EventSourcing\Subscription\Engine\CatchUpSubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\Command\Run;
 use Patchlevel\EventSourcing\Subscription\Engine\Error;
 use Patchlevel\EventSourcing\Subscription\Engine\ProcessedResult;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngine;
 use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
 use Patchlevel\EventSourcing\Subscription\Subscription;
@@ -86,4 +87,19 @@ final class CatchUpSubscriptionEngineTest extends TestCase
 
         self::assertEquals($expectedSubscriptions, $subscriptions);
     }
+
+    public function testPassthroughUnexpectedResult(): void
+    {
+        $parent = $this->createMock(SubscriptionEngine::class);
+
+        $engine = new CatchUpSubscriptionEngine($parent);
+
+        $expectedResult = new Result();
+        $command = new Run();
+
+        $parent->expects($this->once())->method('execute')->with($command)->willReturn($expectedResult);
+
+        self::assertSame($expectedResult, $engine->execute($command));
+    }
+
 }

--- a/tests/Unit/Subscription/Engine/CleanerNotConfiguredTest.php
+++ b/tests/Unit/Subscription/Engine/CleanerNotConfiguredTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Subscription\Engine\CleanerNotConfigured;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CleanerNotConfigured::class)]
+final class CleanerNotConfiguredTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new CleanerNotConfigured();
+
+        self::assertSame(
+            'Cleaner not configured.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Engine/CleanupRunnerTest.php
+++ b/tests/Unit/Subscription/Engine/CleanupRunnerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Subscription\Cleanup\Cleaner;
+use Patchlevel\EventSourcing\Subscription\Engine\CleanerNotConfigured;
+use Patchlevel\EventSourcing\Subscription\Engine\CleanupRunner;
+use Patchlevel\EventSourcing\Subscription\Engine\Error;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionManager;
+use Patchlevel\EventSourcing\Subscription\Store\SubscriptionStore;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(CleanupRunner::class)]
+final class CleanupRunnerTest extends TestCase
+{
+    public function testCleanerNotConfigured(): void
+    {
+        $subscriptionStore = $this->createMock(SubscriptionStore::class);
+        $runner = new CleanupRunner(new SubscriptionManager($subscriptionStore));
+
+        $this->expectException(CleanerNotConfigured::class);
+
+        $runner->cleanup(new Subscription('foo'));
+    }
+
+    public function testCleanupSuccessful(): void
+    {
+        $subscription = new Subscription('foo');
+
+        $subscriptionStore = $this->createMock(SubscriptionStore::class);
+        $subscriptionStore
+            ->expects($this->once())
+            ->method('remove')
+            ->with($subscription);
+
+        $cleaner = $this->createMock(Cleaner::class);
+        $cleaner
+            ->expects($this->once())
+            ->method('cleanup')
+            ->with($subscription);
+
+        $subscriptionManager = new SubscriptionManager($subscriptionStore);
+        $runner = new CleanupRunner($subscriptionManager, $cleaner);
+
+        self::assertNull($runner->cleanup($subscription));
+
+        $subscriptionManager->flush();
+    }
+
+    public function testCleanupFailed(): void
+    {
+        $subscription = new Subscription('foo');
+
+        $subscriptionStore = $this->createMock(SubscriptionStore::class);
+        $subscriptionStore
+            ->expects($this->never())
+            ->method('remove');
+
+        $exception = new RuntimeException('cleanup failed');
+
+        $cleaner = $this->createMock(Cleaner::class);
+        $cleaner
+            ->expects($this->once())
+            ->method('cleanup')
+            ->with($subscription)
+            ->willThrowException($exception);
+
+        $subscriptionManager = new SubscriptionManager($subscriptionStore);
+        $runner = new CleanupRunner($subscriptionManager, $cleaner);
+
+        $error = $runner->cleanup($subscription);
+
+        self::assertInstanceOf(Error::class, $error);
+        self::assertSame('foo', $error->subscriptionId);
+        self::assertSame('cleanup failed', $error->message);
+        self::assertSame($exception, $error->throwable);
+
+        $subscriptionManager->flush();
+    }
+
+    public function testCleanupFailedWithForce(): void
+    {
+        $subscription = new Subscription('foo');
+
+        $subscriptionStore = $this->createMock(SubscriptionStore::class);
+        $subscriptionStore
+            ->expects($this->once())
+            ->method('remove')
+            ->with($subscription);
+
+        $cleaner = $this->createMock(Cleaner::class);
+        $cleaner
+            ->expects($this->once())
+            ->method('cleanup')
+            ->with($subscription)
+            ->willThrowException(new RuntimeException('cleanup failed'));
+
+        $subscriptionManager = new SubscriptionManager($subscriptionStore);
+        $runner = new CleanupRunner($subscriptionManager, $cleaner);
+
+        $error = $runner->cleanup($subscription, true);
+
+        self::assertInstanceOf(Error::class, $error);
+
+        $subscriptionManager->flush();
+    }
+}

--- a/tests/Unit/Subscription/Engine/Command/BootTest.php
+++ b/tests/Unit/Subscription/Engine/Command/BootTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Command;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Boot;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Boot::class)]
+final class BootTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new Boot(['foo'], ['bar'], 100);
+
+        self::assertSame(['foo'], $object->ids);
+        self::assertSame(['bar'], $object->groups);
+        self::assertSame(100, $object->limit);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $object = new Boot();
+
+        self::assertNull($object->ids);
+        self::assertNull($object->groups);
+        self::assertNull($object->limit);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Command/RunTest.php
+++ b/tests/Unit/Subscription/Engine/Command/RunTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Command;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Run;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Run::class)]
+final class RunTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new Run(['foo'], ['bar'], 100);
+
+        self::assertSame(['foo'], $object->ids);
+        self::assertSame(['bar'], $object->groups);
+        self::assertSame(100, $object->limit);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $object = new Run();
+
+        self::assertNull($object->ids);
+        self::assertNull($object->groups);
+        self::assertNull($object->limit);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Command/SetupTest.php
+++ b/tests/Unit/Subscription/Engine/Command/SetupTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Command;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Setup;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Setup::class)]
+final class SetupTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new Setup(['foo'], ['bar'], true);
+
+        self::assertSame(['foo'], $object->ids);
+        self::assertSame(['bar'], $object->groups);
+        self::assertTrue($object->skipBooting);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $object = new Setup();
+
+        self::assertNull($object->ids);
+        self::assertNull($object->groups);
+        self::assertFalse($object->skipBooting);
+    }
+}

--- a/tests/Unit/Subscription/Engine/ErrorTest.php
+++ b/tests/Unit/Subscription/Engine/ErrorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Error;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(Error::class)]
+final class ErrorTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new Error('foo', 'something went wrong', $throwable = new RuntimeException('error'));
+
+        self::assertSame('foo', $object->subscriptionId);
+        self::assertSame('something went wrong', $object->message);
+        self::assertSame($throwable, $object->throwable);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Event/OnCommandTest.php
+++ b/tests/Unit/Subscription/Engine/Event/OnCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Event;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Run;
+use Patchlevel\EventSourcing\Subscription\Engine\Event\OnCommand;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OnCommand::class)]
+final class OnCommandTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $command = new Run();
+
+        $event = new OnCommand($command);
+
+        self::assertSame($command, $event->command);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Event/OnHandleMessageErrorTest.php
+++ b/tests/Unit/Subscription/Engine/Event/OnHandleMessageErrorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Event;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Subscription\Engine\Event\OnHandleMessageError;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(OnHandleMessageError::class)]
+final class OnHandleMessageErrorTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')));
+        $subscription = new Subscription('foo');
+        $throwable = new RuntimeException('error');
+
+        $event = new OnHandleMessageError($subscription, $throwable, $message, 42);
+
+        self::assertSame($subscription, $event->subscription);
+        self::assertSame($throwable, $event->throwable);
+        self::assertSame($message, $event->message);
+        self::assertSame(42, $event->index);
+        self::assertFalse($event->transitionToFailed);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Event/OnHandleMessageSuccessTest.php
+++ b/tests/Unit/Subscription/Engine/Event/OnHandleMessageSuccessTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Event;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Subscription\Engine\Event\OnHandleMessageSuccess;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OnHandleMessageSuccess::class)]
+final class OnHandleMessageSuccessTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')));
+        $subscription = new Subscription('foo');
+
+        $event = new OnHandleMessageSuccess($subscription, $message, 42);
+
+        self::assertSame($subscription, $event->subscription);
+        self::assertSame($message, $event->message);
+        self::assertSame(42, $event->index);
+        self::assertTrue($event->shouldChangePosition);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Event/OnHandleMessageTest.php
+++ b/tests/Unit/Subscription/Engine/Event/OnHandleMessageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Event;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Subscription\Engine\Event\OnHandleMessage;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OnHandleMessage::class)]
+final class OnHandleMessageTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')));
+        $subscription = new Subscription('foo');
+
+        $event = new OnHandleMessage($subscription, $message);
+
+        self::assertSame($subscription, $event->subscription);
+        self::assertSame($message, $event->message);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Event/OnResultTest.php
+++ b/tests/Unit/Subscription/Engine/Event/OnResultTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Event;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Command\Run;
+use Patchlevel\EventSourcing\Subscription\Engine\Event\OnResult;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OnResult::class)]
+final class OnResultTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $command = new Run();
+        $result = new Result();
+
+        $event = new OnResult($command, $result);
+
+        self::assertSame($command, $event->command);
+        self::assertSame($result, $event->result);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Event/OnSubscriptionProcessedTest.php
+++ b/tests/Unit/Subscription/Engine/Event/OnSubscriptionProcessedTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Event;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Event\OnSubscriptionProcessed;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OnSubscriptionProcessed::class)]
+final class OnSubscriptionProcessedTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $subscription = new Subscription('foo');
+
+        $event = new OnSubscriptionProcessed($subscription, 42);
+
+        self::assertSame($subscription, $event->subscription);
+        self::assertSame(42, $event->lastIndex);
+        self::assertSame([], $event->errors);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Event/OnSubscriptionRemovedTest.php
+++ b/tests/Unit/Subscription/Engine/Event/OnSubscriptionRemovedTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Event;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Event\OnSubscriptionRemoved;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OnSubscriptionRemoved::class)]
+final class OnSubscriptionRemovedTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $subscription = new Subscription('foo');
+
+        $event = new OnSubscriptionRemoved($subscription);
+
+        self::assertSame($subscription, $event->subscription);
+    }
+}

--- a/tests/Unit/Subscription/Engine/Event/OnSubscriptionsTest.php
+++ b/tests/Unit/Subscription/Engine/Event/OnSubscriptionsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine\Event;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Event\OnSubscriptions;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OnSubscriptions::class)]
+final class OnSubscriptionsTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $criteria = new SubscriptionEngineCriteria(['foo']);
+
+        $event = new OnSubscriptions($criteria);
+
+        self::assertSame($criteria, $event->criteria);
+    }
+}

--- a/tests/Unit/Subscription/Engine/EventFilteredStoreMessageLoaderTest.php
+++ b/tests/Unit/Subscription/Engine/EventFilteredStoreMessageLoaderTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Stream;
+use Patchlevel\EventSourcing\Metadata\Event\AttributeEventMetadataFactory;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscribeMethodMetadata;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadata;
+use Patchlevel\EventSourcing\Store\Criteria\Criteria;
+use Patchlevel\EventSourcing\Store\Criteria\EventsCriterion;
+use Patchlevel\EventSourcing\Store\Criteria\FromIndexCriterion;
+use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Subscription\Engine\EventFilteredStoreMessageLoader;
+use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
+use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessorRepository;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventFilteredStoreMessageLoader::class)]
+final class EventFilteredStoreMessageLoaderTest extends TestCase
+{
+    public function testLoadWithEventFilter(): void
+    {
+        $stream = new Stream();
+
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(new Criteria(
+                new FromIndexCriterion(5),
+                new EventsCriterion(['profile_created']),
+            ))
+            ->willReturn($stream);
+
+        $accessor = new MetadataSubscriberAccessor(
+            new class {
+            },
+            new SubscriberMetadata('foo', subscribeMethods: [
+                ProfileCreated::class => new SubscribeMethodMetadata('onProfileCreated'),
+            ]),
+        );
+
+        $subscriberRepository = $this->createMock(SubscriberAccessorRepository::class);
+        $subscriberRepository
+            ->expects($this->once())
+            ->method('get')
+            ->with('foo')
+            ->willReturn($accessor);
+
+        $loader = new EventFilteredStoreMessageLoader(
+            $store,
+            new AttributeEventMetadataFactory(),
+            $subscriberRepository,
+        );
+
+        self::assertSame($stream, $loader->load(5, [new Subscription('foo')]));
+    }
+
+    public function testLoadWithoutFilterBecauseSubscribeAll(): void
+    {
+        $stream = new Stream();
+
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(new Criteria())
+            ->willReturn($stream);
+
+        $accessor = new MetadataSubscriberAccessor(
+            new class {
+            },
+            new SubscriberMetadata('foo', subscribeMethods: [
+                '*' => new SubscribeMethodMetadata('onAll'),
+            ]),
+        );
+
+        $subscriberRepository = $this->createMock(SubscriberAccessorRepository::class);
+        $subscriberRepository
+            ->expects($this->once())
+            ->method('get')
+            ->with('foo')
+            ->willReturn($accessor);
+
+        $loader = new EventFilteredStoreMessageLoader(
+            $store,
+            new AttributeEventMetadataFactory(),
+            $subscriberRepository,
+        );
+
+        self::assertSame($stream, $loader->load(null, [new Subscription('foo')]));
+    }
+
+    public function testLoadWithoutFilterBecauseSubscriberNotFound(): void
+    {
+        $stream = new Stream();
+
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(new Criteria())
+            ->willReturn($stream);
+
+        $subscriberRepository = $this->createMock(SubscriberAccessorRepository::class);
+        $subscriberRepository
+            ->expects($this->once())
+            ->method('get')
+            ->with('foo')
+            ->willReturn(null);
+
+        $loader = new EventFilteredStoreMessageLoader(
+            $store,
+            new AttributeEventMetadataFactory(),
+            $subscriberRepository,
+        );
+
+        self::assertSame($stream, $loader->load(null, [new Subscription('foo')]));
+    }
+
+    public function testLastIndex(): void
+    {
+        $message = Message::create(new ProfileVisited(ProfileId::fromString('1')));
+
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(null, 1, null, true)
+            ->willReturn(new Stream([5 => $message]));
+
+        $subscriberRepository = $this->createMock(SubscriberAccessorRepository::class);
+
+        $loader = new EventFilteredStoreMessageLoader(
+            $store,
+            new AttributeEventMetadataFactory(),
+            $subscriberRepository,
+        );
+
+        self::assertSame(5, $loader->lastIndex());
+    }
+}

--- a/tests/Unit/Subscription/Engine/Handler/ReactivateHandlerTest.php
+++ b/tests/Unit/Subscription/Engine/Handler/ReactivateHandlerTest.php
@@ -139,5 +139,4 @@ final class ReactivateHandlerTest extends TestCase
         self::assertEquals([], $result->errors);
         self::assertSame([], $store->updatedSubscriptions);
     }
-
 }

--- a/tests/Unit/Subscription/Engine/Handler/ReactivateHandlerTest.php
+++ b/tests/Unit/Subscription/Engine/Handler/ReactivateHandlerTest.php
@@ -121,4 +121,23 @@ final class ReactivateHandlerTest extends TestCase
             new Subscription($subscriptionId, Subscription::DEFAULT_GROUP, RunMode::FromBeginning, Status::Active),
         );
     }
+
+    public function testReactivateWithMissingSubscriber(): void
+    {
+        $subscriptionId = 'test';
+
+        $store = new DummySubscriptionStore([
+            new Subscription(
+                $subscriptionId,
+                status: Status::Paused,
+            ),
+        ]);
+
+        $handler = $this->createHandler($store);
+        $result = $handler(new ReactivateCommand());
+
+        self::assertEquals([], $result->errors);
+        self::assertSame([], $store->updatedSubscriptions);
+    }
+
 }

--- a/tests/Unit/Subscription/Engine/Handler/RefreshHandlerTest.php
+++ b/tests/Unit/Subscription/Engine/Handler/RefreshHandlerTest.php
@@ -139,5 +139,4 @@ final class RefreshHandlerTest extends TestCase
         self::assertEquals([], $result->errors);
         self::assertSame([], $store->updatedSubscriptions);
     }
-
 }

--- a/tests/Unit/Subscription/Engine/Handler/RefreshHandlerTest.php
+++ b/tests/Unit/Subscription/Engine/Handler/RefreshHandlerTest.php
@@ -126,4 +126,18 @@ final class RefreshHandlerTest extends TestCase
             new Subscription('test', 'new-group', RunMode::FromNow, Status::Active, cleanupTasks: [new DropTableTask('test')]),
         );
     }
+
+    public function testRefreshWithMissingSubscriber(): void
+    {
+        $subscriptionId = 'test';
+
+        $store = new DummySubscriptionStore([new Subscription($subscriptionId)]);
+
+        $handler = $this->createHandler($store);
+        $result = $handler(new RefreshCommand());
+
+        self::assertEquals([], $result->errors);
+        self::assertSame([], $store->updatedSubscriptions);
+    }
+
 }

--- a/tests/Unit/Subscription/Engine/Handler/SetupHandlerTest.php
+++ b/tests/Unit/Subscription/Engine/Handler/SetupHandlerTest.php
@@ -351,4 +351,24 @@ final class SetupHandlerTest extends TestCase
             new Subscription($subscriptionId, Subscription::DEFAULT_GROUP, RunMode::FromNow, Status::Active, 0),
         );
     }
+
+    public function testSetupWithMissingSubscriber(): void
+    {
+        $subscriptionId = 'test';
+
+        $messageLoader = $this->createMock(MessageLoader::class);
+        $messageLoader->expects($this->once())->method('lastIndex')->willReturn(0);
+
+        $store = new DummySubscriptionStore([new Subscription($subscriptionId)]);
+        $handler = $this->createHandler($messageLoader, $store);
+
+        $result = $handler(new SetupCommand());
+
+        self::assertCount(1, $result->errors);
+        self::assertSame($subscriptionId, $result->errors[0]->subscriptionId);
+        self::assertSame('Subscriber with the subscription id "test" not found.', $result->errors[0]->message);
+        self::assertCount(1, $store->updatedSubscriptions);
+        self::assertTrue($store->updatedSubscriptions[0]->isError());
+    }
+
 }

--- a/tests/Unit/Subscription/Engine/Handler/SetupHandlerTest.php
+++ b/tests/Unit/Subscription/Engine/Handler/SetupHandlerTest.php
@@ -370,5 +370,4 @@ final class SetupHandlerTest extends TestCase
         self::assertCount(1, $store->updatedSubscriptions);
         self::assertTrue($store->updatedSubscriptions[0]->isError());
     }
-
 }

--- a/tests/Unit/Subscription/Engine/ProcessedResultTest.php
+++ b/tests/Unit/Subscription/Engine/ProcessedResultTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Error;
+use Patchlevel\EventSourcing\Subscription\Engine\ProcessedResult;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(ProcessedResult::class)]
+final class ProcessedResultTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new ProcessedResult(5, true, [$error = new Error('foo', 'bar', new RuntimeException('error'))]);
+
+        self::assertSame(5, $object->processedMessages);
+        self::assertTrue($object->finished);
+        self::assertSame([$error], $object->errors);
+    }
+
+    public function testEmpty(): void
+    {
+        $result = ProcessedResult::empty();
+
+        self::assertSame(0, $result->processedMessages);
+        self::assertTrue($result->finished);
+        self::assertSame([], $result->errors);
+    }
+
+    public function testMergeEmpty(): void
+    {
+        self::assertEquals(ProcessedResult::empty(), ProcessedResult::merge([]));
+    }
+
+    public function testMerge(): void
+    {
+        $error = new Error('foo', 'bar', new RuntimeException('error'));
+
+        $result = ProcessedResult::merge([
+            new ProcessedResult(2, true),
+            new ProcessedResult(3, false, [$error]),
+        ]);
+
+        self::assertSame(5, $result->processedMessages);
+        self::assertFalse($result->finished);
+        self::assertSame([$error], $result->errors);
+    }
+}

--- a/tests/Unit/Subscription/Engine/ResultTest.php
+++ b/tests/Unit/Subscription/Engine/ResultTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Subscription\Engine\Error;
+use Patchlevel\EventSourcing\Subscription\Engine\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(Result::class)]
+final class ResultTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $object = new Result([$error = new Error('foo', 'bar', new RuntimeException('error'))]);
+
+        self::assertSame([$error], $object->errors);
+    }
+
+    public function testEmpty(): void
+    {
+        self::assertSame([], Result::empty()->errors);
+    }
+
+    public function testMerge(): void
+    {
+        $error1 = new Error('foo', 'bar', new RuntimeException('error'));
+        $error2 = new Error('baz', 'qux', new RuntimeException('error'));
+
+        $result = Result::merge([new Result([$error1]), new Result([$error2])]);
+
+        self::assertSame([$error1, $error2], $result->errors);
+    }
+}

--- a/tests/Unit/Subscription/Engine/StoreMessageLoaderTest.php
+++ b/tests/Unit/Subscription/Engine/StoreMessageLoaderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Stream;
+use Patchlevel\EventSourcing\Store\Criteria\Criteria;
+use Patchlevel\EventSourcing\Store\Criteria\FromIndexCriterion;
+use Patchlevel\EventSourcing\Store\Store;
+use Patchlevel\EventSourcing\Subscription\Engine\StoreMessageLoader;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StoreMessageLoader::class)]
+final class StoreMessageLoaderTest extends TestCase
+{
+    public function testLoadWithoutStartIndex(): void
+    {
+        $stream = new Stream();
+
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(new Criteria())
+            ->willReturn($stream);
+
+        $loader = new StoreMessageLoader($store);
+
+        self::assertSame($stream, $loader->load(null, []));
+    }
+
+    public function testLoadWithStartIndex(): void
+    {
+        $stream = new Stream();
+
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(new Criteria(new FromIndexCriterion(5)))
+            ->willReturn($stream);
+
+        $loader = new StoreMessageLoader($store);
+
+        self::assertSame($stream, $loader->load(5, []));
+    }
+
+    public function testLastIndex(): void
+    {
+        $message = Message::create(new ProfileVisited(ProfileId::fromString('1')));
+
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(null, 1, null, true)
+            ->willReturn(new Stream([5 => $message]));
+
+        $loader = new StoreMessageLoader($store);
+
+        self::assertSame(5, $loader->lastIndex());
+    }
+
+    public function testLastIndexEmptyStream(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store
+            ->expects($this->once())
+            ->method('load')
+            ->with(null, 1, null, true)
+            ->willReturn(new Stream());
+
+        $loader = new StoreMessageLoader($store);
+
+        self::assertSame(0, $loader->lastIndex());
+    }
+}

--- a/tests/Unit/Subscription/Engine/SubscriberNotFoundTest.php
+++ b/tests/Unit/Subscription/Engine/SubscriberNotFoundTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriberNotFound;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SubscriberNotFound::class)]
+final class SubscriberNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = SubscriberNotFound::forSubscriptionId('foo');
+
+        self::assertSame(
+            'Subscriber with the subscription id "foo" not found.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Engine/SubscriptionCollectionTest.php
+++ b/tests/Unit/Subscription/Engine/SubscriptionCollectionTest.php
@@ -55,4 +55,15 @@ final class SubscriptionCollectionTest extends TestCase
 
         self::assertSame(null, $collection->lowestPosition());
     }
+
+    public function testToArray(): void
+    {
+        $subscription1 = new Subscription('foo', position: 5);
+        $subscription2 = new Subscription('bar', position: 10);
+
+        $collection = new SubscriptionCollection([$subscription1, $subscription2]);
+
+        self::assertSame([$subscription1, $subscription2], $collection->toArray());
+    }
+
 }

--- a/tests/Unit/Subscription/Engine/SubscriptionCollectionTest.php
+++ b/tests/Unit/Subscription/Engine/SubscriptionCollectionTest.php
@@ -65,5 +65,4 @@ final class SubscriptionCollectionTest extends TestCase
 
         self::assertSame([$subscription1, $subscription2], $collection->toArray());
     }
-
 }

--- a/tests/Unit/Subscription/Engine/SubscriptionEngineCriteriaTest.php
+++ b/tests/Unit/Subscription/Engine/SubscriptionEngineCriteriaTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SubscriptionEngineCriteria::class)]
+final class SubscriptionEngineCriteriaTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $criteria = new SubscriptionEngineCriteria(['foo'], ['bar']);
+
+        self::assertSame(['foo'], $criteria->ids);
+        self::assertSame(['bar'], $criteria->groups);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $criteria = new SubscriptionEngineCriteria();
+
+        self::assertNull($criteria->ids);
+        self::assertNull($criteria->groups);
+    }
+}

--- a/tests/Unit/Subscription/Engine/SubscriptionRunnerTest.php
+++ b/tests/Unit/Subscription/Engine/SubscriptionRunnerTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Engine;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Message\Stream;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadata;
+use Patchlevel\EventSourcing\Subscription\Engine\MessageLoader;
+use Patchlevel\EventSourcing\Subscription\Engine\MessageProcessor;
+use Patchlevel\EventSourcing\Subscription\Engine\ProcessedResult;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionManager;
+use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionRunner;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Status;
+use Patchlevel\EventSourcing\Subscription\Store\SubscriptionStore;
+use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
+use Patchlevel\EventSourcing\Subscription\Subscriber\SubscriberAccessorRepository;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+#[CoversClass(SubscriptionRunner::class)]
+final class SubscriptionRunnerTest extends TestCase
+{
+    public function testProcessWithoutSubscriptions(): void
+    {
+        $runner = $this->runner(
+            $this->createMock(MessageLoader::class),
+            $this->createMock(SubscriberAccessorRepository::class),
+        );
+
+        self::assertEquals(ProcessedResult::empty(), $runner->process([], null));
+    }
+
+    public function testProcessSkipsUnknownSubscriber(): void
+    {
+        $loader = $this->createMock(MessageLoader::class);
+        $loader
+            ->expects($this->never())
+            ->method('load');
+
+        $subscriberRepository = $this->createMock(SubscriberAccessorRepository::class);
+        $subscriberRepository
+            ->expects($this->atLeastOnce())
+            ->method('get')
+            ->with('foo')
+            ->willReturn(null);
+
+        $runner = $this->runner($loader, $subscriberRepository);
+
+        self::assertEquals(
+            ProcessedResult::empty(),
+            $runner->process([new Subscription('foo')], null),
+        );
+    }
+
+    public function testProcessMessages(): void
+    {
+        $subscription = new Subscription('foo', runMode: RunMode::FromBeginning, status: Status::Active);
+
+        $message = Message::create(new ProfileVisited(ProfileId::fromString('1')));
+
+        $loader = $this->createMock(MessageLoader::class);
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->with(null, [$subscription])
+            ->willReturn(new Stream([1 => $message, 2 => $message]));
+
+        $subscriberRepository = $this->subscriberRepository();
+
+        $runner = $this->runner($loader, $subscriberRepository);
+
+        $result = $runner->process([$subscription], null);
+
+        self::assertSame(2, $result->processedMessages);
+        self::assertTrue($result->finished);
+        self::assertSame([], $result->errors);
+        self::assertSame(2, $subscription->position());
+        self::assertSame(Status::Active, $subscription->status());
+    }
+
+    public function testProcessWithLimit(): void
+    {
+        $subscription = new Subscription('foo', runMode: RunMode::FromBeginning, status: Status::Active);
+
+        $message = Message::create(new ProfileVisited(ProfileId::fromString('1')));
+
+        $loader = $this->createMock(MessageLoader::class);
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->with(null, [$subscription])
+            ->willReturn(new Stream([1 => $message, 2 => $message]));
+
+        $runner = $this->runner($loader, $this->subscriberRepository());
+
+        $result = $runner->process([$subscription], 1);
+
+        self::assertSame(1, $result->processedMessages);
+        self::assertFalse($result->finished);
+        self::assertSame(1, $subscription->position());
+    }
+
+    public function testProcessFinishesRunOnceSubscription(): void
+    {
+        $subscription = new Subscription('foo', runMode: RunMode::Once, status: Status::Active);
+
+        $message = Message::create(new ProfileVisited(ProfileId::fromString('1')));
+
+        $loader = $this->createMock(MessageLoader::class);
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn(new Stream([1 => $message]));
+
+        $runner = $this->runner($loader, $this->subscriberRepository());
+
+        $result = $runner->process([$subscription], null);
+
+        self::assertTrue($result->finished);
+        self::assertSame(Status::Finished, $subscription->status());
+    }
+
+    public function testProcessBootFinishesRunOnceSubscription(): void
+    {
+        $subscription = new Subscription('foo', runMode: RunMode::Once, status: Status::Booting);
+
+        $message = Message::create(new ProfileVisited(ProfileId::fromString('1')));
+
+        $loader = $this->createMock(MessageLoader::class);
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn(new Stream([1 => $message]));
+
+        $runner = $this->runner($loader, $this->subscriberRepository());
+
+        $runner->process([$subscription], null, true);
+
+        self::assertSame(Status::Finished, $subscription->status());
+    }
+
+    public function testProcessBootActivatesSubscription(): void
+    {
+        $subscription = new Subscription('foo', runMode: RunMode::FromBeginning, status: Status::Booting);
+
+        $message = Message::create(new ProfileVisited(ProfileId::fromString('1')));
+
+        $loader = $this->createMock(MessageLoader::class);
+        $loader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn(new Stream([1 => $message]));
+
+        $runner = $this->runner($loader, $this->subscriberRepository());
+
+        $runner->process([$subscription], null, true);
+
+        self::assertSame(Status::Active, $subscription->status());
+    }
+
+    private function runner(
+        MessageLoader $loader,
+        SubscriberAccessorRepository $subscriberRepository,
+    ): SubscriptionRunner {
+        $eventDispatcher = new EventDispatcher();
+
+        return new SubscriptionRunner(
+            $loader,
+            new SubscriptionManager($this->createMock(SubscriptionStore::class)),
+            $subscriberRepository,
+            new MessageProcessor($subscriberRepository, $eventDispatcher),
+            $eventDispatcher,
+        );
+    }
+
+    private function subscriberRepository(): SubscriberAccessorRepository
+    {
+        $accessor = new MetadataSubscriberAccessor(
+            new class {
+            },
+            new SubscriberMetadata('foo'),
+        );
+
+        $subscriberRepository = $this->createMock(SubscriberAccessorRepository::class);
+        $subscriberRepository
+            ->method('get')
+            ->with('foo')
+            ->willReturn($accessor);
+
+        return $subscriberRepository;
+    }
+}

--- a/tests/Unit/Subscription/Lookup/LookupTest.php
+++ b/tests/Unit/Subscription/Lookup/LookupTest.php
@@ -16,6 +16,7 @@ use Patchlevel\EventSourcing\Store\Header\IndexHeader;
 use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
 use Patchlevel\EventSourcing\Store\Store;
 use Patchlevel\EventSourcing\Subscription\Lookup\Lookup;
+use Patchlevel\EventSourcing\Subscription\Lookup\MessageNotFound;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -280,4 +281,99 @@ final class LookupTest extends TestCase
 
         self::assertSame($message2, $result);
     }
+
+    public function testResetStream(): void
+    {
+        $expectedResult = new Stream([]);
+        $expectedCriteria = new Criteria(new ToIndexCriterion(1));
+
+        $store = $this->createMock(Store::class);
+        $store->expects($this->once())->method('load')->with($expectedCriteria, null, null, false)
+            ->willReturn($expectedResult);
+
+        $event = new class () {
+        };
+
+        $message = (new Message($event))
+            ->withHeader(new IndexHeader(1));
+
+        $lookup = new Lookup(
+            $store,
+            $message,
+        );
+
+        $result = $lookup->stream('foo')->stream(null)->fetchAll();
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function testForward(): void
+    {
+        $expectedResult = new Stream([]);
+        $expectedCriteria = new Criteria(new ToIndexCriterion(1));
+
+        $store = $this->createMock(Store::class);
+        $store->expects($this->once())->method('load')->with($expectedCriteria, null, null, false)
+            ->willReturn($expectedResult);
+
+        $event = new class () {
+        };
+
+        $message = (new Message($event))
+            ->withHeader(new IndexHeader(1));
+
+        $lookup = new Lookup(
+            $store,
+            $message,
+        );
+
+        $result = $lookup->backwards()->forward()->fetchAll();
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public function testFetchFirstNotFound(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store->expects($this->once())->method('load')->with(new Criteria(new ToIndexCriterion(1)), 1, null, false)
+            ->willReturn(new Stream([]));
+
+        $event = new class () {
+        };
+
+        $message = (new Message($event))
+            ->withHeader(new IndexHeader(1));
+
+        $lookup = new Lookup(
+            $store,
+            $message,
+        );
+
+        $this->expectException(MessageNotFound::class);
+
+        $lookup->fetchFirst();
+    }
+
+    public function testFetchLastNotFound(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store->expects($this->once())->method('load')->with(new Criteria(new ToIndexCriterion(1)), 1, null, true)
+            ->willReturn(new Stream([]));
+
+        $event = new class () {
+        };
+
+        $message = (new Message($event))
+            ->withHeader(new IndexHeader(1));
+
+        $lookup = new Lookup(
+            $store,
+            $message,
+        );
+
+        $this->expectException(MessageNotFound::class);
+
+        $lookup->fetchLast();
+    }
+
 }

--- a/tests/Unit/Subscription/Lookup/LookupTest.php
+++ b/tests/Unit/Subscription/Lookup/LookupTest.php
@@ -375,5 +375,4 @@ final class LookupTest extends TestCase
 
         $lookup->fetchLast();
     }
-
 }

--- a/tests/Unit/Subscription/Lookup/MessageNotFoundTest.php
+++ b/tests/Unit/Subscription/Lookup/MessageNotFoundTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Lookup;
+
+use Patchlevel\EventSourcing\Subscription\Lookup\MessageNotFound;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MessageNotFound::class)]
+final class MessageNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new MessageNotFound();
+
+        self::assertSame(
+            'Message not found',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/NoErrorToRetryTest.php
+++ b/tests/Unit/Subscription/NoErrorToRetryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription;
+
+use Patchlevel\EventSourcing\Subscription\NoErrorToRetry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NoErrorToRetry::class)]
+final class NoErrorToRetryTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new NoErrorToRetry();
+
+        self::assertSame(
+            'No error to retry.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/RetryStrategy/ClockBasedRetryStrategyTest.php
+++ b/tests/Unit/Subscription/RetryStrategy/ClockBasedRetryStrategyTest.php
@@ -108,5 +108,4 @@ final class ClockBasedRetryStrategyTest extends TestCase
 
         self::assertFalse($strategy->shouldRetry($subscription));
     }
-
 }

--- a/tests/Unit/Subscription/RetryStrategy/ClockBasedRetryStrategyTest.php
+++ b/tests/Unit/Subscription/RetryStrategy/ClockBasedRetryStrategyTest.php
@@ -98,4 +98,15 @@ final class ClockBasedRetryStrategyTest extends TestCase
         yield [0, 0, false];
         yield [1, 0, true];
     }
+
+    public function testShouldNotRetryWithoutLastSavedAt(): void
+    {
+        $clock = new FrozenClock(new DateTimeImmutable('2024-01-01 10:00:00'));
+        $strategy = new ClockBasedRetryStrategy($clock);
+
+        $subscription = new Subscription('test', retryAttempt: 1);
+
+        self::assertFalse($strategy->shouldRetry($subscription));
+    }
+
 }

--- a/tests/Unit/Subscription/RetryStrategy/NoRetryStrategyTest.php
+++ b/tests/Unit/Subscription/RetryStrategy/NoRetryStrategyTest.php
@@ -29,5 +29,4 @@ final class NoRetryStrategyTest extends TestCase
             new Subscription('test'),
         ));
     }
-
 }

--- a/tests/Unit/Subscription/RetryStrategy/NoRetryStrategyTest.php
+++ b/tests/Unit/Subscription/RetryStrategy/NoRetryStrategyTest.php
@@ -20,4 +20,14 @@ final class NoRetryStrategyTest extends TestCase
             new Subscription('test'),
         ));
     }
+
+    public function testCanRetry(): void
+    {
+        $strategy = new NoRetryStrategy();
+
+        self::assertFalse($strategy->canRetry(
+            new Subscription('test'),
+        ));
+    }
+
 }

--- a/tests/Unit/Subscription/RetryStrategy/RetryStrategyNotFoundTest.php
+++ b/tests/Unit/Subscription/RetryStrategy/RetryStrategyNotFoundTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\RetryStrategy;
+
+use Patchlevel\EventSourcing\Subscription\RetryStrategy\RetryStrategyNotFound;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RetryStrategyNotFound::class)]
+final class RetryStrategyNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new RetryStrategyNotFound('foo');
+
+        self::assertSame(
+            'Retry strategy with name "foo" not found',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/RetryStrategy/RetryStrategyRepositoryTest.php
+++ b/tests/Unit/Subscription/RetryStrategy/RetryStrategyRepositoryTest.php
@@ -60,5 +60,4 @@ final class RetryStrategyRepositoryTest extends TestCase
 
         self::assertSame($strategy, $repository->getDefaultRetryStrategy());
     }
-
 }

--- a/tests/Unit/Subscription/RetryStrategy/RetryStrategyRepositoryTest.php
+++ b/tests/Unit/Subscription/RetryStrategy/RetryStrategyRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\RetryStrategy;
 
+use Patchlevel\EventSourcing\Subscription\RetryStrategy\NoRetryStrategy;
 use Patchlevel\EventSourcing\Subscription\RetryStrategy\RetryStrategy;
 use Patchlevel\EventSourcing\Subscription\RetryStrategy\RetryStrategyNotFound;
 use Patchlevel\EventSourcing\Subscription\RetryStrategy\RetryStrategyRepository;
@@ -50,4 +51,14 @@ final class RetryStrategyRepositoryTest extends TestCase
 
         self::assertSame($strategy, $repository->get('test'));
     }
+
+    public function testWithDefault(): void
+    {
+        $strategy = new NoRetryStrategy();
+
+        $repository = RetryStrategyRepository::withDefault($strategy);
+
+        self::assertSame($strategy, $repository->getDefaultRetryStrategy());
+    }
+
 }

--- a/tests/Unit/Subscription/Store/DoctrineSubscriptionStoreTest.php
+++ b/tests/Unit/Subscription/Store/DoctrineSubscriptionStoreTest.php
@@ -1,0 +1,595 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Store;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDO\Exception;
+use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Patchlevel\EventSourcing\Subscription\Cleanup\Dbal\DropTableTask;
+use Patchlevel\EventSourcing\Subscription\RunMode;
+use Patchlevel\EventSourcing\Subscription\Status;
+use Patchlevel\EventSourcing\Subscription\Store\DoctrineSubscriptionStore;
+use Patchlevel\EventSourcing\Subscription\Store\SubscriptionCriteria;
+use Patchlevel\EventSourcing\Subscription\Store\SubscriptionNotFound;
+use Patchlevel\EventSourcing\Subscription\Store\TransactionCommitNotPossible;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Subscription\SubscriptionError;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+use function serialize;
+
+#[CoversClass(DoctrineSubscriptionStore::class)]
+final class DoctrineSubscriptionStoreTest extends TestCase
+{
+    public function testGet(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->atLeastOnce())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->with('SELECT * FROM subscriptions WHERE id = :id', ['id' => 'foo'])
+            ->willReturn([
+                'id' => 'foo',
+                'group_name' => 'default',
+                'run_mode' => 'from_beginning',
+                'position' => 42,
+                'status' => 'active',
+                'error_message' => null,
+                'error_previous_status' => null,
+                'error_context' => null,
+                'retry_attempt' => 0,
+                'last_saved_at' => '2024-01-01 10:00:00',
+                'cleanup_tasks' => null,
+            ]);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        self::assertEquals(
+            new Subscription(
+                'foo',
+                'default',
+                RunMode::FromBeginning,
+                Status::Active,
+                42,
+                null,
+                0,
+                new DateTimeImmutable('2024-01-01 10:00:00'),
+            ),
+            $store->get('foo'),
+        );
+    }
+
+    public function testGetWithErrorAndCleanupTasks(): void
+    {
+        $task = new DropTableTask('projection_table');
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->atLeastOnce())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->with('SELECT * FROM subscriptions WHERE id = :id', ['id' => 'foo'])
+            ->willReturn([
+                'id' => 'foo',
+                'group_name' => 'default',
+                'run_mode' => 'from_beginning',
+                'position' => null,
+                'status' => 'error',
+                'error_message' => 'something went wrong',
+                'error_previous_status' => 'active',
+                'error_context' => '[]',
+                'retry_attempt' => 2,
+                'last_saved_at' => '2024-01-01 10:00:00',
+                'cleanup_tasks' => serialize([$task]),
+            ]);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        self::assertEquals(
+            new Subscription(
+                'foo',
+                'default',
+                RunMode::FromBeginning,
+                Status::Error,
+                null,
+                new SubscriptionError('something went wrong', Status::Active, []),
+                2,
+                new DateTimeImmutable('2024-01-01 10:00:00'),
+                [$task],
+            ),
+            $store->get('foo'),
+        );
+    }
+
+    public function testGetNotFound(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->atLeastOnce())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->with('SELECT * FROM subscriptions WHERE id = :id', ['id' => 'foo'])
+            ->willReturn(false);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $this->expectException(SubscriptionNotFound::class);
+
+        $store->get('foo');
+    }
+
+    public function testFind(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->atLeastOnce())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'id' => 'foo',
+                    'group_name' => 'default',
+                    'run_mode' => 'from_beginning',
+                    'position' => null,
+                    'status' => 'new',
+                    'error_message' => null,
+                    'error_previous_status' => null,
+                    'error_context' => null,
+                    'retry_attempt' => 0,
+                    'last_saved_at' => '2024-01-01 10:00:00',
+                    'cleanup_tasks' => null,
+                ],
+            ]);
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with('SELECT * FROM subscriptions ORDER BY id', [], $this->isArray())
+            ->willReturn($result);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $subscriptions = $store->find();
+
+        self::assertCount(1, $subscriptions);
+        self::assertSame('foo', $subscriptions[0]->id());
+    }
+
+    public function testFindWithCriteria(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->atLeastOnce())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with(
+                'SELECT * FROM subscriptions WHERE (id IN (:ids)) AND (group_name IN (:groups)) AND (status IN (:status)) ORDER BY id',
+                [
+                    'ids' => ['foo'],
+                    'groups' => ['default'],
+                    'status' => ['active'],
+                ],
+                $this->isArray(),
+            )
+            ->willReturn($result);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        self::assertSame([], $store->find(new SubscriptionCriteria(['foo'], ['default'], [Status::Active])));
+    }
+
+    public function testClaim(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->atLeastOnce())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'id' => 'foo',
+                'group_name' => 'default',
+                'run_mode' => 'from_beginning',
+                'position' => null,
+                'status' => 'active',
+                'error_message' => null,
+                'error_previous_status' => null,
+                'error_context' => null,
+                'retry_attempt' => 0,
+                'last_saved_at' => '2024-01-01 10:00:00',
+                'cleanup_tasks' => null,
+            ]);
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with(
+                'SELECT * FROM subscriptions WHERE (id = :id) AND (status IN (:status))',
+                [
+                    'id' => 'foo',
+                    'status' => ['active'],
+                ],
+                $this->isArray(),
+            )
+            ->willReturn($result);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $subscription = $store->claim('foo', new SubscriptionCriteria(status: [Status::Active]));
+
+        self::assertInstanceOf(Subscription::class, $subscription);
+        self::assertSame('foo', $subscription->id());
+    }
+
+    public function testClaimNotFound(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->atLeastOnce())
+            ->method('getDatabasePlatform')
+            ->willReturn(new SQLitePlatform());
+        $connection
+            ->expects($this->once())
+            ->method('createQueryBuilder')
+            ->willReturnCallback(
+                static fn (): QueryBuilder => new QueryBuilder($connection),
+            );
+        $result = $this->createMock(Result::class);
+        $result
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn(false);
+        $connection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        self::assertNull($store->claim('foo', new SubscriptionCriteria(status: [Status::Active])));
+    }
+
+    public function testAdd(): void
+    {
+        $now = new DateTimeImmutable('2024-01-01 10:00:00');
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn($now);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('insert')
+            ->with(
+                'subscriptions',
+                [
+                    'id' => 'foo',
+                    'group_name' => 'default',
+                    'run_mode' => 'from_beginning',
+                    'status' => 'new',
+                    'position' => null,
+                    'error_message' => null,
+                    'error_previous_status' => null,
+                    'error_context' => null,
+                    'retry_attempt' => 0,
+                    'last_saved_at' => $now,
+                    'cleanup_tasks' => null,
+                ],
+                ['last_saved_at' => Types::DATETIME_IMMUTABLE],
+            );
+
+        $store = new DoctrineSubscriptionStore($connection, $clock);
+
+        $store->add(new Subscription('foo'));
+    }
+
+    public function testAddWithError(): void
+    {
+        $now = new DateTimeImmutable('2024-01-01 10:00:00');
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn($now);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('insert')
+            ->with(
+                'subscriptions',
+                [
+                    'id' => 'foo',
+                    'group_name' => 'default',
+                    'run_mode' => 'from_beginning',
+                    'status' => 'error',
+                    'position' => null,
+                    'error_message' => 'something went wrong',
+                    'error_previous_status' => 'active',
+                    'error_context' => '[]',
+                    'retry_attempt' => 0,
+                    'last_saved_at' => $now,
+                    'cleanup_tasks' => null,
+                ],
+                ['last_saved_at' => Types::DATETIME_IMMUTABLE],
+            );
+
+        $store = new DoctrineSubscriptionStore($connection, $clock);
+
+        $store->add(new Subscription(
+            'foo',
+            status: Status::Error,
+            error: new SubscriptionError('something went wrong', Status::Active, []),
+        ));
+    }
+
+    public function testUpdate(): void
+    {
+        $now = new DateTimeImmutable('2024-01-01 10:00:00');
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn($now);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('update')
+            ->with(
+                'subscriptions',
+                [
+                    'group_name' => 'default',
+                    'run_mode' => 'from_beginning',
+                    'status' => 'new',
+                    'position' => null,
+                    'error_message' => null,
+                    'error_previous_status' => null,
+                    'error_context' => null,
+                    'retry_attempt' => 0,
+                    'last_saved_at' => $now,
+                    'cleanup_tasks' => null,
+                ],
+                ['id' => 'foo'],
+                ['last_saved_at' => Types::DATETIME_IMMUTABLE],
+            )
+            ->willReturn(1);
+
+        $store = new DoctrineSubscriptionStore($connection, $clock);
+
+        $store->update(new Subscription('foo'));
+    }
+
+    public function testUpdateNotFound(): void
+    {
+        $now = new DateTimeImmutable('2024-01-01 10:00:00');
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn($now);
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('update')
+            ->willReturn(0);
+
+        $store = new DoctrineSubscriptionStore($connection, $clock);
+
+        $this->expectException(SubscriptionNotFound::class);
+
+        $store->update(new Subscription('foo'));
+    }
+
+    public function testRemove(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('delete')
+            ->with('subscriptions', ['id' => 'foo']);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $store->remove(new Subscription('foo'));
+    }
+
+    public function testInLock(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('beginTransaction');
+        $connection
+            ->expects($this->once())
+            ->method('commit');
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $value = new DateTimeImmutable();
+
+        self::assertSame($value, $store->inLock(static fn (): DateTimeImmutable => $value));
+    }
+
+    public function testInLockRetryableException(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('beginTransaction');
+        $connection
+            ->expects($this->once())
+            ->method('commit');
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $this->expectException(TransactionCommitNotPossible::class);
+
+        $store->inLock(static function (): void {
+            throw new DeadlockException(new Exception('deadlock'), null);
+        });
+    }
+
+    public function testInLockCommitNotPossible(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('beginTransaction');
+        $connection
+            ->expects($this->once())
+            ->method('commit')
+            ->willThrowException(new DriverException(new Exception('commit failed'), null));
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $this->expectException(TransactionCommitNotPossible::class);
+
+        $store->inLock(static fn (): string => 'result');
+    }
+
+    public function testConfigureSchema(): void
+    {
+        $connection = $this->createMock(Connection::class);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $expectedSchema = new Schema();
+        $table = $expectedSchema->createTable('subscriptions');
+        $table->addColumn('id', Types::STRING)
+            ->setLength(255)
+            ->setNotnull(true);
+        $table->addColumn('group_name', Types::STRING)
+            ->setLength(32)
+            ->setNotnull(true);
+        $table->addColumn('run_mode', Types::STRING)
+            ->setLength(16)
+            ->setNotnull(true);
+        $table->addColumn('position', Types::INTEGER)
+            ->setNotnull(false);
+        $table->addColumn('status', Types::STRING)
+            ->setLength(32)
+            ->setNotnull(true);
+        $table->addColumn('error_message', Types::TEXT)
+            ->setNotnull(false);
+        $table->addColumn('error_previous_status', Types::STRING)
+            ->setLength(32)
+            ->setNotnull(false);
+        $table->addColumn('error_context', Types::JSON)
+            ->setNotnull(false);
+        $table->addColumn('retry_attempt', Types::INTEGER)
+            ->setNotnull(true);
+        $table->addColumn('last_saved_at', Types::DATETIMETZ_IMMUTABLE)
+            ->setNotnull(true);
+        $table->addColumn('cleanup_tasks', Types::TEXT)
+            ->setNotnull(false);
+
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['group_name']);
+        $table->addIndex(['status']);
+
+        $schema = new Schema();
+        $store->configureSchema($schema, $connection);
+
+        self::assertEquals($expectedSchema, $schema);
+    }
+
+    public function testConfigureSchemaWithDifferentDatabase(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db']);
+
+        $differentConnection = $this->createMock(Connection::class);
+        $differentConnection
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['dbname' => 'db2']);
+
+        $store = new DoctrineSubscriptionStore($connection);
+
+        $schema = new Schema();
+        $store->configureSchema($schema, $differentConnection);
+
+        self::assertEquals(new Schema(), $schema);
+    }
+}

--- a/tests/Unit/Subscription/Store/InMemorySubscriptionStoreTest.php
+++ b/tests/Unit/Subscription/Store/InMemorySubscriptionStoreTest.php
@@ -173,4 +173,42 @@ final class InMemorySubscriptionStoreTest extends TestCase
 
         self::assertSame([], $store->find());
     }
+
+    public function testClaim(): void
+    {
+        $subscription = new Subscription('foo', status: Status::Active);
+
+        $store = new InMemorySubscriptionStore([$subscription]);
+
+        self::assertSame(
+            $subscription,
+            $store->claim('foo', new SubscriptionCriteria(status: [Status::Active])),
+        );
+    }
+
+    public function testClaimNotFound(): void
+    {
+        $store = new InMemorySubscriptionStore();
+
+        self::assertNull($store->claim('foo', new SubscriptionCriteria()));
+    }
+
+    public function testClaimCriteriaNotMatched(): void
+    {
+        $subscription = new Subscription('foo', status: Status::New);
+
+        $store = new InMemorySubscriptionStore([$subscription]);
+
+        self::assertNull($store->claim('foo', new SubscriptionCriteria(status: [Status::Active])));
+    }
+
+    public function testInLock(): void
+    {
+        $store = new InMemorySubscriptionStore();
+
+        $subscription = new Subscription('foo');
+
+        self::assertSame($subscription, $store->inLock(static fn (): Subscription => $subscription));
+    }
+
 }

--- a/tests/Unit/Subscription/Store/InMemorySubscriptionStoreTest.php
+++ b/tests/Unit/Subscription/Store/InMemorySubscriptionStoreTest.php
@@ -210,5 +210,4 @@ final class InMemorySubscriptionStoreTest extends TestCase
 
         self::assertSame($subscription, $store->inLock(static fn (): Subscription => $subscription));
     }
-
 }

--- a/tests/Unit/Subscription/Store/SubscriptionCriteriaTest.php
+++ b/tests/Unit/Subscription/Store/SubscriptionCriteriaTest.php
@@ -4,18 +4,29 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Store;
 
-use Patchlevel\EventSourcing\Subscription\Engine\SubscriptionEngineCriteria;
+use Patchlevel\EventSourcing\Subscription\Status;
+use Patchlevel\EventSourcing\Subscription\Store\SubscriptionCriteria;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(SubscriptionEngineCriteria::class)]
+#[CoversClass(SubscriptionCriteria::class)]
 final class SubscriptionCriteriaTest extends TestCase
 {
-    public function testSubscriptionId(): void
+    public function testInstantiate(): void
     {
-        $id = 'test';
-        $criteria = new SubscriptionEngineCriteria([$id]);
+        $criteria = new SubscriptionCriteria(['foo'], ['bar'], [Status::Active]);
 
-        self::assertEquals([$id], $criteria->ids);
+        self::assertSame(['foo'], $criteria->ids);
+        self::assertSame(['bar'], $criteria->groups);
+        self::assertSame([Status::Active], $criteria->status);
+    }
+
+    public function testInstantiateWithDefaults(): void
+    {
+        $criteria = new SubscriptionCriteria();
+
+        self::assertNull($criteria->ids);
+        self::assertNull($criteria->groups);
+        self::assertNull($criteria->status);
     }
 }

--- a/tests/Unit/Subscription/Store/TransactionCommitNotPossibleTest.php
+++ b/tests/Unit/Subscription/Store/TransactionCommitNotPossibleTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Store;
+
+use Patchlevel\EventSourcing\Subscription\Store\TransactionCommitNotPossible;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(TransactionCommitNotPossible::class)]
+final class TransactionCommitNotPossibleTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new TransactionCommitNotPossible($previous = new RuntimeException('error'));
+
+        self::assertSame(
+            'Committing a transaction is not possible. Maybe your platform does not support transactional DDL.',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+        self::assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Unit/Subscription/Subscriber/ArgumentResolver/ArgumentResolverContextTest.php
+++ b/tests/Unit/Subscription/Subscriber/ArgumentResolver/ArgumentResolverContextTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber\ArgumentResolver;
+
+use Patchlevel\EventSourcing\Message\Message;
+use Patchlevel\EventSourcing\Metadata\Subscriber\SubscriberMetadata;
+use Patchlevel\EventSourcing\Subscription\Subscriber\ArgumentResolver\ArgumentResolverContext;
+use Patchlevel\EventSourcing\Subscription\Subscription;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ArgumentResolverContext::class)]
+final class ArgumentResolverContextTest extends TestCase
+{
+    public function testInstantiate(): void
+    {
+        $message = Message::create(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('foo@bar.com')));
+        $subscription = new Subscription('foo');
+        $metadata = new SubscriberMetadata('foo');
+
+        $context = new ArgumentResolverContext($message, $subscription, $metadata);
+
+        self::assertSame($message, $context->message);
+        self::assertSame($subscription, $context->subscription);
+        self::assertSame($metadata, $context->subscriber);
+    }
+}

--- a/tests/Unit/Subscription/Subscriber/BatchNotFoundTest.php
+++ b/tests/Unit/Subscription/Subscriber/BatchNotFoundTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber;
+
+use Patchlevel\EventSourcing\Subscription\Subscriber\BatchNotFound;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BatchNotFound::class)]
+final class BatchNotFoundTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new BatchNotFound('foo');
+
+        self::assertSame(
+            'No batch found for subscription "foo".',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Subscriber/DuplicateSubscriberIdTest.php
+++ b/tests/Unit/Subscription/Subscriber/DuplicateSubscriberIdTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber;
+
+use Patchlevel\EventSourcing\Subscription\Subscriber\DuplicateSubscriberId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DuplicateSubscriberId::class)]
+final class DuplicateSubscriberIdTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new DuplicateSubscriberId('foo');
+
+        self::assertSame(
+            'Duplicate subscriber id "foo".',
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
@@ -239,5 +239,4 @@ final class MetadataSubscriberAccessorTest extends TestCase
             $accessor->subscribeMethods(ProfileVisited::class),
         );
     }
-
 }

--- a/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
+++ b/tests/Unit/Subscription/Subscriber/MetadataSubscriberAccessorTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber;
 
+use Patchlevel\EventSourcing\Attribute\Cleanup;
+use Patchlevel\EventSourcing\Attribute\OnFailed;
 use Patchlevel\EventSourcing\Attribute\Setup;
 use Patchlevel\EventSourcing\Attribute\Subscribe;
 use Patchlevel\EventSourcing\Attribute\Subscriber;
@@ -15,6 +17,9 @@ use Patchlevel\EventSourcing\Subscription\Subscriber\MetadataSubscriberAccessor;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileVisited;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+use Throwable;
 
 #[CoversClass(MetadataSubscriberAccessor::class)]
 final class MetadataSubscriberAccessorTest extends TestCase
@@ -121,4 +126,118 @@ final class MetadataSubscriberAccessorTest extends TestCase
 
         self::assertEquals($subscriber, $this->accessor($subscriber)->subscriber());
     }
+
+    public function testMetadata(): void
+    {
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+        };
+
+        $accessor = $this->accessor($subscriber);
+
+        self::assertSame('profile', $accessor->metadata()->id);
+        self::assertSame($subscriber, $accessor->subscriber());
+    }
+
+    public function testCleanupMethod(): void
+    {
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+            public bool $called = false;
+
+            #[Cleanup]
+            public function cleanup(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $cleanupMethod = $this->accessor($subscriber)->cleanupMethod();
+
+        self::assertNotNull($cleanupMethod);
+
+        $cleanupMethod();
+
+        self::assertTrue($subscriber->called);
+    }
+
+    public function testNoCleanupMethod(): void
+    {
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+        };
+
+        self::assertNull($this->accessor($subscriber)->cleanupMethod());
+    }
+
+    public function testFailedMethod(): void
+    {
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+            public bool $called = false;
+            public Message|null $message = null;
+            public Throwable|null $throwable = null;
+
+            #[OnFailed]
+            public function onFailed(Message $message, Throwable $throwable): void
+            {
+                $this->called = true;
+                $this->message = $message;
+                $this->throwable = $throwable;
+            }
+        };
+
+        $failedMethod = $this->accessor($subscriber)->failedMethod();
+        $message = new Message(new stdClass());
+        $throwable = new RuntimeException();
+
+        self::assertNotNull($failedMethod);
+
+        $failedMethod($message, $throwable);
+
+        self::assertTrue($subscriber->called);
+        self::assertSame($message, $subscriber->message);
+        self::assertSame($throwable, $subscriber->throwable);
+    }
+
+    public function testNoFailedMethod(): void
+    {
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+        };
+
+        self::assertNull($this->accessor($subscriber)->failedMethod());
+    }
+
+    public function testEvents(): void
+    {
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+            #[Subscribe(ProfileVisited::class)]
+            public function onProfileVisited(Message $message): void
+            {
+            }
+        };
+
+        self::assertSame([ProfileVisited::class], $this->accessor($subscriber)->events());
+    }
+
+    public function testSubscribeMethodsCache(): void
+    {
+        $subscriber = new #[Subscriber('profile', RunMode::FromBeginning)]
+        class {
+            #[Subscribe(ProfileVisited::class)]
+            public function onProfileVisited(Message $message): void
+            {
+            }
+        };
+
+        $accessor = $this->accessor($subscriber);
+
+        self::assertSame(
+            $accessor->subscribeMethods(ProfileVisited::class),
+            $accessor->subscribeMethods(ProfileVisited::class),
+        );
+    }
+
 }

--- a/tests/Unit/Subscription/Subscriber/NoSuitableResolverTest.php
+++ b/tests/Unit/Subscription/Subscriber/NoSuitableResolverTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Patchlevel\EventSourcing\Tests\Unit\Subscription\Subscriber;
+
+use Patchlevel\EventSourcing\Subscription\Subscriber\NoSuitableResolver;
+use Patchlevel\EventSourcing\Tests\Unit\Fixture\Profile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function sprintf;
+
+#[CoversClass(NoSuitableResolver::class)]
+final class NoSuitableResolverTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $exception = new NoSuitableResolver(Profile::class, 'onProfileCreated', 'event');
+
+        self::assertSame(
+            sprintf('No suitable resolver found for argument "event" in method "onProfileCreated" of class "%s"', Profile::class),
+            $exception->getMessage(),
+        );
+        self::assertSame(0, $exception->getCode());
+    }
+}

--- a/tests/Unit/Subscription/SubscriptionTest.php
+++ b/tests/Unit/Subscription/SubscriptionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Subscription;
 
+use DateTimeImmutable;
 use Patchlevel\EventSourcing\Subscription\NoErrorToRetry;
 use Patchlevel\EventSourcing\Subscription\RunMode;
 use Patchlevel\EventSourcing\Subscription\Status;
@@ -13,6 +14,7 @@ use Patchlevel\EventSourcing\Subscription\ThrowableToErrorContextTransformer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use stdClass;
 
 #[CoversClass(Subscription::class)]
 final class SubscriptionTest extends TestCase
@@ -147,4 +149,120 @@ final class SubscriptionTest extends TestCase
 
         self::assertEquals(null, $subscription->retryAttempt());
     }
+
+    public function testGroupAndRunMode(): void
+    {
+        $subscription = new Subscription('foo');
+
+        self::assertSame('foo', $subscription->subscriberId());
+        self::assertSame(Subscription::DEFAULT_GROUP, $subscription->group());
+        self::assertSame(RunMode::FromBeginning, $subscription->runMode());
+
+        $subscription->changeGroup('other');
+        $subscription->changeRunMode(RunMode::Once);
+
+        self::assertSame('other', $subscription->group());
+        self::assertSame(RunMode::Once, $subscription->runMode());
+    }
+
+    public function testNew(): void
+    {
+        $subscription = new Subscription('foo', status: Status::Error);
+
+        $subscription->new();
+
+        self::assertTrue($subscription->isNew());
+        self::assertNull($subscription->subscriptionError());
+    }
+
+    public function testPause(): void
+    {
+        $subscription = new Subscription('foo');
+
+        $subscription->pause();
+
+        self::assertTrue($subscription->isPaused());
+        self::assertSame(Status::Paused, $subscription->status());
+    }
+
+    public function testFinished(): void
+    {
+        $subscription = new Subscription('foo');
+
+        $subscription->finished();
+
+        self::assertTrue($subscription->isFinished());
+        self::assertNull($subscription->subscriptionError());
+    }
+
+    public function testErrorWithString(): void
+    {
+        $subscription = new Subscription('foo', status: Status::Active);
+
+        $subscription->error('something went wrong');
+
+        self::assertTrue($subscription->isError());
+
+        $error = $subscription->subscriptionError();
+
+        self::assertNotNull($error);
+        self::assertSame('something went wrong', $error->errorMessage);
+        self::assertSame(Status::Active, $error->previousStatus);
+    }
+
+    public function testFailedWithThrowable(): void
+    {
+        $subscription = new Subscription('foo', status: Status::Active);
+
+        $subscription->failed(new RuntimeException('something went wrong'));
+
+        self::assertTrue($subscription->isFailed());
+
+        $error = $subscription->subscriptionError();
+
+        self::assertNotNull($error);
+        self::assertSame('something went wrong', $error->errorMessage);
+        self::assertSame(Status::Active, $error->previousStatus);
+    }
+
+    public function testFailedWithString(): void
+    {
+        $subscription = new Subscription('foo', status: Status::Active);
+
+        $subscription->failed('something went wrong');
+
+        self::assertTrue($subscription->isFailed());
+
+        $error = $subscription->subscriptionError();
+
+        self::assertNotNull($error);
+        self::assertSame('something went wrong', $error->errorMessage);
+    }
+
+    public function testLastSavedAt(): void
+    {
+        $subscription = new Subscription('foo');
+
+        self::assertNull($subscription->lastSavedAt());
+
+        $now = new DateTimeImmutable();
+        $subscription->updateLastSavedAt($now);
+
+        self::assertSame($now, $subscription->lastSavedAt());
+    }
+
+    public function testCleanupTasks(): void
+    {
+        $subscription = new Subscription('foo');
+
+        self::assertNull($subscription->cleanupTasks());
+        self::assertFalse($subscription->hasCleanupTasks());
+
+        $task = new stdClass();
+        $subscription->replaceCleanupTasks([$task]);
+
+        self::assertSame([$task], $subscription->cleanupTasks());
+        self::assertTrue($subscription->hasCleanupTasks());
+    }
+
 }

--- a/tests/Unit/Subscription/SubscriptionTest.php
+++ b/tests/Unit/Subscription/SubscriptionTest.php
@@ -264,5 +264,4 @@ final class SubscriptionTest extends TestCase
         self::assertSame([$task], $subscription->cleanupTasks());
         self::assertTrue($subscription->hasCleanupTasks());
     }
-
 }


### PR DESCRIPTION
This uncovered 2 issues:
* `SubscriptionRemoveCommand` was missing the parent call on configure (~needs a fix in 3.x too~ https://github.com/patchlevel/event-sourcing/pull/879)
* `AttributeEventTagExtractor` was converting numeric strings into `int` by using `array_keys`, we need to cast it to `string` again.