### PR TITLE
Fix event subset direction in SubQuery::includes()

### DIFF
--- a/src/Store/SubQuery.php
+++ b/src/Store/SubQuery.php
@@ -62,7 +62,10 @@ final class SubQuery
             return false;
         }
 
-        if (!self::isSubset($this->events, $other->events)) {
+        // events is an allow list: an empty list matches everything, so it is the
+        // broadest filter. Otherwise this query only covers the other one when
+        // every event the other query allows is also allowed here.
+        if ($this->events !== [] && ($other->events === [] || !self::isSubset($other->events, $this->events))) {
             return false;
         }
 

--- a/tests/Unit/Store/QueryTest.php
+++ b/tests/Unit/Store/QueryTest.php
@@ -123,6 +123,25 @@ final class QueryTest extends TestCase
             ),
         ];
 
+        yield 'broader event set absorbs narrower one' => [
+            new Query(
+                new SubQuery(
+                    ['a'],
+                    [ProfileCreated::class],
+                ),
+                new SubQuery(
+                    ['a'],
+                    [ProfileCreated::class, ProfileVisited::class],
+                ),
+            ),
+            new Query(
+                new SubQuery(
+                    ['a'],
+                    [ProfileCreated::class, ProfileVisited::class],
+                ),
+            ),
+        ];
+
         yield 'empty sub query includes all' => [
             new Query(
                 new SubQuery(

--- a/tests/Unit/Store/SubQueryTest.php
+++ b/tests/Unit/Store/SubQueryTest.php
@@ -159,15 +159,39 @@ final class SubQueryTest extends TestCase
             false,
         ];
 
-        yield 'subset includes' => [
-            new SubQuery(['tag1'], [ProfileCreated::class]),
-            new SubQuery(['tag1', 'tag2'], [ProfileCreated::class, ProfileVisited::class]),
+        yield 'fewer tags and more events includes' => [
+            new SubQuery(['tag1'], [ProfileCreated::class, ProfileVisited::class]),
+            new SubQuery(['tag1', 'tag2'], [ProfileCreated::class]),
             true,
         ];
 
-        yield 'non-subset not includes' => [
-            new SubQuery(['tag1', 'tag2'], [ProfileCreated::class, ProfileVisited::class]),
+        yield 'more tags does not include' => [
+            new SubQuery(['tag1', 'tag2'], [ProfileCreated::class]),
             new SubQuery(['tag1'], [ProfileCreated::class]),
+            false,
+        ];
+
+        yield 'more events includes fewer events' => [
+            new SubQuery(['tag1'], [ProfileCreated::class, ProfileVisited::class]),
+            new SubQuery(['tag1'], [ProfileCreated::class]),
+            true,
+        ];
+
+        yield 'fewer events does not include more events' => [
+            new SubQuery(['tag1'], [ProfileCreated::class]),
+            new SubQuery(['tag1'], [ProfileCreated::class, ProfileVisited::class]),
+            false,
+        ];
+
+        yield 'all events includes specific events' => [
+            new SubQuery(['tag1']),
+            new SubQuery(['tag1'], [ProfileCreated::class]),
+            true,
+        ];
+
+        yield 'specific events does not include all events' => [
+            new SubQuery(['tag1'], [ProfileCreated::class]),
+            new SubQuery(['tag1']),
             false,
         ];
 


### PR DESCRIPTION
The events check used the same subset direction as tags, but events is an allow list with reversed semantics: an empty list matches everything and a larger list is broader. Because of that, Query::optimize() could drop a sub-query whose events were only a subset of a sibling's, so the remaining fetch no longer covered every projection's events.                                                                                                                                 
                                                                                                                                                                                     
Now includes() only reports coverage when this query's event list is empty or the other query's events are a non-empty subset of it.