### PR TITLE
Apply the append condition to the whole event batch

### DIFF
--- a/src/Store/AppendCondition.php
+++ b/src/Store/AppendCondition.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Store;
 
+use InvalidArgumentException;
+
 /** @experimental */
 final class AppendCondition
 {
@@ -11,5 +13,11 @@ final class AppendCondition
         public readonly Query $query = new Query(),
         public readonly int|null $highestSequenceNumber = null,
     ) {
+        if ($query->subQueries !== [] && $highestSequenceNumber === null) {
+            throw new InvalidArgumentException(
+                'An AppendCondition with a non-empty query needs a highestSequenceNumber. '
+                . 'Pass 0 to require that no matching event exists yet.',
+            );
+        }
     }
 }

--- a/src/Store/TaggableDoctrineDbalStore.php
+++ b/src/Store/TaggableDoctrineDbalStore.php
@@ -416,15 +416,15 @@ final class TaggableDoctrineDbalStore implements Store, AppendStore, Subscriptio
             $position = 0;
 
             foreach ($messages as $message) {
-                $selects[] = 'SELECT :stream' . $position
-                    . ', :playhead' . $position . ($this->isPostgres ? '::int' : '')
-                    . ', :event_id' . $position
-                    . ', :event_name' . $position
-                    . ', :event_payload' . $position . ($this->isPostgres ? '::jsonb' : '')
-                    . ', :tags' . $position . ($this->isPostgres ? '::jsonb' : '')
-                    . ', :recorded_on' . $position . ($this->isPostgres ? '::timestamptz' : '')
-                    . ', :archived' . $position . ($this->isPostgres ? '::boolean' : '')
-                    . ', :custom_headers' . $position . ($this->isPostgres ? '::jsonb' : '');
+                $selects[] = 'SELECT :stream' . $position . ' AS stream'
+                    . ', :playhead' . $position . ($this->isPostgres ? '::int' : '') . ' AS playhead'
+                    . ', :event_id' . $position . ' AS event_id'
+                    . ', :event_name' . $position . ' AS event_name'
+                    . ', :event_payload' . $position . ($this->isPostgres ? '::jsonb' : '') . ' AS event_payload'
+                    . ', :tags' . $position . ($this->isPostgres ? '::jsonb' : '') . ' AS tags'
+                    . ', :recorded_on' . $position . ($this->isPostgres ? '::timestamptz' : '') . ' AS recorded_on'
+                    . ', :archived' . $position . ($this->isPostgres ? '::boolean' : '') . ' AS archived'
+                    . ', :custom_headers' . $position . ($this->isPostgres ? '::jsonb' : '') . ' AS custom_headers';
 
                 $data = $this->eventSerializer->serialize($message->event());
 
@@ -464,14 +464,21 @@ final class TaggableDoctrineDbalStore implements Store, AppendStore, Subscriptio
                 $position++;
             }
 
+            // The rows are wrapped in a derived table so that the append condition
+            // below applies to the whole batch. Appending it straight after a
+            // `UNION ALL` chain would bind it to the last SELECT only, letting every
+            // earlier event bypass the check.
+            $columnList = implode(', ', $columns);
+
             $query = sprintf(
-                'INSERT INTO %s (%s) %s',
+                'INSERT INTO %s (%s) SELECT %s FROM (%s) AS data',
                 $this->config['table_name'],
-                implode(', ', $columns),
+                $columnList,
+                $columnList,
                 implode(' UNION ALL ', $selects),
             );
 
-            if ($appendCondition instanceof AppendCondition) {
+            if ($appendCondition instanceof AppendCondition && $appendCondition->highestSequenceNumber !== null) {
                 $queryBuilder = $this->connection->createQueryBuilder()
                     ->select('events.id')
                     ->from($this->config['table_name'], 'events')

--- a/tests/Integration/Store/TaggableDoctrineDbalStoreTest.php
+++ b/tests/Integration/Store/TaggableDoctrineDbalStoreTest.php
@@ -832,6 +832,69 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
         );
     }
 
