### PR TITLE
Skip null values in attribute event tag extractor

### DIFF
--- a/docs/dynamic-consistency-boundary.md
+++ b/docs/dynamic-consistency-boundary.md
@@ -46,6 +46,11 @@ final class HotelCreated
     }
 }
 ```
+
+:::note
+A tagged property that is `null` is skipped, so no tag is generated for it. This lets you tag optional properties without having to guard against missing values.
+:::
+
 A guest can check in.
 We tag the hotelId and the guest name so projections can filter by this combination.
 

--- a/src/Serializer/AttributeEventTagExtractor.php
+++ b/src/Serializer/AttributeEventTagExtractor.php
@@ -38,6 +38,10 @@ final class AttributeEventTagExtractor implements EventTagExtractor
 
             $value = $property->getValue($event);
 
+            if ($value === null) {
+                continue;
+            }
+
             if ($value instanceof Stringable || is_int($value)) {
                 $value = (string)$value;
             }

--- a/tests/Unit/Serializer/AttributeEventTagExtractorTest.php
+++ b/tests/Unit/Serializer/AttributeEventTagExtractorTest.php
@@ -139,6 +139,42 @@ final class AttributeEventTagExtractorTest extends TestCase
         self::assertSame(['foo'], $tags);
     }
 
+    public function testExtractNullIsSkipped(): void
+    {
+        $extractor = new AttributeEventTagExtractor();
+
+        $event = new class (null) {
+            public function __construct(
+                #[EventTag]
+                public string|null $id,
+            ) {
+            }
+        };
+
+        $tags = $extractor->extract($event);
+
+        self::assertSame([], $tags);
+    }
+
+    public function testExtractNullIsSkippedButOtherTagsRemain(): void
+    {
+        $extractor = new AttributeEventTagExtractor();
+
+        $event = new class ('foo', null) {
+            public function __construct(
+                #[EventTag]
+                public string $id,
+                #[EventTag(prefix: 'guest')]
+                public string|null $guestName,
+            ) {
+            }
+        };
+
+        $tags = $extractor->extract($event);
+
+        self::assertSame(['foo'], $tags);
+    }
+
     public function testExtractInvalidValueType(): void
     {
         $extractor = new AttributeEventTagExtractor();


### PR DESCRIPTION
A tagged property that is null no longer raises an invalid-value-type error, it is simply skipped and produces no tag. Makes it possible to put #[EventTag] on optional properties without guarding against missing values.