### PR TITLE
Implement AppendStore in InMemoryStore

### DIFF
--- a/docs/dynamic-consistency-boundary.md
+++ b/docs/dynamic-consistency-boundary.md
@@ -423,6 +423,13 @@ $provider = new ServiceHandlerProvider([
 
 $commandBus = new SyncCommandBus($provider);
 ```
+
+:::tip
+For tests you can replace the `TaggableDoctrineDbalStore` with an `InMemoryStore`. It implements the
+same tag query and conditional append, so the decision model and the append condition behave the same
+way without a database.
+:::
+
 ## Database setup
 
 The last step is to create the database schema.

--- a/docs/store.md
+++ b/docs/store.md
@@ -63,6 +63,67 @@ The table structure of the `StreamDoctrineDbalStore` looks like this:
 | archived         | bool     | If the event is archived                         |
 | custom_headers   | json     | Custom headers for the event                     |
 
+### TaggableDoctrineDbalStore
+
+The `TaggableDoctrineDbalStore` works like the `StreamDoctrineDbalStore`, but additionally stores the
+event tags in a dedicated `tags` column and can query events by tag and append events with an
+optimistic condition. This is the store used by the
+[dynamic consistency boundary](dynamic-consistency-boundary.md).
+
+Besides the dbal connection and the event serializer, it also needs the event registry so it can
+resolve tags and event names.
+
+```php
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\DsnParser;
+use Patchlevel\EventSourcing\Metadata\Event\AttributeEventRegistryFactory;
+use Patchlevel\EventSourcing\Serializer\DefaultEventSerializer;
+use Patchlevel\EventSourcing\Store\TaggableDoctrineDbalStore;
+
+$connection = DriverManager::getConnection(
+    (new DsnParser())->parse('pdo-pgsql://user:secret@localhost/app'),
+);
+
+$eventRegistry = (new AttributeEventRegistryFactory())->create(['src/Event']);
+$serializer = new DefaultEventSerializer($eventRegistry);
+
+$store = new TaggableDoctrineDbalStore(
+    $connection,
+    $serializer,
+    $eventRegistry,
+);
+```
+:::experimental
+This feature is still experimental and may change in the future.
+Use it with caution.
+:::
+
+Following options are available in `TaggableDoctrineDbalStore`:
+
+| Option              | Type   | Default     | Description                                          |
+|---------------------|--------|-------------|-----------------------------------------------------|
+| table_name          | string | event_store | The name of the table in the database               |
+| locking             | bool   | true        | If the store should use locking for writing         |
+| lock_id             | int    | 133742      | The id of the lock                                  |
+| lock_timeout        | int    | -1          | The timeout of the lock. -1 means no timeout        |
+| keep_index          | bool   | false       | If enabled, the index header is kept on save        |
+| default_stream_name | string | main        | Stream name used when a message has no stream header |
+
+The table structure of the `TaggableDoctrineDbalStore` looks like this:
+
+| Column         | Type     | Description                                   |
+|----------------|----------|----------------------------------------------|
+| id             | bigint   | The index of the whole stream (autoincrement) |
+| stream         | string   | The name of the stream                        |
+| playhead       | ?int     | The current playhead of the aggregate         |
+| event_id       | string   | The id of the event                           |
+| event_name     | string   | The name of the event                         |
+| event_payload  | json     | The payload of the event                      |
+| recorded_on    | datetime | The date when the event was recorded          |
+| archived       | bool     | If the event is archived                      |
+| tags           | ?json    | The tags attached to the event                |
+| custom_headers | json     | Custom headers for the event                  |
+
 ### InMemoryStore
 
 We also offer an in-memory store for testing purposes.
@@ -75,6 +136,10 @@ $store = new InMemoryStore();
 :::tip
 You can pass messages to the constructor to initialize the store with some events.
 :::
+
+The `InMemoryStore` also implements the tag-based query and conditional append API, so it can
+back a [dynamic consistency boundary](dynamic-consistency-boundary.md) decision model in tests
+without a real database.
 
 ### ReadOnlyStore
 

--- a/src/Store/InMemoryStore.php
+++ b/src/Store/InMemoryStore.php
@@ -25,8 +25,10 @@ use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
 use Psr\Clock\ClockInterface;
 use Ramsey\Uuid\Uuid;
 use Throwable;
+use Traversable;
 
 use function array_filter;
+use function array_key_last;
 use function array_map;
 use function array_reverse;
 use function array_slice;
@@ -34,13 +36,15 @@ use function array_unique;
 use function array_values;
 use function count;
 use function in_array;
+use function iterator_to_array;
+use function ksort;
 use function mb_substr;
 use function str_ends_with;
 use function str_starts_with;
 
 use const ARRAY_FILTER_USE_BOTH;
 
-final class InMemoryStore implements Store
+final class InMemoryStore implements Store, AppendStore
 {
     /** @var array<positive-int, Message> */
     private array $messages = [];
@@ -104,6 +108,32 @@ final class InMemoryStore implements Store
 
                 $this->messages[$count] = $message;
             }
+        });
+    }
+
+    public function query(Query $query): Stream
+    {
+        return new Stream($this->matchQuery($query));
+    }
+
+    /** @param iterable<Message> $messages */
+    public function append(iterable $messages, AppendCondition|null $appendCondition = null): void
+    {
+        $messages = $messages instanceof Traversable
+            ? iterator_to_array($messages, false)
+            : array_values($messages);
+
+        $this->transactional(function () use ($messages, $appendCondition): void {
+            if ($appendCondition instanceof AppendCondition && $appendCondition->highestSequenceNumber !== null) {
+                $matched = $this->matchQuery($appendCondition->query);
+                $highestSequenceNumber = $matched === [] ? 0 : array_key_last($matched);
+
+                if ($highestSequenceNumber !== $appendCondition->highestSequenceNumber) {
+                    throw new AppendConditionNotMet($appendCondition);
+                }
+            }
+
+            $this->save(...$messages);
         });
     }
 
@@ -274,6 +304,39 @@ final class InMemoryStore implements Store
             },
             ARRAY_FILTER_USE_BOTH,
         );
+    }
+
+    /**
+     * Resolves a {@see Query} against the stored messages using {@see SubQuery::match()},
+     * so it mirrors what {@see TaggableDoctrineDbalStore::query()} produces on a real database.
+     *
+     * @return array<positive-int, Message>
+     */
+    private function matchQuery(Query $query): array
+    {
+        if ($query->subQueries === []) {
+            return $this->messages;
+        }
+
+        $matched = [];
+
+        foreach ($query->subQueries as $subQuery) {
+            $subMatched = array_filter(
+                $this->messages,
+                static fn (Message $message): bool => $subQuery->match($message),
+            );
+
+            if ($subQuery->onlyLastEvent && $subMatched !== []) {
+                $lastKey = array_key_last($subMatched);
+                $subMatched = [$lastKey => $subMatched[$lastKey]];
+            }
+
+            $matched += $subMatched;
+        }
+
+        ksort($matched);
+
+        return $matched;
     }
 
     public function clear(): void

--- a/tests/Unit/Store/InMemoryStoreTest.php
+++ b/tests/Unit/Store/InMemoryStoreTest.php
@@ -7,6 +7,8 @@ namespace Patchlevel\EventSourcing\Tests\Unit\Store;
 use DateTimeImmutable;
 use Patchlevel\EventSourcing\Message\Message;
 use Patchlevel\EventSourcing\Metadata\Event\EventRegistry;
+use Patchlevel\EventSourcing\Store\AppendCondition;
+use Patchlevel\EventSourcing\Store\AppendConditionNotMet;
 use Patchlevel\EventSourcing\Store\ArchivedHeader;
 use Patchlevel\EventSourcing\Store\Criteria\ArchivedCriterion;
 use Patchlevel\EventSourcing\Store\Criteria\Criteria;
@@ -20,8 +22,11 @@ use Patchlevel\EventSourcing\Store\Header\IndexHeader;
 use Patchlevel\EventSourcing\Store\Header\PlayheadHeader;
 use Patchlevel\EventSourcing\Store\Header\RecordedOnHeader;
 use Patchlevel\EventSourcing\Store\Header\StreamNameHeader;
+use Patchlevel\EventSourcing\Store\Header\TagsHeader;
 use Patchlevel\EventSourcing\Store\InMemoryStore;
 use Patchlevel\EventSourcing\Store\MissingEventRegistry;
+use Patchlevel\EventSourcing\Store\Query;
+use Patchlevel\EventSourcing\Store\SubQuery;
 use Patchlevel\EventSourcing\Store\UnsupportedCriterion;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\Email;
 use Patchlevel\EventSourcing\Tests\Unit\Fixture\ProfileCreated;
@@ -662,5 +667,178 @@ final class InMemoryStoreTest extends TestCase
         $stream = $store->load();
 
         self::assertSame([], $stream->toList());
+    }
+
+    public function testQueryByTag(): void
+    {
+        $message1 = $this->message(new ProfileVisited(ProfileId::fromString('1')), 1, ['profile-1']);
+        $message2 = $this->message(new ProfileVisited(ProfileId::fromString('2')), 2, ['profile-2']);
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $stream = $store->query(new Query(new SubQuery(['profile-1'])));
+
+        self::assertSame([$message1], $stream->toList());
+    }
+
+    public function testQueryByEventClass(): void
+    {
+        $message1 = $this->message(new ProfileCreated(ProfileId::fromString('1'), Email::fromString('a')), 1);
+        $message2 = $this->message(new ProfileVisited(ProfileId::fromString('1')), 2);
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $stream = $store->query(new Query(new SubQuery(events: [ProfileVisited::class])));
+
+        self::assertSame([$message2], $stream->toList());
+    }
+
+    public function testQueryUnionOfSubQueriesKeepsIndexOrder(): void
+    {
+        $message1 = $this->message(new ProfileVisited(ProfileId::fromString('1')), 1, ['profile-1']);
+        $message2 = $this->message(new ProfileVisited(ProfileId::fromString('2')), 2, ['profile-2']);
+        $message3 = $this->message(new ProfileVisited(ProfileId::fromString('3')), 3, ['profile-1']);
+
+        $store = new InMemoryStore([$message1, $message2, $message3]);
+
+        $stream = $store->query(new Query(
+            new SubQuery(['profile-2']),
+            new SubQuery(['profile-1']),
+        ));
+
+        self::assertSame([$message1, $message2, $message3], $stream->toList());
+    }
+
+    public function testQueryWithoutSubQueriesReturnsEverything(): void
+    {
+        $message1 = $this->message(new ProfileVisited(ProfileId::fromString('1')), 1);
+        $message2 = $this->message(new ProfileVisited(ProfileId::fromString('2')), 2);
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $stream = $store->query(new Query());
+
+        self::assertSame([$message1, $message2], $stream->toList());
+    }
+
+    public function testQueryOnlyLastEvent(): void
+    {
+        $message1 = $this->message(new ProfileVisited(ProfileId::fromString('1')), 1, ['profile-1']);
+        $message2 = $this->message(new ProfileVisited(ProfileId::fromString('2')), 2, ['profile-1']);
+
+        $store = new InMemoryStore([$message1, $message2]);
+
+        $stream = $store->query(new Query(new SubQuery(['profile-1'], onlyLastEvent: true)));
+
+        self::assertSame([$message2], $stream->toList());
+    }
+
+    public function testAppendAssignsIndex(): void
+    {
+        $store = new InMemoryStore();
+
+        $store->append([
+            (new Message(new ProfileVisited(ProfileId::fromString('1'))))
+                ->withHeader(new StreamNameHeader('foo')),
+        ]);
+
+        $messages = iterator_to_array($store->load());
+
+        self::assertCount(1, $messages);
+        self::assertSame(1, $messages[1]->header(IndexHeader::class)->index);
+    }
+
+    public function testAppendWithConditionMet(): void
+    {
+        $existing = $this->message(new ProfileVisited(ProfileId::fromString('1')), 1, ['profile-1']);
+
+        $store = new InMemoryStore([$existing]);
+
+        $store->append(
+            [
+                (new Message(new ProfileVisited(ProfileId::fromString('2'))))
+                    ->withHeader(new TagsHeader(['profile-1'])),
+            ],
+            new AppendCondition(new Query(new SubQuery(['profile-1'])), 1),
+        );
+
+        self::assertCount(2, iterator_to_array($store->load()));
+    }
+
+    public function testAppendWithConditionNotMet(): void
+    {
+        $existing = $this->message(new ProfileVisited(ProfileId::fromString('1')), 1, ['profile-1']);
+
+        $store = new InMemoryStore([$existing]);
+
+        try {
+            $store->append(
+                [
+                    (new Message(new ProfileVisited(ProfileId::fromString('2'))))
+                        ->withHeader(new TagsHeader(['profile-1'])),
+                ],
+                new AppendCondition(new Query(new SubQuery(['profile-1'])), 0),
+            );
+
+            self::fail('Expected AppendConditionNotMet to be thrown');
+        } catch (AppendConditionNotMet) {
+        }
+
+        self::assertCount(1, iterator_to_array($store->load()));
+    }
+
+    public function testAppendWithConditionRejectsEntireBatch(): void
+    {
+        $existing = $this->message(new ProfileVisited(ProfileId::fromString('1')), 1, ['profile-1']);
+
+        $store = new InMemoryStore([$existing]);
+
+        try {
+            $store->append(
+                [
+                    new Message(new ProfileVisited(ProfileId::fromString('2'))),
+                    new Message(new ProfileVisited(ProfileId::fromString('3'))),
+                ],
+                new AppendCondition(new Query(new SubQuery(['profile-1'])), 0),
+            );
+
+            self::fail('Expected AppendConditionNotMet to be thrown');
+        } catch (AppendConditionNotMet) {
+        }
+
+        self::assertCount(1, iterator_to_array($store->load()));
+    }
+
+    public function testAppendWithZeroSequenceConditionMet(): void
+    {
+        $store = new InMemoryStore();
+
+        $store->append(
+            [
+                (new Message(new ProfileVisited(ProfileId::fromString('1'))))
+                    ->withHeader(new TagsHeader(['profile-9'])),
+            ],
+            new AppendCondition(new Query(new SubQuery(['profile-9'])), 0),
+        );
+
+        self::assertCount(1, iterator_to_array($store->load()));
+    }
+
+    /**
+     * @param positive-int $index
+     * @param list<string> $tags
+     */
+    private function message(object $event, int $index, array $tags = []): Message
+    {
+        $message = (new Message($event))
+            ->withHeader(new EventIdHeader('019aa600-56ef-7ca3-b92a-37c53851e2c2'))
+            ->withHeader(new RecordedOnHeader(new DateTimeImmutable('2020-01-01 00:00:00')))
+            ->withHeader(new IndexHeader($index));
+
+        if ($tags !== []) {
+            $message = $message->withHeader(new TagsHeader($tags));
+        }
+
+        return $message;
     }
 }


### PR DESCRIPTION
InMemoryStore now provides query() and append() with an AppendCondition, so a dynamic consistency boundary decision model can be built and tested without a real database. query() resolves a Query against the stored messages through the existing SubQuery::match(), and append() checks the highest matching index against the expected sequence number before writing, rejecting the whole batch with AppendConditionNotMet if it does not line up.                                                                                                                                 
                                                                                                                                                                                     
Also document TaggableDoctrineDbalStore in store.md (it was missing entirely) and note that InMemoryStore can stand in for it in tests. 