+    public function testAppendConditionRejectsEntireBatch(): void
+    {
+        $profileId1 = ProfileId::generate();
+        $profileId2 = ProfileId::generate();
+
+        $this->store->append([
+            Message::create(new ProfileCreated($profileId1, 'test'))
+                ->withHeader(new StreamNameHeader('foo'))
+                ->withHeader(new RecordedOnHeader(new DateTimeImmutable('2020-01-01 00:00:00')))
+                ->withHeader(new TagsHeader(['profile:' . $profileId1->toString()])),
+        ]);
+
+        $batch = [
+            Message::create(new ExternEvent('first'))
+                ->withHeader(new StreamNameHeader('foo'))
+                ->withHeader(new TagsHeader(['profile:' . $profileId2->toString()])),
+            Message::create(new ExternEvent('second'))
+                ->withHeader(new StreamNameHeader('foo'))
+                ->withHeader(new TagsHeader(['profile:' . $profileId2->toString()])),
+        ];
+
+        try {
+            $this->store->append(
+                $batch,
+                new AppendCondition(
+                    new Query(new SubQuery(['profile:' . $profileId1->toString()])),
+                    0,
+                ),
+            );
+
+            self::fail('Expected AppendConditionNotMet to be thrown');
+        } catch (AppendConditionNotMet) {
+        }
+
+        // not even the first event of the rejected batch may have landed
+        self::assertCount(1, iterator_to_array($this->store->load()));
+    }
+
+    public function testAppendConditionAppliesEntireBatch(): void
+    {
+        $profileId = ProfileId::generate();
+
+        $first = Message::create(new ProfileCreated($profileId, 'test'))
+            ->withHeader(new StreamNameHeader('foo'))
+            ->withHeader(new RecordedOnHeader(new DateTimeImmutable('2020-01-01 00:00:00')))
+            ->withHeader(new TagsHeader(['profile:' . $profileId->toString()]));
+
+        $second = Message::create(new ExternEvent('second'))
+            ->withHeader(new StreamNameHeader('foo'))
+            ->withHeader(new RecordedOnHeader(new DateTimeImmutable('2020-01-01 00:00:00')))
+            ->withHeader(new TagsHeader(['profile:' . $profileId->toString()]));
+
+        $this->store->append(
+            [$first, $second],
+            new AppendCondition(
+                new Query(new SubQuery(['profile:' . $profileId->toString()])),
+                0,
+            ),
+        );
+
+        self::assertStreamEquals([$first, $second], $this->store->load());
+    }
+
     public function testAppendRaceConditionEmptyQuery(): void
     {
         $profileId1 = ProfileId::generate();

--- a/tests/Unit/Store/AppendConditionTest.php
+++ b/tests/Unit/Store/AppendConditionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Patchlevel\EventSourcing\Tests\Unit\Store;
 
+use InvalidArgumentException;
 use Patchlevel\EventSourcing\Store\AppendCondition;
 use Patchlevel\EventSourcing\Store\Query;
 use Patchlevel\EventSourcing\Store\SubQuery;
@@ -29,5 +30,22 @@ final class AppendConditionTest extends TestCase
 
         self::assertEquals(new Query(), $condition->query);
         self::assertNull($condition->highestSequenceNumber);
+    }
+
+    public function testInstantiateWithZeroSequenceAndQuery(): void
+    {
+        $query = new Query(new SubQuery(['foo']));
+
+        $condition = new AppendCondition($query, 0);
+
+        self::assertSame($query, $condition->query);
+        self::assertSame(0, $condition->highestSequenceNumber);
+    }
+
+    public function testNonEmptyQueryWithoutSequenceNumberIsRejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new AppendCondition(new Query(new SubQuery(['foo'])));
     }
 }

--- a/tests/Unit/Store/TaggableDoctrineDbalStoreTest.php
+++ b/tests/Unit/Store/TaggableDoctrineDbalStoreTest.php
@@ -1804,7 +1804,7 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT :stream0, :playhead0, :event_id0, :event_name0, :event_payload0, :tags0, :recorded_on0, :archived0, :custom_headers0',
+                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers FROM (SELECT :stream0 AS stream, :playhead0 AS playhead, :event_id0 AS event_id, :event_name0 AS event_name, :event_payload0 AS event_payload, :tags0 AS tags, :recorded_on0 AS recorded_on, :archived0 AS archived, :custom_headers0 AS custom_headers) AS data',
                 [
                     'stream0' => 'profile-1',
                     'playhead0' => 1,
@@ -1883,7 +1883,7 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT :stream0, :playhead0, :event_id0, :event_name0, :event_payload0, :tags0, :recorded_on0, :archived0, :custom_headers0 UNION ALL SELECT :stream1, :playhead1, :event_id1, :event_name1, :event_payload1, :tags1, :recorded_on1, :archived1, :custom_headers1',
+                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers FROM (SELECT :stream0 AS stream, :playhead0 AS playhead, :event_id0 AS event_id, :event_name0 AS event_name, :event_payload0 AS event_payload, :tags0 AS tags, :recorded_on0 AS recorded_on, :archived0 AS archived, :custom_headers0 AS custom_headers UNION ALL SELECT :stream1 AS stream, :playhead1 AS playhead, :event_id1 AS event_id, :event_name1 AS event_name, :event_payload1 AS event_payload, :tags1 AS tags, :recorded_on1 AS recorded_on, :archived1 AS archived, :custom_headers1 AS custom_headers) AS data',
                 [
                     'stream0' => 'profile-1',
                     'playhead0' => 1,
@@ -1969,7 +1969,7 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT :stream0, :playhead0::int, :event_id0, :event_name0, :event_payload0::jsonb, :tags0::jsonb, :recorded_on0::timestamptz, :archived0::boolean, :custom_headers0::jsonb',
+                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers FROM (SELECT :stream0 AS stream, :playhead0::int AS playhead, :event_id0 AS event_id, :event_name0 AS event_name, :event_payload0::jsonb AS event_payload, :tags0::jsonb AS tags, :recorded_on0::timestamptz AS recorded_on, :archived0::boolean AS archived, :custom_headers0::jsonb AS custom_headers) AS data',
                 [
                     'stream0' => 'profile-1',
                     'playhead0' => 1,
@@ -2046,7 +2046,7 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT :stream0, :playhead0, :event_id0, :event_name0, :event_payload0, :tags0, :recorded_on0, :archived0, :custom_headers0',
+                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers FROM (SELECT :stream0 AS stream, :playhead0 AS playhead, :event_id0 AS event_id, :event_name0 AS event_name, :event_payload0 AS event_payload, :tags0 AS tags, :recorded_on0 AS recorded_on, :archived0 AS archived, :custom_headers0 AS custom_headers) AS data',
                 $this->callback(static function (array $parameters) use ($now): bool {
                     return $parameters['stream0'] === 'main'
                         && $parameters['playhead0'] === null
@@ -2128,7 +2128,7 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT :stream0, :playhead0, :event_id0, :event_name0, :event_payload0, :tags0, :recorded_on0, :archived0, :custom_headers0 WHERE (SELECT events.id FROM event_store events INNER JOIN (SELECT id FROM (SELECT id FROM event_store WHERE stream = :param1) j GROUP BY j.id) ej ON ej.id = events.id ORDER BY events.id DESC LIMIT 1) = :highestId',
+                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers FROM (SELECT :stream0 AS stream, :playhead0 AS playhead, :event_id0 AS event_id, :event_name0 AS event_name, :event_payload0 AS event_payload, :tags0 AS tags, :recorded_on0 AS recorded_on, :archived0 AS archived, :custom_headers0 AS custom_headers) AS data WHERE (SELECT events.id FROM event_store events INNER JOIN (SELECT id FROM (SELECT id FROM event_store WHERE stream = :param1) j GROUP BY j.id) ej ON ej.id = events.id ORDER BY events.id DESC LIMIT 1) = :highestId',
                 [
                     'stream0' => 'profile-1',
                     'playhead0' => 1,
@@ -2214,7 +2214,7 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT :stream0, :playhead0, :event_id0, :event_name0, :event_payload0, :tags0, :recorded_on0, :archived0, :custom_headers0 WHERE NOT EXISTS (SELECT events.id FROM event_store events ORDER BY events.id DESC LIMIT 1)',
+                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers FROM (SELECT :stream0 AS stream, :playhead0 AS playhead, :event_id0 AS event_id, :event_name0 AS event_name, :event_payload0 AS event_payload, :tags0 AS tags, :recorded_on0 AS recorded_on, :archived0 AS archived, :custom_headers0 AS custom_headers) AS data WHERE NOT EXISTS (SELECT events.id FROM event_store events ORDER BY events.id DESC LIMIT 1)',
                 [
                     'stream0' => 'profile-1',
                     'playhead0' => 1,
@@ -2297,7 +2297,7 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT :stream0, :playhead0, :event_id0, :event_name0, :event_payload0, :tags0, :recorded_on0, :archived0, :custom_headers0 WHERE (SELECT events.id FROM event_store events ORDER BY events.id DESC LIMIT 1) = :highestId',
+                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers FROM (SELECT :stream0 AS stream, :playhead0 AS playhead, :event_id0 AS event_id, :event_name0 AS event_name, :event_payload0 AS event_payload, :tags0 AS tags, :recorded_on0 AS recorded_on, :archived0 AS archived, :custom_headers0 AS custom_headers) AS data WHERE (SELECT events.id FROM event_store events ORDER BY events.id DESC LIMIT 1) = :highestId',
                 [
                     'stream0' => 'profile-1',
                     'playhead0' => 1,
@@ -2377,7 +2377,7 @@ final class TaggableDoctrineDbalStoreTest extends TestCase
             ->expects($this->once())
             ->method('executeStatement')
             ->with(
-                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT :stream0, :playhead0, :event_id0, :event_name0, :event_payload0, :tags0, :recorded_on0, :archived0, :custom_headers0',
+                'INSERT INTO event_store (stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers) SELECT stream, playhead, event_id, event_name, event_payload, tags, recorded_on, archived, custom_headers FROM (SELECT :stream0 AS stream, :playhead0 AS playhead, :event_id0 AS event_id, :event_name0 AS event_name, :event_payload0 AS event_payload, :tags0 AS tags, :recorded_on0 AS recorded_on, :archived0 AS archived, :custom_headers0 AS custom_headers) AS data',
                 [
                     'stream0' => 'profile-1',
                     'playhead0' => 1,


### PR DESCRIPTION
When append() was called with more than one message and an AppendCondition, the condition ended up bound to the last SELECT of the UNION ALL chain only, so every earlier event was written unconditionally. The value rows are now wrapped in a derived table and the condition sits on the outer statement, so the batch is inserted all-or-nothing. Each row aliases its columns because MySQL and MariaDB reject a derived table with duplicate column names.                                                                                                              
                                                                                                                                                                                     
Also reject an AppendCondition that carries a non-empty query but no highestSequenceNumber: that combination produced `WHERE ... = NULL`, inserted nothing and swallowed the exception, silently dropping the events. append() now only adds the sequence check when a number is given.